### PR TITLE
[CMAKE] Look for `Development.Module` instead of `Development`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ enable_language(CUDA)
 set(CMAKE_BUILD_TYPE "Release")
 
 find_package(CUDAToolkit REQUIRED)
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
 
 file(GLOB_RECURSE SOURCES "src/*/*.cu" "src/*/*.cc")
 list(FILTER SOURCES EXCLUDE REGEX ".*test.*")


### PR DESCRIPTION
Same issue with https://github.com/pytorch/pytorch/pull/129729

> Based on the [cmake issue](https://gitlab.kitware.com/cmake/cmake/-/issues/23716) and [manylinux issue](https://github.com/pypa/manylinux/issues/1347), when building a python module, it should find the `Development.Module` module, not `Development`, which includes `Development.Module` and `Development.Embed`, and will expect the shared python library only. After this PR and before #124613, pytorch could be built with a static libpython (e.g. in manylinux).