### PR TITLE
Docs: clarify minimum CUDA version due to register spill errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ HPC-Ops is a **production-grade, high-performance, and easy-to-use** operator li
 - NVIDIA SM90 architecture GPU
 - Python 3.8 or higher
 - Compilers with C++17 support
-- CUDA Toolkit: CUDA 12.3 or higher
+- CUDA Toolkit: CUDA 12.8 or higher
 
 *You can set up the environment by installing the modules listed in requirements-dev.txt.*
 


### PR DESCRIPTION
This PR updates the README to revise the stated minimum CUDA version.

The previously documented minimum CUDA version can lead to compiler-generated
register spill issues ("Registers are spilled to local memory") when building
the project.

The updated version reflects the minimum CUDA release that has been verified
to compile the kernels correctly without register spilling issues.

This change is documentation-only and does not modify any code or behavior.

Fixes #9 