### PR TITLE
add block-sparse fp8 prefill attention (dim=128, two quant schemes)

### DIFF
--- a/hpc/attention.py
+++ b/hpc/attention.py
@@ -1,5 +1,15 @@
+from enum import Enum
+from typing import Optional
+
 import torch
 from torch import Tensor
+
+
+class QuantType(Enum):
+    QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD = 0
+    QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR = 1
+    QPERTENSOR_KPERTENSOR_VPERTENSOR = 2
+    QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD_QKHADAMARD = 3
 
 
 def attention_prefill_bf16(
@@ -67,23 +77,31 @@ def attention_with_kvcache_prefill_bf16(
     max_seqlens_q: int,
     output: Tensor = None,
 ) -> Tensor:
-    """Computes attention prefill using bfloat16 precision.
+    """Computes paged KV-cache attention prefill in bfloat16.
 
-    This function performs the attention prefill computation using custom hardware
-    operations optimized for bfloat16 data type. The prefill stage processes all
-    input tokens simultaneously to generate the initial attention context, which
-    is typically used during the first forward pass of autoregressive models.
+    This interface supports both NHD-contiguous and HND-backed KV cache layouts
+    through tensor strides while keeping the same logical tensor shape.
+    In other words, the cache tensors should still be passed as
+    ``[num_blocks, block_size, num_head_kv, num_dim]``, and layout selection is
+    expressed by stride metadata (for example, via
+    ``transpose(1, 2).contiguous().transpose(1, 2)``).
 
     Args:
         q: Query tensor for attention computation
             Shape: [total_seq, num_head_q, num_dim_qk]
             Dtype: bfloat16
-        kcache: Key tensor for attention computation in paged format.
-                 Constrainst the unused slots in last block of vcache for each request to be set zeros.
+        kcache: Paged key cache tensor.
+            Logical shape must be ``[num_blocks, block_size, num_head_kv, num_dim_qk]``.
+            Both standard contiguous (NHD-like) and stride-transformed HND-backed
+            views are supported.
+            Unused slots in each request's last cache block should be zero-padded.
             Shape: [num_blocks, block_size, num_head_kv, num_dim_qk]
             Dtype: bfloat16
-        vcache: Value tensor for attention computation in paged format.
-                 Constrainst the unused slots in last block of vcache for each request to be set zeros.
+        vcache: Paged value cache tensor.
+            Logical shape must be ``[num_blocks, block_size, num_head_kv, num_dim_v]``.
+            Both standard contiguous (NHD-like) and stride-transformed HND-backed
+            views are supported.
+            Unused slots in each request's last cache block should be zero-padded.
             Shape: [num_blocks, block_size, num_head_kv, num_dim_v]
             Dtype: bfloat16
         cu_seqlens_q: start_seq_q for each batch
@@ -108,8 +126,10 @@ def attention_with_kvcache_prefill_bf16(
         RuntimeError: If the shapes or dtypes do not satisfy the constraints above.
 
     Note:
-        - All input tensors must be on CUDA device and in bfloat16 format
-        - The query and key tensors must have the same embedding dimension (num_dim_qk)
+        - All input tensors must be on CUDA.
+        - ``q``/``kcache`` head dimensions must match on ``num_dim_qk``.
+        - ``kcache``/``vcache`` may be non-contiguous as long as logical shape is
+          preserved and strides encode the desired KV layout (NHD/HND).
         - total_seq = sum(seqlens_q[ibatch] for ibatch in range(num_batch))
     """
 
@@ -136,33 +156,46 @@ def attention_with_kvcache_prefill_fp8(
     block_ids: Tensor,
     seqlens_kvcache: Tensor,
     max_seqlens_q: int,
+    quant_type: QuantType = QuantType.QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR,
     output: Tensor = None,
 ) -> Tensor:
-    """Computes attention prefill using fp8 precision.
+    """Computes paged KV-cache attention prefill with FP8 KV tensors.
 
-    This function performs the attention prefill computation using custom hardware
-    operations optimized for fp8 data type. The prefill stage processes all
-    input tokens simultaneously to generate the initial attention context, which
-    is typically used during the first forward pass of autoregressive models.
+    This interface supports both NHD-contiguous and HND-backed KV cache layouts
+    through tensor strides while keeping the same logical tensor shape.
+    Layout selection is represented by cache tensor strides, not by changing
+    tensor rank or shape.
 
     Args:
         q: Query tensor for attention computation
             Shape: [total_seq, num_head_q, num_dim_qk]
             Dtype: fp8
-        kcache: Key tensor for attention computation in paged format.
-                 Constrainst the unused slots in last block of vcache for each request to be set zeros.
+        kcache: Paged key cache tensor.
+            Logical shape must be ``[num_blocks, block_size, num_head_kv, num_dim_qk]``.
+            Both standard contiguous (NHD-like) and stride-transformed HND-backed
+            views are supported.
+            Unused slots in each request's last cache block should be zero-padded.
             Shape: [num_blocks, block_size, num_head_kv, num_dim_qk]
             Dtype: fp8
-        vcache: Value tensor for attention computation in paged format.
-                 Constrainst the unused slots in last block of vcache for each request to be set zeros.
+        vcache: Paged value cache tensor.
+            Logical shape must be ``[num_blocks, block_size, num_head_kv, num_dim_v]``.
+            Both standard contiguous (NHD-like) and stride-transformed HND-backed
+            views are supported.
+            Unused slots in each request's last cache block should be zero-padded.
             Shape: [num_blocks, block_size, num_head_kv, num_dim_v]
             Dtype: fp8
         qscale: QK fp8 quant scale. Per Token Per Head Fp8 Quant.
             Shape: [num_batch, num_head_q, max_seqlens_q_pad]
             Dtype: float32
-        kscale: K fp8 quant scale. Per Tensor Fp8 Quant.
-            Shape: [1]
-            Dtype: float32
+        kscale: K fp8 quant scale tensor.
+            Shape: depends on `quant_type`:
+                   - If `quant_type == QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR`:
+                       Shape: [1]
+                   - If `quant_type == QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD`:
+                       Shape: [num_blocks, scale_block_size, num_head_kv, num_dim_scale]
+            Dtype: float32/fp8
+            For per-token/per-head K scale mode, stride-transformed layouts are
+            also accepted as long as the logical shape above is preserved.
         vscale: V fp8 quant scale. Per Tensor Fp8 Quant.
             Shape: [1]
             Dtype: float32
@@ -178,6 +211,14 @@ def attention_with_kvcache_prefill_fp8(
         max_seqlens_q: max seqlens amang all batchs
             Shape: scalar
             Dtype: int
+        quant_type: Type of quantization scheme for attention computation.
+            Defaults to QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR.
+        output: Optional output tensor to store the attention result.
+            If provided, must be a bf16 tensor with appropriate shape
+            (typically [total_seq, num_head_q, num_dim_v]).
+            The result will be written into this tensor and the same tensor
+            will be returned. If None, a new tensor is allocated and returned.
+            Dtype: bf16
 
     Returns:
         Tensor: Attention output tensor in bfloat16 format on CUDA device
@@ -188,11 +229,11 @@ def attention_with_kvcache_prefill_fp8(
         RuntimeError: If the shapes or dtypes do not satisfy the constraints above.
 
     Note:
-        - All input tensors must be on CUDA device and in bfloat16 format
-        - The query and key tensors must have the same embedding dimension (num_dim_qk)
+        - All input tensors must be on CUDA.
+        - ``kcache``/``vcache`` may be non-contiguous as long as logical shape is
+          preserved and strides encode the desired KV layout (NHD/HND).
         - total_seq = sum(seqlens_q[ibatch] for ibatch in range(num_batch))
     """
-
     return torch.ops.hpc.attention_with_kvcache_prefill_fp8(
         q,
         kcache,
@@ -204,6 +245,95 @@ def attention_with_kvcache_prefill_fp8(
         block_ids,
         seqlens_kvcache,
         max_seqlens_q,
+        quant_type.value,
+        output,
+    )
+
+
+def attention_with_kvcache_blocksparse_prefill_fp8(
+    q: Tensor,
+    kcache: Tensor,
+    vcache: Tensor,
+    qscale: Tensor,
+    kscale: Tensor,
+    vscale: Tensor,
+    cu_seqlens_q: Tensor,
+    block_ids: Tensor,
+    seqlens_kvcache: Tensor,
+    max_seqlens_q: int,
+    quant_type: QuantType = QuantType.QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR,
+    block_mask: Optional[Tensor] = None,
+    output: Tensor = None,
+) -> Tensor:
+    """Unified dense / block-sparse attention prefill with paged FP8 KV cache.
+
+    When `block_mask` is None, this dispatches to the dense-compatible
+    `kHasMask=False` path inside the unified kernel family.
+    When provided, only KV tiles marked True in `block_mask` are computed.
+
+    Recommendation: the causal diagonal tile (the last KV tile in each
+    Q-tile's causal range) should be True in block_mask to avoid NaN.
+    The kernel guarantees no deadlock regardless of mask content, but if
+    any Q-tile has zero active tiles, softmax(all -inf) will produce NaN.
+
+    Args:
+        q: Query tensor. Shape: [total_seq, num_head_q, num_dim_qk], Dtype: fp8_e4m3
+        kcache: Paged K cache.
+            Logical shape: [num_blocks, block_size, num_head_kv, num_dim_qk].
+            Both contiguous NHD-like and stride-transformed HND-backed layouts
+            are supported.
+            Dtype: fp8.
+        vcache: Paged V cache.
+            Logical shape: [num_blocks, block_size, num_head_kv, num_dim_v].
+            Both contiguous NHD-like and stride-transformed HND-backed layouts
+            are supported.
+            Dtype: fp8.
+        qscale: Per-token per-head Q dequant scale. Shape: [num_batch, num_head_q, max_seq_q_pad],
+            Dtype: float32
+        kscale: K fp8 quant scale tensor.
+            Shape: depends on `quant_type`:
+                   - If `quant_type == QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR`:
+                       Shape: [1]
+                   - If `quant_type == QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD`:
+                       Shape: [num_blocks, scale_block_size, num_head_kv, num_dim_scale]
+            Dtype: float32/fp8
+            For per-token/per-head K scale mode, stride-transformed layouts are
+            also accepted as long as the logical shape above is preserved.
+        vscale: V fp8 quant scale.
+            Shape: depends on `quant_type`:
+                   - If `quant_type == QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR`:
+                       Shape: [1] (per-tensor)
+                   - If `quant_type == QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD`:
+                       Shape: [num_head_kv] (per-head)
+            Dtype: float32
+        cu_seqlens_q: Cumulative Q lengths. Shape: [num_batch + 1], Dtype: int32
+        block_ids: Page table. Shape: [num_batch, max_blocks], Dtype: int32
+        seqlens_kvcache: KV cache lengths. Shape: [num_batch], Dtype: int32
+        max_seqlens_q: Max Q sequence length (scalar).
+        quant_type: Type of quantization scheme for attention computation.
+            Defaults to QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR (legacy). Pass
+            QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD for the new dense-aligned
+            layout (K per-token-group per-head per-dim-group, V per-head).
+        block_mask: Optional bool mask for KV tiles. True = compute, False = skip.
+            Shape: [num_batch, num_head_q, max_tile_m, num_tile_kv_in_mask], Dtype: uint8.
+        output: Optional pre-allocated output tensor.
+
+    Returns:
+        Tensor: Shape [total_seq, num_head_q, num_dim_v], Dtype: bfloat16.
+    """
+    return torch.ops.hpc.attention_with_kvcache_blocksparse_prefill_fp8(
+        q,
+        kcache,
+        vcache,
+        qscale,
+        kscale,
+        vscale,
+        cu_seqlens_q,
+        block_ids,
+        seqlens_kvcache,
+        max_seqlens_q,
+        quant_type.value,
+        block_mask,
         output,
     )
 
@@ -371,14 +501,16 @@ def attention_decode_fp8(
 
 @torch.library.register_fake("hpc::attention_prefill_bf16")
 def attention_prefill_bf16_fake(q, k, v, seqlens_q, cu_seqlens_q, max_seqlens_q, output):
-    return torch.empty_like(q)
+    return torch.empty((q.size(0), q.size(1), v.size(-1)), dtype=torch.bfloat16, device=q.device)
 
 
 @torch.library.register_fake("hpc::attention_with_kvcache_prefill_bf16")
 def attention_with_kvcache_prefill_bf16_fake(
     q, kcache, vcache, cu_seqlens_q, block_ids, seqlens_kvcache, max_seqlens_q, output
 ):
-    return torch.empty_like(q)
+    return torch.empty(
+        (q.size(0), q.size(1), vcache.size(-1)), dtype=torch.bfloat16, device=q.device
+    )
 
 
 @torch.library.register_fake("hpc::attention_with_kvcache_prefill_fp8")
@@ -393,9 +525,33 @@ def attention_with_kvcache_prefill_fp8_fake(
     block_ids,
     seqlens_kvcache,
     max_seqlens_q,
-    output,
+    quant_type,
+    output=None,
 ):
-    return torch.empty_like(q)
+    return torch.empty(
+        (q.size(0), q.size(1), vcache.size(-1)), dtype=torch.bfloat16, device=q.device
+    )
+
+
+@torch.library.register_fake("hpc::attention_with_kvcache_blocksparse_prefill_fp8")
+def attention_with_kvcache_blocksparse_prefill_fp8_fake(
+    q,
+    kcache,
+    vcache,
+    qscale,
+    kscale,
+    vscale,
+    cu_seqlens_q,
+    block_ids,
+    seqlens_kvcache,
+    max_seqlens_q,
+    quant_type,
+    block_mask=None,
+    output=None,
+):
+    return torch.empty(
+        (q.size(0), q.size(1), vcache.size(-1)), dtype=torch.bfloat16, device=q.device
+    )
 
 
 @torch.library.register_fake("hpc::attention_decode_bf16")

--- a/src/attention/entry.cc
+++ b/src/attention/entry.cc
@@ -35,6 +35,13 @@ torch::Tensor attention_prefill_bf16_entry(const torch::Tensor &q, const torch::
   torch::Tensor y;
   if (output.has_value()) {
     y = output.value();
+    TORCH_CHECK(y.device().is_cuda(), "output tensor must be cuda");
+    TORCH_CHECK(y.get_device() == q.get_device(), "output tensor must be on the same device as q");
+    TORCH_CHECK(y.scalar_type() == torch::kBFloat16, "output dtype must be bfloat16");
+    TORCH_CHECK(y.is_contiguous(), "output tensor must be contiguous");
+    TORCH_CHECK(y.dim() == 3 && y.size(0) == total_seq_q && y.size(1) == num_head_q &&
+                    y.size(2) == num_dim_v,
+                "output must have shape [total_seq_q, num_head_q, num_dim_v]");
   } else {
     y = torch::empty({total_seq_q, num_head_q, num_dim_v}, options);
   }
@@ -88,6 +95,9 @@ torch::Tensor attention_with_kvcache_prefill_bf16_entry(
 
   int num_head_kv = kcache.size(2);
   int num_dim_v = vcache.size(3);
+  TORCH_CHECK(num_dim_qk == 128 && num_dim_v == 128,
+              "attention_with_kvcache_prefill_bf16: expected dim_qk=128 and dim_v=128, got dim_qk=",
+              num_dim_qk, " dim_v=", num_dim_v);
 
   int num_seq_max_blocks = block_ids.size(1);
 
@@ -95,6 +105,13 @@ torch::Tensor attention_with_kvcache_prefill_bf16_entry(
   torch::Tensor y;
   if (output.has_value()) {
     y = output.value();
+    TORCH_CHECK(y.device().is_cuda(), "output tensor must be cuda");
+    TORCH_CHECK(y.get_device() == q.get_device(), "output tensor must be on the same device as q");
+    TORCH_CHECK(y.scalar_type() == torch::kBFloat16, "output dtype must be bfloat16");
+    TORCH_CHECK(y.is_contiguous(), "output tensor must be contiguous");
+    TORCH_CHECK(y.dim() == 3 && y.size(0) == total_seq_q && y.size(1) == num_head_q &&
+                    y.size(2) == num_dim_v,
+                "output must have shape [total_seq_q, num_head_q, num_dim_v]");
   } else {
     y = torch::empty({total_seq_q, num_head_q, num_dim_v}, options);
   }
@@ -113,15 +130,20 @@ torch::Tensor attention_with_kvcache_prefill_bf16_entry(
   using T = __nv_bfloat16;
   auto *y_ptr = reinterpret_cast<T *>(y.mutable_data_ptr());
 
-  int ldQ = q.stride(0);       // num_head_q * num_dim_qk;
-  int ldK = kcache.stride(0);  // num_head_kv * num_dim_qk;
-  int ldV = vcache.stride(0);  // num_head_kv * num_dim_v;
-  int ldY = y.stride(0);       // num_head_q * num_dim_v;
+  int ldQ = q.stride(0);  // num_head_q * num_dim_qk;
+  int ldK = kcache.stride(0);
+  int ldK1 = kcache.stride(1);
+  int ldK2 = kcache.stride(2);
+  int ldV = vcache.stride(0);
+  int ldV1 = vcache.stride(1);
+  int ldV2 = vcache.stride(2);
+  int ldY = y.stride(0);  // num_head_q * num_dim_v;
 
   attention_with_kvcache_prefill_bf16_async(
       y_ptr, q_ptr, kcache_ptr, vcache_ptr, cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr,
       tmas_ptr, num_batch, total_seq_q, max_seqlens_q, num_dim_qk, num_dim_v, num_head_q,
-      num_head_kv, num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldV, stream);
+      num_head_kv, num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2,
+      ldV, ldV1, ldV2, stream);
 
   return y;
 }
@@ -130,7 +152,7 @@ torch::Tensor attention_with_kvcache_prefill_fp8_entry(
     const torch::Tensor &q, const torch::Tensor &kcache, const torch::Tensor &vcache,
     const torch::Tensor &qscale, const torch::Tensor &kscale, const torch::Tensor &vscale,
     const torch::Tensor &cu_seqlens_q, const torch::Tensor block_ids,
-    const torch::Tensor seqlens_kvcache, int64_t max_seqlens_q,
+    const torch::Tensor seqlens_kvcache, int64_t max_seqlens_q, int64_t quant_type,
     std::optional<torch::Tensor> output) {
   auto stream = at::cuda::getCurrentCUDAStream(q.get_device());
   TORCH_CHECK(q.device().is_cuda(), "q tensor must be cuda");
@@ -142,6 +164,12 @@ torch::Tensor attention_with_kvcache_prefill_fp8_entry(
   TORCH_CHECK(cu_seqlens_q.device().is_cuda(), "cu_seqlens_q tensor must be cuda");
   TORCH_CHECK(block_ids.device().is_cuda(), "block_ids tensor must be cuda");
   TORCH_CHECK(seqlens_kvcache.device().is_cuda(), "seqlens_kvcache tensor must be cuda");
+  TORCH_CHECK((quant_type == 0 || quant_type == 1), "quant_type only support 0/1");
+  TORCH_CHECK((kscale.dtype().itemsize() == 4 || kscale.dtype().itemsize() == 1),
+              "kscale dtype must be float or fp8");
+  TORCH_CHECK(q.scalar_type() == torch::kFloat8_e4m3fn, "q dtype must be float8_e4m3fn");
+  TORCH_CHECK(kcache.scalar_type() == torch::kFloat8_e4m3fn, "kcache dtype must be float8_e4m3fn");
+  TORCH_CHECK(vcache.scalar_type() == torch::kFloat8_e4m3fn, "vcache dtype must be float8_e4m3fn");
 
   int total_seq_q = q.size(0);
   int num_head_q = q.size(1);
@@ -154,6 +182,9 @@ torch::Tensor attention_with_kvcache_prefill_fp8_entry(
 
   int num_head_kv = kcache.size(2);
   int num_dim_v = vcache.size(3);
+  TORCH_CHECK(num_dim_qk == 128 && num_dim_v == 128,
+              "attention_with_kvcache_prefill_fp8: expected dim_qk=128 and dim_v=128, got dim_qk=",
+              num_dim_qk, " dim_v=", num_dim_v);
 
   int num_seq_max_blocks = block_ids.size(1);
 
@@ -163,6 +194,13 @@ torch::Tensor attention_with_kvcache_prefill_fp8_entry(
   torch::Tensor y;
   if (output.has_value()) {
     y = output.value();
+    TORCH_CHECK(y.device().is_cuda(), "output tensor must be cuda");
+    TORCH_CHECK(y.get_device() == q.get_device(), "output tensor must be on the same device as q");
+    TORCH_CHECK(y.scalar_type() == torch::kBFloat16, "output dtype must be bfloat16");
+    TORCH_CHECK(y.is_contiguous(), "output tensor must be contiguous");
+    TORCH_CHECK(y.dim() == 3 && y.size(0) == total_seq_q && y.size(1) == num_head_q &&
+                    y.size(2) == num_dim_v,
+                "output must have shape [total_seq_q, num_head_q, num_dim_v]");
   } else {
     y = torch::empty({total_seq_q, num_head_q, num_dim_v}, options);
   }
@@ -184,16 +222,187 @@ torch::Tensor attention_with_kvcache_prefill_fp8_entry(
   using T = __nv_bfloat16;
   auto *y_ptr = reinterpret_cast<T *>(y.mutable_data_ptr());
 
-  int ldQ = q.stride(0);       // num_head_q * num_dim_qk;
-  int ldK = kcache.stride(0);  // num_head_kv * num_dim_qk;
-  int ldV = vcache.stride(0);  // num_head_kv * num_dim_v;
-  int ldY = y.stride(0);       // num_head_q * num_dim_v;
+  int ldQ = q.stride(0);
+  int ldK = kcache.stride(0);
+  int ldK1 = kcache.stride(1);
+  int ldK2 = kcache.stride(2);
+  int ldV = vcache.stride(0);
+  int ldV1 = vcache.stride(1);
+  int ldV2 = vcache.stride(2);
+  int ldY = y.stride(0);
 
-  attention_with_kvcache_prefill_fp8_async(
-      y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
-      block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seqlens_q,
-      max_seqlens_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks,
-      block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldV, stream);
+  if (quant_type == 1) {
+    attention_with_kvcache_prefill_qpertoken_perhead_kvpertensor_fp8_async(
+        y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
+        block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seqlens_q,
+        max_seqlens_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks,
+        block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1, ldV2, stream);
+  } else if (quant_type == 0) {
+    int ldKS = 0;
+    int ldKS1 = 0;
+    int ldKS2 = 0;
+    if (kscale.dtype().itemsize() == 4) {
+      ldKS = kscale.stride(0);
+      ldKS1 = kscale.stride(1);
+      ldKS2 = kscale.stride(2);
+    } else if (kscale.dtype().itemsize() == 1) {
+      ldKS = kscale.stride(0) / sizeof(float);
+      ldKS1 = kscale.stride(1) / sizeof(float);
+      ldKS2 = kscale.stride(2) / sizeof(float);
+    }
+    int scale_block_size = kscale.size(1);
+    attention_with_kvcache_prefill_qkpertoken_perhead_vperhead_fp8_async(
+        y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
+        block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seqlens_q,
+        max_seqlens_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks,
+        block_size, scale_block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1,
+        ldV2, ldKS, ldKS1, ldKS2, stream);
+  }
+
+  return y;
+}
+
+torch::Tensor attention_with_kvcache_blocksparse_prefill_fp8_entry(
+    const torch::Tensor &q, const torch::Tensor &kcache, const torch::Tensor &vcache,
+    const torch::Tensor &qscale, const torch::Tensor &kscale, const torch::Tensor &vscale,
+    const torch::Tensor &cu_seqlens_q, const torch::Tensor block_ids,
+    const torch::Tensor seqlens_kvcache, int64_t max_seqlens_q, int64_t quant_type,
+    std::optional<torch::Tensor> block_mask, std::optional<torch::Tensor> output) {
+  auto stream = at::cuda::getCurrentCUDAStream(q.get_device());
+  TORCH_CHECK(q.device().is_cuda(), "q tensor must be cuda");
+  TORCH_CHECK(kcache.device().is_cuda(), "kcache tensor must be cuda");
+  TORCH_CHECK(vcache.device().is_cuda(), "vcache tensor must be cuda");
+  TORCH_CHECK(qscale.device().is_cuda(), "qscale tensor must be cuda");
+  TORCH_CHECK(kscale.device().is_cuda(), "kscale tensor must be cuda");
+  TORCH_CHECK(vscale.device().is_cuda(), "vscale tensor must be cuda");
+  TORCH_CHECK(cu_seqlens_q.device().is_cuda(), "cu_seqlens_q tensor must be cuda");
+  TORCH_CHECK(block_ids.device().is_cuda(), "block_ids tensor must be cuda");
+  TORCH_CHECK(seqlens_kvcache.device().is_cuda(), "seqlens_kvcache tensor must be cuda");
+  TORCH_CHECK((quant_type == 0 || quant_type == 1), "quant_type only support 0/1");
+  TORCH_CHECK((kscale.dtype().itemsize() == 4 || kscale.dtype().itemsize() == 1),
+              "kscale dtype must be float or fp8");
+  TORCH_CHECK(q.scalar_type() == torch::kFloat8_e4m3fn, "q dtype must be float8_e4m3fn");
+  TORCH_CHECK(kcache.scalar_type() == torch::kFloat8_e4m3fn, "kcache dtype must be float8_e4m3fn");
+  TORCH_CHECK(vcache.scalar_type() == torch::kFloat8_e4m3fn, "vcache dtype must be float8_e4m3fn");
+
+  bool has_block_mask = block_mask.has_value();
+
+  int total_seq_q = q.size(0);
+  int num_head_q = q.size(1);
+  int num_dim_qk = q.size(2);
+
+  int num_batch = cu_seqlens_q.size(0) - 1;
+
+  int num_kvcache_blocks = kcache.size(0);
+  int block_size = kcache.size(1);
+
+  int num_head_kv = kcache.size(2);
+  int num_dim_v = vcache.size(3);
+  TORCH_CHECK(
+      num_dim_qk == 128 && num_dim_v == 128,
+      "attention_with_kvcache_blocksparse_prefill_fp8: expected dim_qk=128 and dim_v=128, got "
+      "dim_qk=",
+      num_dim_qk, " dim_v=", num_dim_v);
+
+  int num_seq_max_blocks = block_ids.size(1);
+
+  int max_seqlens_q_pad = qscale.size(2);
+
+  constexpr int kTileM = 128;
+  constexpr int kTileN = 128;
+  TORCH_CHECK(kTileN % block_size == 0, "unsupported block_size for FP8 blocksparse prefill");
+  int expected_max_num_tile_m = (max_seqlens_q + kTileM - 1) / kTileM;
+
+  int num_tile_kv_in_mask = 0;
+  if (has_block_mask) {
+    const auto &block_mask_tensor = block_mask.value();
+    TORCH_CHECK(block_mask_tensor.device() == q.device(),
+                "block_mask tensor must be on the same device as q");
+    TORCH_CHECK(block_mask_tensor.scalar_type() == torch::kUInt8, "block_mask dtype must be uint8");
+    TORCH_CHECK(block_mask_tensor.is_contiguous(), "block_mask tensor must be contiguous");
+    TORCH_CHECK(block_mask_tensor.dim() == 4 && block_mask_tensor.size(0) == num_batch &&
+                    block_mask_tensor.size(1) == num_head_q &&
+                    block_mask_tensor.size(2) == expected_max_num_tile_m,
+                "block_mask must have shape [", num_batch, ", ", num_head_q, ", ",
+                expected_max_num_tile_m, ", Kb] where Kb = ceil(max_kv_len / kTileN=", kTileN, ")");
+    num_tile_kv_in_mask = block_mask_tensor.size(3);
+
+    TORCH_CHECK(num_tile_kv_in_mask > 0, "block_mask Kb dim must be > 0");
+  }
+
+  auto options = q.options().dtype(torch::kBFloat16);
+  torch::Tensor y;
+  if (output.has_value()) {
+    y = output.value();
+    TORCH_CHECK(y.device().is_cuda(), "output tensor must be cuda");
+    TORCH_CHECK(y.get_device() == q.get_device(), "output tensor must be on the same device as q");
+    TORCH_CHECK(y.scalar_type() == torch::kBFloat16, "output dtype must be bfloat16");
+    TORCH_CHECK(y.is_contiguous(), "output tensor must be contiguous");
+    TORCH_CHECK(y.dim() == 3 && y.size(0) == total_seq_q && y.size(1) == num_head_q &&
+                    y.size(2) == num_dim_v,
+                "output must have shape [total_seq_q, num_head_q, num_dim_v]");
+  } else {
+    y = torch::empty({total_seq_q, num_head_q, num_dim_v}, options);
+  }
+
+  int num_tmas = 2 * num_batch;
+  torch::Tensor tmas = torch::empty({num_tmas, 64}, options);
+
+  const auto *q_ptr = q.const_data_ptr();
+  const auto *kcache_ptr = kcache.const_data_ptr();
+  const auto *vcache_ptr = vcache.const_data_ptr();
+  const auto *qscale_ptr = qscale.const_data_ptr();
+  const auto *kscale_ptr = kscale.const_data_ptr();
+  const auto *vscale_ptr = vscale.const_data_ptr();
+  const auto *cu_seqlens_q_ptr = cu_seqlens_q.const_data_ptr();
+  const auto *block_ids_ptr = block_ids.const_data_ptr();
+  const auto *seqlens_kvcache_ptr = seqlens_kvcache.const_data_ptr();
+  const void *block_mask_ptr = nullptr;
+  if (has_block_mask) {
+    block_mask_ptr = block_mask.value().const_data_ptr();
+  }
+  void *tmas_ptr = tmas.mutable_data_ptr();
+
+  using T = __nv_bfloat16;
+  auto *y_ptr = reinterpret_cast<T *>(y.mutable_data_ptr());
+
+  int ldQ = q.stride(0);  // num_head_q * num_dim_qk;
+  int ldK = kcache.stride(0);
+  int ldK1 = kcache.stride(1);
+  int ldK2 = kcache.stride(2);
+  int ldV = vcache.stride(0);
+  int ldV1 = vcache.stride(1);
+  int ldV2 = vcache.stride(2);
+  int ldY = y.stride(0);  // num_head_q * num_dim_v;
+
+  if (quant_type == 1) {
+    attention_with_kvcache_blocksparse_prefill_qpertoken_perhead_kvpertensor_fp8_async(
+        y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
+        block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seqlens_q,
+        max_seqlens_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks,
+        block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1, ldV2, block_mask_ptr,
+        num_tile_kv_in_mask, stream);
+  } else if (quant_type == 0) {
+    int ldKS = 0;
+    int ldKS1 = 0;
+    int ldKS2 = 0;
+    if (kscale.dtype().itemsize() == 4) {
+      ldKS = kscale.stride(0);
+      ldKS1 = kscale.stride(1);
+      ldKS2 = kscale.stride(2);
+    } else if (kscale.dtype().itemsize() == 1) {
+      ldKS = kscale.stride(0) / sizeof(float);
+      ldKS1 = kscale.stride(1) / sizeof(float);
+      ldKS2 = kscale.stride(2) / sizeof(float);
+    }
+    int scale_block_size = kscale.size(1);
+    attention_with_kvcache_blocksparse_prefill_qkpertoken_perhead_vperhead_fp8_async(
+        y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
+        block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seqlens_q,
+        max_seqlens_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks,
+        block_size, scale_block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1,
+        ldV2, ldKS, ldKS1, ldKS2, block_mask_ptr, num_tile_kv_in_mask, stream);
+  }
 
   return y;
 }
@@ -456,9 +665,18 @@ TORCH_LIBRARY_FRAGMENT(hpc, m) {
   m.def(
       "attention_with_kvcache_prefill_fp8(Tensor q, Tensor kcache, Tensor vcache,"
       "Tensor qscale, Tensor kscale, Tensor vscale, Tensor cu_seqlens_q,"
-      "Tensor block_ids, Tensor num_seq_kvcache, int max_seqlens_q, Tensor? output) -> (Tensor)");
+      "Tensor block_ids, Tensor num_seq_kvcache, int max_seqlens_q, int quant_type,"
+      "Tensor? output) -> (Tensor)");
   m.impl("attention_with_kvcache_prefill_fp8", torch::kCUDA,
          &hpc::attention::attention_with_kvcache_prefill_fp8_entry);
+
+  m.def(
+      "attention_with_kvcache_blocksparse_prefill_fp8(Tensor q, Tensor kcache, Tensor vcache,"
+      "Tensor qscale, Tensor kscale, Tensor vscale, Tensor cu_seqlens_q,"
+      "Tensor block_ids, Tensor num_seq_kvcache, int max_seqlens_q, int quant_type,"
+      "Tensor? block_mask, Tensor? output) -> (Tensor)");
+  m.impl("attention_with_kvcache_blocksparse_prefill_fp8", torch::kCUDA,
+         &hpc::attention::attention_with_kvcache_blocksparse_prefill_fp8_entry);
 
   m.def(
       "attention_decode_bf16(Tensor q, Tensor! kcache, Tensor! vcache, Tensor block_ids, Tensor "

--- a/src/attention/prefill/config.h
+++ b/src/attention/prefill/config.h
@@ -11,6 +11,35 @@ namespace prefill {
 
 using namespace cute;  // NOLINT
 
+template <int kSwizzle, typename T, bool kKmajor = true>
+static constexpr auto slayout_selector() {
+  if constexpr (kSwizzle == 128) {
+    if constexpr (kKmajor) {
+      return cute::GMMA::Layout_K_SW128_Atom<T>{};
+    } else {
+      return cute::GMMA::Layout_MN_SW128_Atom<T>{};
+    }
+  } else if constexpr (kSwizzle == 64) {
+    if constexpr (kKmajor) {
+      return cute::GMMA::Layout_K_SW64_Atom<T>{};
+    } else {
+      return cute::GMMA::Layout_MN_SW64_Atom<T>{};
+    }
+  } else if constexpr (kSwizzle == 32) {
+    if constexpr (kKmajor) {
+      return cute::GMMA::Layout_K_SW32_Atom<T>{};
+    } else {
+      return cute::GMMA::Layout_MN_SW32_Atom<T>{};
+    }
+  } else {
+    if constexpr (kKmajor) {
+      return cute::GMMA::Layout_K_INTER_Atom<T>{};
+    } else {
+      return cute::GMMA::Layout_MN_INTER_Atom<T>{};
+    }
+  }
+}
+
 template <typename Tin_, typename Tout_, typename TiledMmaQKAtom, typename TiledMmaPVAtom,
           int kTileM_, int kTileN_, int kTileK_, int kTileV_, int kStage_, int kWarpgroupM_ = 2,
           int kWarpgroupN_ = 1, int kSwizzleQ = 128, int kSwizzleK = 128, int kSwizzleV = 128,
@@ -25,35 +54,6 @@ struct AttentionPrefillConfig {
   static constexpr int kTileV = kTileV_;
   static constexpr int kStage = kStage_;
   static constexpr int kWarpgroupM = kWarpgroupM_;
-
-  template <int kSwizzle, typename T, bool kKmajor = true>
-  static constexpr auto slayout_selector() {
-    if constexpr (kSwizzle == 128) {
-      if constexpr (kKmajor) {
-        return cute::GMMA::Layout_K_SW128_Atom<T>{};
-      } else {
-        return cute::GMMA::Layout_MN_SW128_Atom<T>{};
-      }
-    } else if constexpr (kSwizzle == 64) {
-      if constexpr (kKmajor) {
-        return cute::GMMA::Layout_K_SW64_Atom<T>{};
-      } else {
-        return cute::GMMA::Layout_MN_SW64_Atom<T>{};
-      }
-    } else if constexpr (kSwizzle == 32) {
-      if constexpr (kKmajor) {
-        return cute::GMMA::Layout_K_SW32_Atom<T>{};
-      } else {
-        return cute::GMMA::Layout_MN_SW32_Atom<T>{};
-      }
-    } else {
-      if constexpr (kKmajor) {
-        return cute::GMMA::Layout_K_INTER_Atom<T>{};
-      } else {
-        return cute::GMMA::Layout_MN_INTER_Atom<T>{};
-      }
-    }
-  }
 
   using SLayoutQAtom = decltype(slayout_selector<kSwizzleQ, Tin>());
   using SLayoutKAtom = decltype(slayout_selector<kSwizzleK, Tin>());
@@ -109,35 +109,6 @@ struct AttentionKVCachePrefillConfig {
   static constexpr int kStage = kStage_;
   static constexpr int kWarpgroupM = kWarpgroupM_;
 
-  template <int kSwizzle, typename T, bool kKmajor = true>
-  static constexpr auto slayout_selector() {
-    if constexpr (kSwizzle == 128) {
-      if constexpr (kKmajor) {
-        return cute::GMMA::Layout_K_SW128_Atom<T>{};
-      } else {
-        return cute::GMMA::Layout_MN_SW128_Atom<T>{};
-      }
-    } else if constexpr (kSwizzle == 64) {
-      if constexpr (kKmajor) {
-        return cute::GMMA::Layout_K_SW64_Atom<T>{};
-      } else {
-        return cute::GMMA::Layout_MN_SW64_Atom<T>{};
-      }
-    } else if constexpr (kSwizzle == 32) {
-      if constexpr (kKmajor) {
-        return cute::GMMA::Layout_K_SW32_Atom<T>{};
-      } else {
-        return cute::GMMA::Layout_MN_SW32_Atom<T>{};
-      }
-    } else {
-      if constexpr (kKmajor) {
-        return cute::GMMA::Layout_K_INTER_Atom<T>{};
-      } else {
-        return cute::GMMA::Layout_MN_INTER_Atom<T>{};
-      }
-    }
-  }
-
   using SLayoutQAtom = decltype(slayout_selector<kSwizzleQ, Tin>());
   using SLayoutKAtom = decltype(slayout_selector<kSwizzleK, Tin>());
   using SLayoutVAtom = decltype(slayout_selector<kSwizzleV, Tin, false>());
@@ -180,12 +151,11 @@ struct AttentionKVCachePrefillConfig {
 
   auto get_shm_size() { return shm_size; }
 };
-
 template <typename Tin_, typename Tout_, typename TiledMmaQKAtom, typename TiledMmaPVAtom,
           int kTileM_, int kTileN_, int kTileK_, int kTileV_, int kBlockSize_, int kStage_,
           int kWarpgroupM_ = 2, int kWarpgroupN_ = 1, int kSwizzleQ = 128, int kSwizzleK = 128,
           int kSwizzleV = 128, int kSwizzleY = 128>
-struct AttentionKVCachePrefillFp8Config {
+struct AttentionKVCachePrefillQTokenKVTensorFp8Config {
   using Tin = Tin_;
   using Tout = Tout_;
 
@@ -196,35 +166,6 @@ struct AttentionKVCachePrefillFp8Config {
   static constexpr int kBlockSize = kBlockSize_;
   static constexpr int kStage = kStage_;
   static constexpr int kWarpgroupM = kWarpgroupM_;
-
-  template <int kSwizzle, typename T, bool kKmajor = true>
-  static constexpr auto slayout_selector() {
-    if constexpr (kSwizzle == 128) {
-      if constexpr (kKmajor) {
-        return cute::GMMA::Layout_K_SW128_Atom<T>{};
-      } else {
-        return cute::GMMA::Layout_MN_SW128_Atom<T>{};
-      }
-    } else if constexpr (kSwizzle == 64) {
-      if constexpr (kKmajor) {
-        return cute::GMMA::Layout_K_SW64_Atom<T>{};
-      } else {
-        return cute::GMMA::Layout_MN_SW64_Atom<T>{};
-      }
-    } else if constexpr (kSwizzle == 32) {
-      if constexpr (kKmajor) {
-        return cute::GMMA::Layout_K_SW32_Atom<T>{};
-      } else {
-        return cute::GMMA::Layout_MN_SW32_Atom<T>{};
-      }
-    } else {
-      if constexpr (kKmajor) {
-        return cute::GMMA::Layout_K_INTER_Atom<T>{};
-      } else {
-        return cute::GMMA::Layout_MN_INTER_Atom<T>{};
-      }
-    }
-  }
 
   using SLayoutQAtom = decltype(slayout_selector<kSwizzleQ, Tin>());
   using SLayoutKAtom = decltype(slayout_selector<kSwizzleK, Tin>());
@@ -272,6 +213,83 @@ struct AttentionKVCachePrefillFp8Config {
   static constexpr int shm_y = cosize(SLayoutY{}) * sizeof(Tout);
   static constexpr int shm_qs = cosize(SLayoutQS{}) * sizeof(float);
   static constexpr int shm_size = shm_qkv + shm_y + shm_qs;
+
+  auto get_shm_size() { return shm_size; }
+};
+
+template <typename Tin_, typename Tout_, typename TiledMmaQKAtom, typename TiledMmaPVAtom,
+          int kTileM_, int kTileN_, int kTileK_, int kTileV_, int kTileS_, int kBlockSize_,
+          int kScaleBlockSize_, int kStage_, int kWarpgroupM_ = 2, int kWarpgroupN_ = 1,
+          int kSwizzleQ = 128, int kSwizzleK = 128, int kSwizzleV = 128, int kSwizzleY = 128>
+struct AttentionKVCachePrefillQKTokenVTensorFp8Config {
+  using Tin = Tin_;
+  using Tout = Tout_;
+
+  static constexpr int kTileM = kTileM_;
+  static constexpr int kTileN = kTileN_;
+  static constexpr int kTileK = kTileK_;
+  static constexpr int kTileV = kTileV_;
+  static constexpr int kTileS = kTileS_;
+  static constexpr int kBlockSize = kBlockSize_;
+  static constexpr int kScaleBlockSize = kScaleBlockSize_;
+  static constexpr int kStage = kStage_;
+  static constexpr int kWarpgroupM = kWarpgroupM_;
+
+  using SLayoutQAtom = decltype(slayout_selector<kSwizzleQ, Tin>());
+  using SLayoutKAtom = decltype(slayout_selector<kSwizzleK, Tin>());
+  using SLayoutVAtom = decltype(slayout_selector<kSwizzleV, Tin, false>());
+  using SLayoutVTAtom = decltype(slayout_selector<kSwizzleV, Tin>());
+  using SLayoutYAtom = decltype(slayout_selector<kSwizzleY, Tout>());
+
+  using SLayoutQ =
+      decltype(tile_to_shape(SLayoutQAtom{}, make_shape(Int<kTileM>{}, Int<kTileK>{})));
+  using SLayoutK = decltype(tile_to_shape(SLayoutKAtom{},
+                                          make_shape(Int<kTileN>{}, Int<kTileK>{}, Int<kStage>{})));
+  using SLayoutV = decltype(tile_to_shape(SLayoutVAtom{},
+                                          make_shape(Int<kTileV>{}, Int<kTileN>{}, Int<kStage>{})));
+  using SLayoutVT = decltype(tile_to_shape(
+      SLayoutVTAtom{}, make_shape(Int<kTileV>{}, Int<kTileN>{}, Int<kStage * kWarpgroupM>{})));
+  using SLayoutY =
+      decltype(tile_to_shape(SLayoutYAtom{}, make_shape(Int<kTileM>{}, Int<kTileV>{})));
+  using SLayoutQS = decltype(make_layout(make_shape(Int<kTileM>{}), make_stride(Int<1>{})));
+  using SLayoutKS = decltype(make_layout(make_shape(Int<kTileN>{}, Int<kStage>{}),
+                                         make_stride(Int<1>{}, Int<kTileN>{})));
+  using SLayoutKSC =
+      decltype(make_layout(make_shape(Int<kTileN / kTileS>{}, Int<kTileS>{}, Int<kStage>{}),
+                           make_stride(Int<kTileS>{}, Int<1>{}, Int<kTileN>{})));
+
+  using CopyBoxK =
+      decltype(tile_to_shape(SLayoutKAtom{}, make_shape(Int<kBlockSize>{}, Int<kTileK>{})));
+  using CopyBoxV =
+      decltype(tile_to_shape(SLayoutVAtom{}, make_shape(Int<kTileV>{}, Int<kBlockSize>{})));
+  using CopyBoxY = decltype(tile_to_shape(SLayoutYAtom{},
+                                          make_shape(Int<kTileM / kWarpgroupM>{}, Int<kTileV>{})));
+  using CopyBoxKS = decltype(make_layout(make_shape(Int<kScaleBlockSize>{}, Int<kTileS>{}),
+                                         make_stride(Int<kTileS>{}, Int<1>{})));
+
+  template <typename TQ, typename TK, typename TV, typename TY, typename TQS, typename TKS>
+  auto get_tma(TQ q, TK k, TV v, TY y, TQS qs, TKS ks) {
+    auto tma_q = make_tma_copy(SM90_TMA_LOAD{}, q, SLayoutQ{});
+    auto tma_k = make_tma_copy(SM90_TMA_LOAD{}, k, CopyBoxK{});
+    auto tma_v = make_tma_copy(SM90_TMA_LOAD{}, v, CopyBoxV{});
+    auto tma_y = make_tma_copy(SM90_TMA_STORE{}, y, CopyBoxY{});
+    auto tma_qs = make_tma_copy(SM90_TMA_LOAD{}, qs, SLayoutQS{});
+    auto tma_ks = make_tma_copy(SM90_TMA_LOAD{}, ks, CopyBoxKS{});
+    return std::make_tuple(tma_q, tma_k, tma_v, tma_y, tma_qs, tma_ks);
+  }
+
+  using WarpgroupLayout =
+      decltype(make_layout(make_shape(Int<kWarpgroupM_>{}, Int<kWarpgroupN_>{}, Int<1>{})));
+  using TiledMmaQK = decltype(make_tiled_mma(TiledMmaQKAtom{}, WarpgroupLayout{}));
+  using TiledMmaPV = decltype(make_tiled_mma(TiledMmaPVAtom{}, WarpgroupLayout{}));
+
+  static constexpr int shm_qkv =
+      (cosize(SLayoutQ{}) + cosize(SLayoutK{}) + cosize(SLayoutV{}) + cosize(SLayoutVT{})) *
+      sizeof(Tin);
+  static constexpr int shm_y = cosize(SLayoutY{}) * sizeof(Tout);
+  static constexpr int shm_qs = cosize(SLayoutQS{}) * sizeof(float);
+  static constexpr int shm_ks = cosize(SLayoutKS{}) * sizeof(float);
+  static constexpr int shm_size = shm_qkv + shm_y + shm_qs + shm_ks;
 
   auto get_shm_size() { return shm_size; }
 };

--- a/src/attention/prefill/kernels.cuh
+++ b/src/attention/prefill/kernels.cuh
@@ -17,6 +17,9 @@ namespace hpc {
 namespace attention {
 namespace kernels {
 
+constexpr float kFp8PrefillPScale = 256.0f;
+constexpr float kFp8PrefillPScaleInv = 1.0f / kFp8PrefillPScale;
+
 template <int kTileM>
 __device__ __forceinline__ auto get_next_tile(const int *seqlens_q_ptr, int &iblock, int num_head_q,
                                               int num_batch, int max_total_blocks,
@@ -89,52 +92,14 @@ __device__ __forceinline__ void online_softmax(ATensor &&tAttr_mn, MTensor &&gMa
   }
 }
 
-template <typename ATensor, typename MTensor, typename STensor, typename YTensor, typename QSTensor>
-__device__ __forceinline__ void online_softmax_with_scale(ATensor &&tAttr_mn, MTensor &&gMax,
-                                                          STensor &&gSum, YTensor &&tYr_mn,
-                                                          QSTensor &&tQS, int kM, int kN,
-                                                          float one_over_dk_log2e) {
-#pragma unroll
-  for (int im = 0; im < kM; ++im) {
-    float qs_im = tQS[im];
-    tAttr_mn(im, 0) = tAttr_mn(im, 0) * qs_im;
-    float row_max = tAttr_mn(im, 0);
-    float row_sum = 0.f;
-
-#pragma unroll
-    for (int in = 1; in < kN; ++in) {
-      float local_max = tAttr_mn(im, in) * qs_im;
-      tAttr_mn(im, in) = local_max;
-      row_max = fmaxf(row_max, local_max);
-    }
-
-    row_max = warp_4lane_reduce_max_xor(row_max) * one_over_dk_log2e;
-    float last_max = gMax(im);
-    gMax(im) = fmaxf(last_max, row_max);
-
-#pragma unroll
-    for (int in = 0; in < kN; ++in) {
-      tAttr_mn(im, in) = exp2f_ftz(tAttr_mn(im, in) * one_over_dk_log2e - gMax(im));
-      row_sum += tAttr_mn(im, in);
-    }
-
-    float scale = exp2f_ftz(last_max - gMax(im));
-    gSum(im) = gSum(im) * scale + row_sum;
-
-#pragma unroll
-    for (int in = 0; in < cute::size<1>(tYr_mn); ++in) {
-      tYr_mn(im, in) = tYr_mn(im, in) * scale;
-    }
-  }
-}
-
-template <typename T, typename TmaQ, typename TmaK, typename TmaV, typename TmaY>
+template <typename Tin, typename Tout, typename TmaQ, typename TmaK, typename TmaV, typename TmaY>
 __global__ void update_batched_tma(const vec_t<cute::TmaDescriptor, 4> td_qkvy,
-                                   cute::TmaDescriptor *tma_qkvy, const T *q_ptr, const T *k_ptr,
-                                   const T *v_ptr, const T *y_ptr, const int *seqlens_q_ptr,
-                                   const int *cu_seqlens_q_ptr, int num_batch, int max_seq_q,
-                                   int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv,
-                                   int ldQ, int ldK, int ldV, int ldY) {
+                                   cute::TmaDescriptor *tma_qkvy, const Tin *q_ptr,
+                                   const Tin *k_ptr, const Tin *v_ptr, const Tout *y_ptr,
+                                   const int *seqlens_q_ptr, const int *cu_seqlens_q_ptr,
+                                   const int *cu_seqlens_kv_ptr, int num_batch, int num_dim_qk,
+                                   int num_dim_v, int num_head_q, int num_head_kv, int ldQ, int ldK,
+                                   int ldV, int ldY) {
   using namespace cute;  // NOLINT
 
   int idx = threadIdx.x;
@@ -142,11 +107,16 @@ __global__ void update_batched_tma(const vec_t<cute::TmaDescriptor, 4> td_qkvy,
 
   __shared__ cute::TmaDescriptor smem_tma_desc[4];
 
-  int num_seq = seqlens_q_ptr[ibatch];
+  int num_seq_q = seqlens_q_ptr ? seqlens_q_ptr[ibatch]
+                                : (cu_seqlens_q_ptr[ibatch + 1] - cu_seqlens_q_ptr[ibatch]);
+  int num_seq_kv =
+      cu_seqlens_kv_ptr ? (cu_seqlens_kv_ptr[ibatch + 1] - cu_seqlens_kv_ptr[ibatch]) : num_seq_q;
   int cu_seqlen_q = cu_seqlens_q_ptr[ibatch];
+  int cu_seqlen_kv = cu_seqlens_kv_ptr ? cu_seqlens_kv_ptr[ibatch] : cu_seqlen_q;
+
   auto *q_ibatch_ptr = q_ptr + cu_seqlen_q * ldQ;
-  auto *k_ibatch_ptr = k_ptr + cu_seqlen_q * ldK;
-  auto *v_ibatch_ptr = v_ptr + cu_seqlen_q * ldV;
+  auto *k_ibatch_ptr = k_ptr + cu_seqlen_kv * ldK;
+  auto *v_ibatch_ptr = v_ptr + cu_seqlen_kv * ldV;
   auto *y_ibatch_ptr = y_ptr + cu_seqlen_q * ldY;
 
   if (idx < 4) {
@@ -156,28 +126,31 @@ __global__ void update_batched_tma(const vec_t<cute::TmaDescriptor, 4> td_qkvy,
 
   // Q
   if (idx == 0) {
-    auto gQ = make_tensor(make_gmem_ptr(q_ibatch_ptr), make_shape(num_seq, num_dim_qk, num_head_q),
-                          make_stride(ldQ, Int<1>{}, num_dim_qk));
+    auto gQ =
+        make_tensor(make_gmem_ptr(q_ibatch_ptr), make_shape(num_seq_q, num_dim_qk, num_head_q),
+                    make_stride(ldQ, Int<1>{}, num_dim_qk));
     update_tma_gtensor<TmaQ>(smem_tma_desc[idx], gQ);
   }
 
   // K
   if (idx == 1) {
-    auto gK = make_tensor(make_gmem_ptr(k_ibatch_ptr), make_shape(num_seq, num_dim_qk, num_head_kv),
-                          make_stride(ldK, Int<1>{}, num_dim_qk));
+    auto gK =
+        make_tensor(make_gmem_ptr(k_ibatch_ptr), make_shape(num_seq_kv, num_dim_qk, num_head_kv),
+                    make_stride(ldK, Int<1>{}, num_dim_qk));
     update_tma_gtensor<TmaK>(smem_tma_desc[idx], gK);
   }
 
   // V
   if (idx == 2) {
-    auto gV = make_tensor(make_gmem_ptr(v_ibatch_ptr), make_shape(num_dim_v, num_seq, num_head_kv),
-                          make_stride(Int<1>{}, ldV, num_dim_v));
+    auto gV =
+        make_tensor(make_gmem_ptr(v_ibatch_ptr), make_shape(num_dim_v, num_seq_kv, num_head_kv),
+                    make_stride(Int<1>{}, ldV, num_dim_v));
     update_tma_gtensor<TmaV>(smem_tma_desc[idx], gV);
   }
 
   // Y
   if (idx == 3) {
-    auto gY = make_tensor(make_gmem_ptr(y_ibatch_ptr), make_shape(num_seq, num_dim_v, num_head_q),
+    auto gY = make_tensor(make_gmem_ptr(y_ibatch_ptr), make_shape(num_seq_q, num_dim_v, num_head_q),
                           make_stride(ldY, Int<1>{}, num_dim_v));
     update_tma_gtensor<TmaY>(smem_tma_desc[idx], gY);
   }
@@ -531,7 +504,7 @@ __global__ void __launch_bounds__(384, 1) attention_prefill_bf16_warp_specializa
         auto tAttAbf16 = make_tensor_like<cute::bfloat16_t>(tAttA);
 #pragma unroll
         for (int i = 0; i < size(tAttA); ++i) {
-          tAttAbf16(i) = (cute::bfloat16_t)(tAttA(i));
+          tAttAbf16(i) = static_cast<cute::bfloat16_t>(tAttA(i));
         }
 
         wait_barrier(readable_v[ismem_read], phase);
@@ -926,7 +899,7 @@ __global__ void __launch_bounds__(384, 1)
         auto tAttAbf16 = make_tensor_like<cute::bfloat16_t>(tAttA);
 #pragma unroll
         for (int i = 0; i < size(tAttA); ++i) {
-          tAttAbf16(i) = (cute::bfloat16_t)(tAttA(i));
+          tAttAbf16(i) = static_cast<cute::bfloat16_t>(tAttA(i));
         }
 
         wait_barrier(readable_v[ismem_read], phase);
@@ -993,7 +966,7 @@ __global__ void __launch_bounds__(384, 1)
 template <typename Config, typename TmaQ, typename TmaK, typename TmaV, typename TmaY,
           typename TmaQS>
 __global__ void __launch_bounds__(384, 1)
-    attention_with_kvcache_prefill_fp8_warp_specialization_kernel(
+    attention_with_kvcache_qpertoken_perhead_kvpertensor_prefill_fp8_warp_specialization_kernel(
         cute::TmaDescriptor *td_qy, const __grid_constant__ TmaK tma_k,
         const __grid_constant__ TmaV tma_v, const __grid_constant__ TmaQS tma_qs,
         const float *qscale_ptr, const float *kscale_ptr, const float *vscale_ptr,
@@ -1348,14 +1321,31 @@ __global__ void __launch_bounds__(384, 1)
 
               if ((icol > irow) || (icol >= num_seq_kv)) {
                 tAttr_mn(im, in) = -std::numeric_limits<float>::infinity();
+              } else {
+                tAttr_mn(im, in) *= tQS[im];
               }
+            }
+          }
+        } else {
+#pragma unroll
+          for (int im = 0; im < kM; ++im) {
+#pragma unroll
+            for (int in = 0; in < kN; ++in) {
+              tAttr_mn(im, in) *= tQS[im];
             }
           }
         }
 
         auto tYr_mn = retile_fragment(tYr);
         // online softmax
-        online_softmax_with_scale(tAttr_mn, gMax, gSum, tYr_mn, tQS, kM, kN, one_over_dk_log2e);
+        // online_softmax_with_scale(tAttr_mn, gMax, gSum, tYr_mn, tQS, kM, kN, one_over_dk_log2e);
+        online_softmax(tAttr_mn, gMax, gSum, tYr_mn, kM, kN, one_over_dk_log2e);
+
+        // Scale P before FP8 quantization; epilogue applies the reciprocal.
+#pragma unroll
+        for (int i = 0; i < size(tAttr); ++i) {
+          tAttr(i) *= kFp8PrefillPScale;
+        }
 
         // convert P to fp8 and permute for pv gemm
         auto tAttr_float32x4 = recast<float4>(tAttr);
@@ -1423,9 +1413,1682 @@ __global__ void __launch_bounds__(384, 1)
       // to bfloat16
       auto tYr_bf16 = make_tensor_like<Tout>(tYr);
 
+      float vscale_eff = vscale * kFp8PrefillPScaleInv;
 #pragma unroll
       for (int i = 0; i < size(tYr); ++i) {
-        tYr_bf16(i) = Tout(tYr(i) * vscale);
+        tYr_bf16(i) = Tout(tYr(i) * vscale_eff);
+      }
+
+      // Epilogue: write register-C to global memory
+      using R2SCopyAtomC = Copy_Atom<cute::SM90_U32x4_STSM_N, Tout>;
+      auto r2s_tiled_copy = make_tiled_copy_C(R2SCopyAtomC{}, tiled_mma_pv);
+      auto r2s_thr_copy = r2s_tiled_copy.get_slice(idx);
+
+      auto tYr4s = r2s_thr_copy.retile_S(tYr_bf16);
+      auto tYs4r = r2s_thr_copy.partition_D(sY);
+
+      cute::copy(r2s_tiled_copy, tYr4s, tYs4r);
+      syncwarpgroup(iwarpgroup);
+      tma_store_fence();
+
+      // using TMA to store
+      if (is_leader_in_warpgroup) {
+        auto cY = tma_y.get_tma_tensor(make_shape(max_seq_q, num_dim_v, num_head_q));
+        auto btma_y = tma_y.get_slice(0);
+
+        auto tYss = btma_y.partition_S(sY);  // (TMA, TMA_M, TMA_N)
+        auto tYgg = btma_y.partition_D(cY);  // (TMA, TMA_M, TMA_N, b)
+
+        auto *td_y = td_qy + ibatch * 2 + 1;
+        cute::copy(tma_y.with(td_y), tYss(_, iwarpgroup, 0),
+                   tYgg(_, itile_m * 2 + iwarpgroup, 0, ihead_q));
+        tma_store_arrive();
+      }
+    }
+  }
+}
+
+template <typename Config, typename TmaQ, typename TmaK, typename TmaV, typename TmaY,
+          typename TmaQS, typename TmaKS>
+__global__ void __launch_bounds__(384, 1)
+    attention_with_kvcache_qkpertoken_perhead_vperhead_prefill_fp8_warp_specialization_kernel(
+        cute::TmaDescriptor *td_qy, const __grid_constant__ TmaK tma_k,
+        const __grid_constant__ TmaV tma_v, const __grid_constant__ TmaQS tma_qs,
+        const __grid_constant__ TmaKS tma_ks, const float *qscale_ptr, const float *kscale_ptr,
+        const float *vscale_ptr, const int *cu_seqlens_q_ptr, const int *seqlens_kvcache_ptr,
+        const int *block_ids_ptr, int num_batch, int max_seq_q, int max_seq_q_pad, int num_dim_qk,
+        int num_dim_v, int num_dim_scale, int num_head_q, int num_head_kv, int num_kvcache_blocks,
+        int num_scale_blocks, int block_size, int num_seq_max_blocks, float one_over_dk_log2e,
+        cutlass::FastDivmod head_kv_divmod, cutlass::FastDivmod head_q_divmod,
+        cutlass::FastDivmod tile_m_divmod) {
+  using namespace cute;  // NOLINT
+
+  using Tin = typename Config::Tin;
+  using Tout = typename Config::Tout;
+  using TiledMmaQK = typename Config::TiledMmaQK;
+  using TiledMmaPV = typename Config::TiledMmaPV;
+  using SLayoutQ = typename Config::SLayoutQ;
+  using SLayoutK = typename Config::SLayoutK;
+  using SLayoutV = typename Config::SLayoutV;
+  using SLayoutVT = typename Config::SLayoutVT;
+  using SLayoutY = typename Config::SLayoutY;
+  using SLayoutQS = typename Config::SLayoutQS;
+  using SLayoutKS = typename Config::SLayoutKS;
+  using SLayoutKSC = typename Config::SLayoutKSC;
+
+  constexpr int kTileM = Config::kTileM;
+  constexpr int kTileN = Config::kTileN;
+  constexpr int kTileK = Config::kTileK;
+  constexpr int kTileV = Config::kTileV;
+  constexpr int kStage = Config::kStage;
+  constexpr int kBlockSize = Config::kBlockSize;
+  constexpr int kScaleBlockSize = Config::kScaleBlockSize;
+
+  int idx = threadIdx.x;
+  int iblock = blockIdx.x;
+
+  int elected = cute::elect_one_sync();
+  int iwarp = __shfl_sync(0xFFFFFFFF, idx / 32, 0);
+  bool is_leader_in_block = (iwarp == 0) && elected;
+  bool is_leader_in_warpgroup = ((iwarp % 4) == 0) && elected;
+
+  __shared__ uint64_t readable_q;
+  __shared__ uint64_t writable_q;
+  __shared__ uint64_t readable_k[kStage];
+  __shared__ uint64_t writable_k[kStage];
+  __shared__ uint64_t readable_v[kStage];
+  __shared__ uint64_t writable_v[kStage];
+  extern __shared__ uint8_t shm_data[] alignas(128);
+
+  auto *shm_q = reinterpret_cast<Tin *>(shm_data);
+  auto *shm_k = shm_q + cosize(SLayoutQ{});
+  auto *shm_v = shm_k + cosize(SLayoutK{});
+  auto *shm_vt = shm_v + cosize(SLayoutV{});
+  auto *shm_y = reinterpret_cast<Tout *>(shm_vt + cosize(SLayoutVT{}));
+  auto *shm_qs = reinterpret_cast<float *>(shm_y + cosize(SLayoutY{}));
+  auto *shm_ks = reinterpret_cast<float *>(shm_qs + cosize(SLayoutQS{}));
+  auto *shm_seqlens_q = reinterpret_cast<int *>(shm_ks + cosize(SLayoutKSC{}));
+  auto *shm_seqlens_kv = shm_seqlens_q + num_batch;
+  auto *shm_seqlens_qstart = shm_seqlens_kv + num_batch;
+
+  TmaQ tma_q;
+  TmaY tma_y;
+
+  // Tensor Q/K/V/Y
+  auto gQ = tma_q.get_tma_tensor(make_shape(max_seq_q, num_dim_qk, num_head_q));
+  auto gK =
+      tma_k.get_tma_tensor(make_shape(kBlockSize, num_dim_qk, num_head_kv, num_kvcache_blocks));
+  auto gV =
+      tma_v.get_tma_tensor(make_shape(num_dim_v, kBlockSize, num_head_kv, num_kvcache_blocks));
+  auto gY = tma_y.get_tma_tensor(make_shape(max_seq_q, num_dim_v, num_head_q));
+  auto gQS = tma_qs.get_tma_tensor(make_shape(max_seq_q_pad, num_head_q, num_batch));
+  auto gKS = tma_ks.get_tma_tensor(
+      make_shape(kScaleBlockSize, num_dim_scale, num_head_kv, num_scale_blocks));
+
+  auto gAtt =
+      make_tensor(make_gmem_ptr(static_cast<float *>(nullptr)),
+                  make_shape(Int<kTileM>{}, Int<kTileN>{}), make_stride(Int<kTileN>{}, Int<1>{}));
+  auto gAtt_fp8 =
+      make_tensor(make_gmem_ptr(static_cast<Tin *>(nullptr)),
+                  make_shape(Int<kTileM>{}, Int<kTileN>{}), make_stride(Int<kTileN>{}, Int<1>{}));
+  auto gYY =
+      make_tensor(make_gmem_ptr(static_cast<Tout *>(nullptr)),
+                  make_shape(Int<kTileM>{}, Int<kTileV>{}), make_stride(Int<kTileV>{}, Int<1>{}));
+
+  // Tensor sQ/sK/sV
+  auto sQ = make_tensor(make_smem_ptr(shm_q), SLayoutQ{});
+  auto sK = make_tensor(make_smem_ptr(shm_k), SLayoutK{});
+  auto sV = make_tensor(make_smem_ptr(shm_v), SLayoutV{});
+  auto sVT = make_tensor(make_smem_ptr(shm_vt), SLayoutVT{});
+  auto sY = make_tensor(make_smem_ptr(shm_y), SLayoutY{});
+  auto sQS = make_tensor(make_smem_ptr(shm_qs), SLayoutQS{});
+  auto sKS = make_tensor(make_smem_ptr(shm_ks), SLayoutKS{});
+  auto sKSC = make_tensor(make_smem_ptr(shm_ks), SLayoutKSC{});
+
+  // Block Level tma
+  auto btma_q = tma_q.get_slice(0);
+  auto btma_k = tma_k.get_slice(0);
+  auto btma_v = tma_v.get_slice(0);
+  auto btma_y = tma_y.get_slice(0);
+  auto btma_qs = tma_qs.get_slice(0);
+  auto btma_ks = tma_ks.get_slice(0);
+
+  // Thread Level Tensor
+  auto tQg = btma_q.partition_S(gQ);     // (TMA, TMA_M, TMA_K, head, batch)
+  auto tKg = btma_k.partition_S(gK);     // (TMA, TMA_N, TMA_K, head, batch)
+  auto tVg = btma_v.partition_S(gV);     // (TMA, TMA_V, TMA_N, head, batch)
+  auto tQSg = btma_qs.partition_S(gQS);  // (TMA, TMA_M, head, batch)
+  auto tKSg = btma_ks.partition_S(gKS);  // (TMA, TMA_M, head, batch)
+
+  auto tQs = btma_q.partition_D(sQ);      // (TMA, _1, _1)
+  auto tKs = btma_k.partition_D(sK);      // (TMA, _1, _1, kStage)
+  auto tVs = btma_v.partition_D(sV);      // (TMA, _1, _1, kStage)
+  auto tQSs = btma_qs.partition_D(sQS);   // (TMA, _1)
+  auto tKSs = btma_ks.partition_D(sKSC);  // (TMA, _1)
+
+  TiledMmaQK tiled_mma_qk;
+  TiledMmaPV tiled_mma_pv;
+
+  auto thr_mma_qk = tiled_mma_qk.get_slice(idx);
+  auto thr_mma_pv = tiled_mma_pv.get_slice(idx);
+
+  auto tQs4r = thr_mma_qk.partition_A(sQ);
+  auto tKs4r = thr_mma_qk.partition_B(sK);
+  auto tVTs4r = thr_mma_pv.partition_B(sVT);
+
+  auto tQr = thr_mma_qk.make_fragment_A(tQs4r);    // (MMA, MMA_M, MMA_K)
+  auto tKr = thr_mma_qk.make_fragment_B(tKs4r);    // (MMA, MMA_N, MMA_K)
+  auto tVTr = thr_mma_pv.make_fragment_B(tVTs4r);  // (MMA, MMA_V, MMA_N, kStage)
+
+  auto tAttr = thr_mma_qk.partition_fragment_C(gAtt);
+  auto tYr = thr_mma_pv.partition_fragment_C(gYY);
+
+  // init k/v barrier
+  if (is_leader_in_block) {
+    initialize_barrier(readable_q, 1);
+    initialize_barrier(writable_q, 2);
+#pragma unroll
+    for (int i = 0; i < kStage; ++i) {
+      initialize_barrier(readable_k[i], 1);
+      initialize_barrier(writable_k[i], 2);
+      initialize_barrier(readable_v[i], 1);
+      initialize_barrier(writable_v[i], 2);
+    }
+  }
+
+  for (int i = idx; i < num_batch; i += blockDim.x) {
+    int num_seq_ibatch = cu_seqlens_q_ptr[i + 1] - cu_seqlens_q_ptr[i];
+    shm_seqlens_q[i] = num_seq_ibatch;
+    shm_seqlens_kv[i] = seqlens_kvcache_ptr[i];
+    shm_seqlens_qstart[i] = seqlens_kvcache_ptr[i] - num_seq_ibatch;
+  }
+
+  // sync to avoid ahead thread use(wait) readable when it is not initizlized yet
+  __syncthreads();
+
+  int max_num_tile_m = (max_seq_q + kTileM - 1) / kTileM;
+  int max_total_blocks = num_head_q * num_batch * max_num_tile_m;
+
+  constexpr int kNumBlockPerTileN = kTileN / kBlockSize;
+
+  if (idx >= 256) {
+    cutlass::arch::warpgroup_reg_dealloc<32>();
+    idx -= 256;
+
+    int iwarp = __shfl_sync(0xFFFFFFFF, idx / 32, 0);
+    int is_leader_in_load = ((iwarp == 0) && elected);
+
+    if (is_leader_in_load) {
+      int phase = 1;    // start with ok
+      int phase_q = 1;  // start with ok
+      int ismem_write = __shfl_sync(0xFFFFFFFF, 0, 0);
+
+      while (true) {
+        if (iblock >= max_total_blocks) {
+          break;
+        }
+
+        auto [itile_m, ihead_q, ibatch] =
+            get_next_tile<kTileM>(shm_seqlens_q, iblock, num_head_q, num_batch, max_total_blocks,
+                                  max_num_tile_m, head_q_divmod, tile_m_divmod);
+
+        int num_seq_kv = seqlens_kvcache_ptr[ibatch];
+        int num_seq_q = shm_seqlens_q[ibatch];
+        if (itile_m < 0) {
+          continue;
+        }
+
+        int ihead_kv, res;
+        head_kv_divmod(ihead_kv, res, ihead_q);
+
+        auto *td_q = td_qy + ibatch * 2;
+
+        int start_seq_q = shm_seqlens_qstart[ibatch];
+        auto *block_ids_ibatch_ptr = block_ids_ptr + ibatch * num_seq_max_blocks;
+
+        // Load Q
+        wait_barrier(writable_q, phase_q);
+        cute::copy(tma_q.with(td_q, readable_q), tQg(_, itile_m, _, ihead_q), tQs(_, 0, _));
+        cute::copy(tma_qs.with(readable_q), tQSg(_, itile_m, ihead_q, ibatch), tQSs(_, 0));
+        set_barrier_transaction_bytes(
+            readable_q, sizeof(Tin) * cosize(SLayoutQ{}) + sizeof(float) * cosize(SLayoutQS{}));
+        phase_q ^= 1;
+
+        int num_tile_kv = (start_seq_q + (itile_m + 1) * kTileM + kTileN - 1) / kTileN;
+        int num_blocks = (num_seq_kv + kBlockSize - 1) / kBlockSize;
+        constexpr int kTransactionBytesK = sizeof(Tin) * kTileN * kTileK + sizeof(float) * kTileN;
+        // constexpr int kTransactionBytesK = sizeof(Tin) * kTileN * kTileK;
+        constexpr int kTransactionBytesV = sizeof(Tin) * kTileV * kTileN;
+        // load KV
+#pragma unroll 1
+        for (int itile_seq_kv = 0; itile_seq_kv < num_tile_kv; ++itile_seq_kv) {
+          // k
+          wait_barrier(writable_k[ismem_write], phase);
+
+          int iblock_ids[kNumBlockPerTileN];
+#pragma unroll
+          for (int iblock_kv = 0; iblock_kv < kNumBlockPerTileN; iblock_kv++) {
+            iblock_ids[iblock_kv] = 0;
+            int iblock_id = itile_seq_kv * kNumBlockPerTileN + iblock_kv;
+            if (iblock_id < num_blocks) {
+              iblock_ids[iblock_kv] = block_ids_ibatch_ptr[iblock_id];
+            } else {
+              iblock_ids[iblock_kv] = -1;
+            }
+          }
+
+#pragma unroll
+          for (int iblock_kv = 0; iblock_kv < kNumBlockPerTileN; iblock_kv++) {
+            int iblock_true = iblock_ids[iblock_kv];
+            cute::copy(tma_k.with(readable_k[ismem_write]), tKg(_, 0, _, ihead_kv, iblock_true),
+                       tKs(_, iblock_kv, _, ismem_write));
+            cute::copy(tma_ks.with(readable_k[ismem_write]), tKSg(_, 0, _, ihead_kv, iblock_true),
+                       tKSs(_, iblock_kv, _, ismem_write));
+          }
+          set_barrier_transaction_bytes(readable_k[ismem_write], kTransactionBytesK);
+
+          // v
+          wait_barrier(writable_v[ismem_write], phase);
+#pragma unroll
+          for (int iblock_kv = 0; iblock_kv < kNumBlockPerTileN; iblock_kv++) {
+            int iblock_true = iblock_ids[iblock_kv];
+            cute::copy(tma_v.with(readable_v[ismem_write]), tVg(_, _, 0, ihead_kv, iblock_true),
+                       tVs(_, _, iblock_kv, ismem_write));
+          }
+          set_barrier_transaction_bytes(readable_v[ismem_write], kTransactionBytesV);
+
+          ++ismem_write;
+          if (ismem_write == kStage) {
+            ismem_write = 0;
+            phase ^= 1;
+          }
+        }
+      }
+    }
+  } else {
+    cutlass::arch::warpgroup_reg_alloc<224>();
+
+    int idx_in_warpgroup = idx % 128;
+    int idx_in_warp = idx % 32;
+    int iwarpgroup = idx / 128;
+    int iwarp_in_warpgroup = idx_in_warpgroup / 32;
+    int elected_idx_in_warpgroup = ((iwarp_in_warpgroup == 0) && elected);
+
+    auto tAttr_fp8 = make_tensor_like<Tin>(tAttr);
+    auto layout_asC = tAttr.layout();
+    auto layout_asA = thr_mma_pv.partition_fragment_A(gAtt_fp8).layout();
+    // auto tAttA_fp8 = make_tensor(tAttr_fp8.data(), left_inverse(layout_asC).compose(layout_asA));
+    auto tAttA_fp8 = make_tensor(tAttr_fp8.data(), layout_asA);
+
+    auto gI = make_identity_tensor(gAtt.shape());
+    auto tI = thr_mma_qk.partition_C(gI);
+
+    auto tAttr_mn = retile_fragment(tAttr);
+    constexpr int kM = size<0>(tAttr_mn);
+    constexpr int kN = size<1>(tAttr_mn);
+    Tensor gMax = make_tensor<float>(Int<kM>{});
+    Tensor gSum = make_tensor<float>(Int<kM>{});
+
+    constexpr int kTileTransV = 32;
+    constexpr int kTileTransN = 16;
+    auto sV_tile =
+        local_tile(sV, make_tile(Int<kTileTransV>{}, Int<kTileTransN>{}), make_coord(_, _, _));
+    auto sVT_tile =
+        local_tile(sVT, make_tile(Int<kTileTransV>{}, Int<kTileTransN>{}), make_coord(_, _, _));
+
+    tiled_mma_pv.accumulate_ = GMMA::ScaleOut::One;
+
+    int ismem_read = 0;
+    int phase = 0;
+    int phase_q = 0;
+
+    float tQS[kM];
+    float tKS[kN];
+    // float kscale = kscale_ptr[0];
+    // float vscale = vscale_ptr[0];
+
+    while (true) {
+      if (iblock >= max_total_blocks) {
+        break;
+      }
+
+      auto [itile_m, ihead_q, ibatch] =
+          get_next_tile<kTileM>(shm_seqlens_q, iblock, num_head_q, num_batch, max_total_blocks,
+                                max_num_tile_m, head_q_divmod, tile_m_divmod);
+
+      if (itile_m < 0) {
+        continue;
+      }
+
+      int num_seq_kv = shm_seqlens_kv[ibatch];
+      int start_seq_q = shm_seqlens_qstart[ibatch];
+
+      int ihead_kv, res;
+      head_kv_divmod(ihead_kv, res, ihead_q);
+      int num_tile_kv = (start_seq_q + (itile_m + 1) * kTileM + kTileN - 1) / kTileN;
+      int num_tile_full = (start_seq_q + itile_m * kTileM) / kTileN;
+
+      float vscale = vscale_ptr[ihead_kv];
+
+      clear(tYr);
+      clear(gSum);
+      fill(gMax, -std::numeric_limits<float>::infinity());
+
+      wait_barrier(readable_q, phase_q);
+
+      auto tI_mn = retile_fragment(tI);
+#pragma unroll
+      for (int im = 0; im < kM; im++) {
+        tQS[im] = sQS(get<0>(tI_mn(im, 0)));
+      }
+
+#pragma unroll 1
+      for (int itile_seq_kv = 0; itile_seq_kv < num_tile_kv; ++itile_seq_kv) {
+        wait_barrier(readable_k[ismem_read], phase);
+
+#pragma unroll
+        for (int ins = 0; ins < kN; ins++) {
+          tKS[ins] = sKS(get<1>(tI_mn(0, ins)), ismem_read);
+        }
+
+        // P = QK
+        tiled_mma_qk.accumulate_ = GMMA::ScaleOut::Zero;
+
+        warpgroup_fence_operand(tAttr);
+        warpgroup_arrive();
+#pragma unroll
+        for (int ik = 0; ik < size<2>(tQr); ++ik) {
+          cute::gemm(tiled_mma_qk, tQr(_, _, ik), tKr(_, _, ik, ismem_read), tAttr(_, _, _));
+          tiled_mma_qk.accumulate_ = GMMA::ScaleOut::One;
+        }
+
+        warpgroup_commit_batch();
+        warpgroup_wait<0>();
+        warpgroup_fence_operand(tAttr);
+
+        if (elected_idx_in_warpgroup) {
+          arrive_barrier(writable_k[ismem_read]);
+        }
+
+        if (itile_seq_kv == (num_tile_kv - 1)) {
+          if (elected_idx_in_warpgroup) {
+            arrive_barrier(writable_q);
+          }
+          phase_q ^= 1;
+        }
+
+        // do causal mask
+
+        if (itile_seq_kv >= num_tile_full) {
+#pragma unroll
+          for (int im = 0; im < kM; ++im) {
+#pragma unroll
+            for (int in = 0; in < kN; ++in) {
+              int irow = start_seq_q + itile_m * kTileM + get<0>(tI_mn(im, in));
+              int icol = itile_seq_kv * kTileN + get<1>(tI_mn(im, in));
+
+              if ((icol > irow) || (icol >= num_seq_kv)) {
+                tAttr_mn(im, in) = -std::numeric_limits<float>::infinity();
+              } else {
+                tAttr_mn(im, in) *= tQS[im] * tKS[in];
+              }
+            }
+          }
+        } else {
+#pragma unroll
+          for (int im = 0; im < kM; ++im) {
+#pragma unroll
+            for (int in = 0; in < kN; ++in) {
+              tAttr_mn(im, in) *= tQS[im] * tKS[in];
+            }
+          }
+        }
+
+        auto tYr_mn = retile_fragment(tYr);
+        // online softmax
+        // online_softmax_with_scale(tAttr_mn, gMax, gSum, tYr_mn, tQS, tKS, kM, kN,
+        // one_over_dk_log2e);
+        online_softmax(tAttr_mn, gMax, gSum, tYr_mn, kM, kN, one_over_dk_log2e);
+
+        // Scale P before FP8 quantization; epilogue applies the reciprocal.
+#pragma unroll
+        for (int i = 0; i < size(tAttr); ++i) {
+          tAttr(i) *= kFp8PrefillPScale;
+        }
+
+        // convert P to fp8 and permute for pv gemm
+        auto tAttr_float32x4 = recast<float4>(tAttr);
+        auto tAttr_fp8x4 = recast<__nv_fp8x4_e4m3>(tAttr_fp8);
+
+#pragma unroll
+        for (int i = 0; i < size(tAttr_float32x4); i++) {
+          tAttr_fp8x4(i) = __nv_fp8x4_e4m3(tAttr_float32x4(i));
+        }
+
+        auto tAttr_fp8_u64 = recast<uint2>(tAttr_fp8);
+#pragma unroll
+        for (int i = 0; i < size(tAttr_fp8_u64); i++) {
+          uint32_t upper = tAttr_fp8_u64(i).x;
+          uint32_t lower = tAttr_fp8_u64(i).y;
+          tAttr_fp8_u64(i).x = __byte_perm(upper, lower, 0x5410);
+          tAttr_fp8_u64(i).y = __byte_perm(upper, lower, 0x7632);
+        }
+
+        // Y = PV
+        wait_barrier(readable_v[ismem_read], phase);
+
+        auto sV_tile_iwarp = sV_tile(_, _, _, iwarp_in_warpgroup, ismem_read);
+        auto sVT_tile_iwarp = sVT_tile(_, _, _, iwarp_in_warpgroup, ismem_read);
+
+        constexpr int kNumTilePerWarp = 32 / kTileTransN;
+
+        warpgroup_fence_operand(tYr);
+#pragma unroll
+        for (int in = 0; in < size<2>(tVTr); in++) {
+#pragma unroll
+          for (int iin = 0; iin < kNumTilePerWarp; iin++) {
+            smem_trans_and_interleave0189_nm_nm(
+                sV_tile(_, _, iwarp_in_warpgroup, in * kNumTilePerWarp + iin, ismem_read),
+                sVT_tile(_, _, iwarp_in_warpgroup, in * kNumTilePerWarp + iin,
+                         iwarpgroup * kStage + ismem_read),
+                idx_in_warp);
+          }
+          cutlass::arch::fence_view_async_shared();
+          // syncwarpgroup(iwarpgroup);
+
+          warpgroup_arrive();
+          cute::gemm(tiled_mma_pv, tAttA_fp8(_, _, in),
+                     tVTr(_, _, in, iwarpgroup * kStage + ismem_read), tYr);
+          warpgroup_commit_batch();
+        }
+
+        warpgroup_wait<0>();
+
+        if (elected_idx_in_warpgroup) {
+          arrive_barrier(writable_v[ismem_read]);
+        }
+
+        ++ismem_read;
+        if (ismem_read == kStage) {
+          phase ^= 1;
+          ismem_read = 0;
+        }
+      }
+
+      auto tYr_mn = retile_fragment(tYr);
+      // final online softmax
+      final_online_softmax(tYr_mn, gSum, kM);
+
+      // to bfloat16
+      auto tYr_bf16 = make_tensor_like<Tout>(tYr);
+
+      float vscale_eff = vscale * kFp8PrefillPScaleInv;
+#pragma unroll
+      for (int i = 0; i < size(tYr); ++i) {
+        tYr_bf16(i) = Tout(tYr(i) * vscale_eff);
+      }
+
+      // Epilogue: write register-C to global memory
+      using R2SCopyAtomC = Copy_Atom<cute::SM90_U32x4_STSM_N, Tout>;
+      auto r2s_tiled_copy = make_tiled_copy_C(R2SCopyAtomC{}, tiled_mma_pv);
+      auto r2s_thr_copy = r2s_tiled_copy.get_slice(idx);
+
+      auto tYr4s = r2s_thr_copy.retile_S(tYr_bf16);
+      auto tYs4r = r2s_thr_copy.partition_D(sY);
+
+      cute::copy(r2s_tiled_copy, tYr4s, tYs4r);
+      syncwarpgroup(iwarpgroup);
+      tma_store_fence();
+
+      // using TMA to store
+      if (is_leader_in_warpgroup) {
+        auto cY = tma_y.get_tma_tensor(make_shape(max_seq_q, num_dim_v, num_head_q));
+        auto btma_y = tma_y.get_slice(0);
+
+        auto tYss = btma_y.partition_S(sY);  // (TMA, TMA_M, TMA_N)
+        auto tYgg = btma_y.partition_D(cY);  // (TMA, TMA_M, TMA_N, b)
+
+        auto *td_y = td_qy + ibatch * 2 + 1;
+        cute::copy(tma_y.with(td_y), tYss(_, iwarpgroup, 0),
+                   tYgg(_, itile_m * 2 + iwarpgroup, 0, ihead_q));
+        tma_store_arrive();
+      }
+    }
+  }
+}
+
+// FP8 warp-specialization kernel with paged KV cache and Block-Sparse Attention support,
+// dim_qk=128, dim_v=128.
+template <typename Config, typename TmaQ, typename TmaK, typename TmaV, typename TmaY,
+          typename TmaQS, bool kHasMask>
+__global__ void __launch_bounds__(384, 1)
+    attention_with_kvcache_blocksparse_qpertoken_perhead_kvpertensor_prefill_fp8_warp_specialization_kernel(  // NOLINT(whitespace/line_length)
+        cute::TmaDescriptor *td_qy, const __grid_constant__ TmaK tma_k,
+        const __grid_constant__ TmaV tma_v, const __grid_constant__ TmaQS tma_qs,
+        const float *kscale_ptr, const float *vscale_ptr, const int *cu_seqlens_q_ptr,
+        const int *seqlens_kvcache_ptr, const int *block_ids_ptr, int num_batch, int max_seq_q,
+        int max_seq_q_pad, int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv,
+        int num_kvcache_blocks, int num_seq_max_blocks, float one_over_dk_log2e,
+        cutlass::FastDivmod head_kv_divmod, cutlass::FastDivmod head_q_divmod,
+        cutlass::FastDivmod tile_m_divmod, const uint8_t *block_mask_ptr, int num_tile_kv_in_mask) {
+  using namespace cute;  // NOLINT
+
+  using Tin = typename Config::Tin;
+  using Tout = typename Config::Tout;
+  using TiledMmaQK = typename Config::TiledMmaQK;
+  using TiledMmaPV = typename Config::TiledMmaPV;
+  using SLayoutQ = typename Config::SLayoutQ;
+  using SLayoutK = typename Config::SLayoutK;
+  using SLayoutV = typename Config::SLayoutV;
+  using SLayoutVT = typename Config::SLayoutVT;
+  using SLayoutY = typename Config::SLayoutY;
+  using SLayoutQS = typename Config::SLayoutQS;
+
+  constexpr int kTileM = Config::kTileM;
+  constexpr int kTileN = Config::kTileN;
+  constexpr int kTileK = Config::kTileK;
+  constexpr int kTileV = Config::kTileV;
+  constexpr int kStage = Config::kStage;
+  constexpr int kBlockSize = Config::kBlockSize;
+
+  int idx = threadIdx.x;
+  int iblock = blockIdx.x;
+
+  int elected = cute::elect_one_sync();
+  int iwarp = __shfl_sync(0xFFFFFFFF, idx / 32, 0);
+  bool is_leader_in_block = (iwarp == 0) && elected;
+  bool is_leader_in_warpgroup = ((iwarp % 4) == 0) && elected;
+
+  __shared__ uint64_t readable_q;
+  __shared__ uint64_t writable_q;
+  __shared__ uint64_t readable_list;
+  __shared__ uint64_t writable_list;
+  __shared__ uint64_t readable_k[kStage];
+  __shared__ uint64_t writable_k[kStage];
+  __shared__ uint64_t readable_v[kStage];
+  __shared__ uint64_t writable_v[kStage];
+  extern __shared__ uint8_t shm_data[] alignas(128);
+
+  auto *shm_q = reinterpret_cast<Tin *>(shm_data);
+  auto *shm_k = shm_q + cosize(SLayoutQ{});
+  auto *shm_v = shm_k + cosize(SLayoutK{});
+  auto *shm_vt = shm_v + cosize(SLayoutV{});
+  auto *shm_y = reinterpret_cast<Tout *>(shm_vt + cosize(SLayoutVT{}));
+  auto *shm_qs = reinterpret_cast<float *>(shm_y + cosize(SLayoutY{}));
+  auto *shm_seqlens_q = reinterpret_cast<int *>(shm_qs + cosize(SLayoutQS{}));
+  auto *shm_seqlens_kv = shm_seqlens_q + num_batch;
+  auto *shm_seqlens_qstart = shm_seqlens_kv + num_batch;
+  // Active tile list: [num_tile_active (int)] [tile_indices (int[])]
+  auto *shm_num_active = reinterpret_cast<int *>(shm_seqlens_qstart + num_batch);
+  auto *shm_active_tiles = shm_num_active + 1;
+
+  TmaQ tma_q;
+  TmaY tma_y;
+
+  // Tensor Q/K/V/Y
+  auto gQ = tma_q.get_tma_tensor(make_shape(max_seq_q, num_dim_qk, num_head_q));
+  auto gK =
+      tma_k.get_tma_tensor(make_shape(kBlockSize, num_dim_qk, num_head_kv, num_kvcache_blocks));
+  auto gV =
+      tma_v.get_tma_tensor(make_shape(num_dim_v, kBlockSize, num_head_kv, num_kvcache_blocks));
+  auto gY = tma_y.get_tma_tensor(make_shape(max_seq_q, num_dim_v, num_head_q));
+  auto gQS = tma_qs.get_tma_tensor(make_shape(max_seq_q_pad, num_head_q, num_batch));
+
+  auto gAtt =
+      make_tensor(make_gmem_ptr(static_cast<float *>(nullptr)),
+                  make_shape(Int<kTileM>{}, Int<kTileN>{}), make_stride(Int<kTileN>{}, Int<1>{}));
+  auto gAtt_fp8 =
+      make_tensor(make_gmem_ptr(static_cast<Tin *>(nullptr)),
+                  make_shape(Int<kTileM>{}, Int<kTileN>{}), make_stride(Int<kTileN>{}, Int<1>{}));
+  auto gYY =
+      make_tensor(make_gmem_ptr(static_cast<Tout *>(nullptr)),
+                  make_shape(Int<kTileM>{}, Int<kTileV>{}), make_stride(Int<kTileV>{}, Int<1>{}));
+
+  // Tensor sQ/sK/sV
+  auto sQ = make_tensor(make_smem_ptr(shm_q), SLayoutQ{});
+  auto sK = make_tensor(make_smem_ptr(shm_k), SLayoutK{});
+  auto sV = make_tensor(make_smem_ptr(shm_v), SLayoutV{});
+  auto sVT = make_tensor(make_smem_ptr(shm_vt), SLayoutVT{});
+  auto sY = make_tensor(make_smem_ptr(shm_y), SLayoutY{});
+  auto sQS = make_tensor(make_smem_ptr(shm_qs), SLayoutQS{});
+
+  // Block Level tma
+  auto btma_q = tma_q.get_slice(0);
+  auto btma_k = tma_k.get_slice(0);
+  auto btma_v = tma_v.get_slice(0);
+  auto btma_y = tma_y.get_slice(0);
+  auto btma_qs = tma_qs.get_slice(0);
+
+  // Thread Level Tensor
+  auto tQg = btma_q.partition_S(gQ);     // (TMA, TMA_M, TMA_K, head, batch)
+  auto tKg = btma_k.partition_S(gK);     // (TMA, TMA_N, TMA_K, head, batch)
+  auto tVg = btma_v.partition_S(gV);     // (TMA, TMA_V, TMA_N, head, batch)
+  auto tQSg = btma_qs.partition_S(gQS);  // (TMA, TMA_M, head, batch)
+
+  auto tQs = btma_q.partition_D(sQ);     // (TMA, _1, _1)
+  auto tKs = btma_k.partition_D(sK);     // (TMA, _1, _1, kStage)
+  auto tVs = btma_v.partition_D(sV);     // (TMA, _1, _1, kStage)
+  auto tQSs = btma_qs.partition_D(sQS);  // (TMA, _1)
+
+  TiledMmaQK tiled_mma_qk;
+  TiledMmaPV tiled_mma_pv;
+
+  auto thr_mma_qk = tiled_mma_qk.get_slice(idx);
+  auto thr_mma_pv = tiled_mma_pv.get_slice(idx);
+
+  auto tQs4r = thr_mma_qk.partition_A(sQ);
+  auto tKs4r = thr_mma_qk.partition_B(sK);
+  auto tVTs4r = thr_mma_pv.partition_B(sVT);
+
+  auto tQr = thr_mma_qk.make_fragment_A(tQs4r);    // (MMA, MMA_M, MMA_K)
+  auto tKr = thr_mma_qk.make_fragment_B(tKs4r);    // (MMA, MMA_N, MMA_K)
+  auto tVTr = thr_mma_pv.make_fragment_B(tVTs4r);  // (MMA, MMA_V, MMA_N, kStage)
+
+  auto tAttr = thr_mma_qk.partition_fragment_C(gAtt);
+  auto tYr = thr_mma_pv.partition_fragment_C(gYY);
+
+  // init k/v barrier
+  if (is_leader_in_block) {
+    initialize_barrier(readable_q, 1);
+    initialize_barrier(writable_q, 2);
+    initialize_barrier(readable_list, 32);
+    initialize_barrier(writable_list, 256);
+#pragma unroll
+    for (int i = 0; i < kStage; ++i) {
+      initialize_barrier(readable_k[i], 1);
+      initialize_barrier(writable_k[i], 2);
+      initialize_barrier(readable_v[i], 1);
+      initialize_barrier(writable_v[i], 2);
+    }
+  }
+
+  for (int i = idx; i < num_batch; i += blockDim.x) {
+    int num_seq_ibatch = cu_seqlens_q_ptr[i + 1] - cu_seqlens_q_ptr[i];
+    shm_seqlens_q[i] = num_seq_ibatch;
+    shm_seqlens_kv[i] = seqlens_kvcache_ptr[i];
+    shm_seqlens_qstart[i] = seqlens_kvcache_ptr[i] - num_seq_ibatch;
+  }
+
+  // sync to avoid ahead thread use(wait) readable when it is not initizlized yet
+  __syncthreads();
+
+  int max_num_tile_m = (max_seq_q + kTileM - 1) / kTileM;
+  int max_total_blocks = num_head_q * num_batch * max_num_tile_m;
+
+  constexpr int kNumBlockPerTileN = kTileN / kBlockSize;
+
+  // Producer Warpgroup
+  if (idx >= 256) {
+    cutlass::arch::warpgroup_reg_dealloc<24>();
+    idx -= 256;
+
+    int iwarp = __shfl_sync(0xFFFFFFFF, idx / 32, 0);
+    int idx_in_warp = idx % 32;
+
+    // 32 lanes enter for warp-parallel mask scan; single-thread ops guarded by `if (elected)`.
+    if (iwarp == 0) {
+      int phase = 1;         // start with ok
+      int phase_q = 1;       // start with ok
+      int phase_list_w = 1;  // start with ok
+      int ismem_write = 0;
+
+      while (true) {
+        if (iblock >= max_total_blocks) {
+          break;
+        }
+
+        auto [itile_m, ihead_q, ibatch] =
+            get_next_tile<kTileM>(shm_seqlens_q, iblock, num_head_q, num_batch, max_total_blocks,
+                                  max_num_tile_m, head_q_divmod, tile_m_divmod);
+
+        int num_seq_kv = seqlens_kvcache_ptr[ibatch];
+        int num_seq_q = shm_seqlens_q[ibatch];
+        if (itile_m < 0) {
+          continue;
+        }
+
+        int ihead_kv, res;
+        head_kv_divmod(ihead_kv, res, ihead_q);
+
+        auto *td_q = td_qy + ibatch * 2;
+
+        int start_seq_q = shm_seqlens_qstart[ibatch];
+        auto *block_ids_ibatch_ptr = block_ids_ptr + ibatch * num_seq_max_blocks;
+
+        // Load Q
+        wait_barrier(writable_q, phase_q);
+        if (elected) {
+          cute::copy(tma_q.with(td_q, readable_q), tQg(_, itile_m, _, ihead_q), tQs(_, 0, _));
+          cute::copy(tma_qs.with(readable_q), tQSg(_, itile_m, ihead_q, ibatch), tQSs(_, 0));
+        }
+
+        int num_tile_kv = (start_seq_q + (itile_m + 1) * kTileM + kTileN - 1) / kTileN;
+        int num_blocks = (num_seq_kv + kBlockSize - 1) / kBlockSize;
+        constexpr int kTransactionBytesK = sizeof(Tin) * kTileN * kTileK;
+        constexpr int kTransactionBytesV = sizeof(Tin) * kTileV * kTileN;
+
+        // Build active tile list in SMEM (parallel with TMA Q in flight)
+        int num_tile_active = num_tile_kv;
+        if constexpr (kHasMask) {
+          wait_barrier(writable_list, phase_list_w);
+          phase_list_w ^= 1;
+
+          int block_mask_offset = ibatch * (num_head_q * max_num_tile_m * num_tile_kv_in_mask) +
+                                  ihead_q * (max_num_tile_m * num_tile_kv_in_mask) +
+                                  itile_m * num_tile_kv_in_mask;
+          int num_tile_with_mask = min(num_tile_kv, num_tile_kv_in_mask);
+
+          // Warp-parallel stream compaction of active tiles into SMEM.
+          num_tile_active = 0;
+#pragma unroll 1
+          for (int base = 0; base < num_tile_with_mask; base += 32) {
+            int i = base + idx_in_warp;
+            bool active = (i < num_tile_with_mask) && (block_mask_ptr[block_mask_offset + i] != 0);
+            uint32_t ballot = __ballot_sync(0xFFFFFFFF, active);
+            // rank within active lanes = popcount of earlier-lane bits in ballot
+            if (active) {
+              shm_active_tiles[num_tile_active + __popc(ballot & ((1u << idx_in_warp) - 1))] = i;
+            }
+            num_tile_active += __popc(ballot);
+          }
+
+          if (num_tile_with_mask < num_tile_kv) {
+            if (elected) {
+              shm_active_tiles[num_tile_active] = num_tile_with_mask;
+            }
+            num_tile_active += 1;
+          }
+
+          __syncwarp();
+
+          if (elected) {
+            *shm_num_active = num_tile_active;
+          }
+          arrive_barrier(readable_list);
+        }
+
+        if (elected) {
+          set_barrier_transaction_bytes(
+              readable_q, sizeof(Tin) * cosize(SLayoutQ{}) + sizeof(float) * cosize(SLayoutQS{}));
+        }
+        phase_q ^= 1;
+
+#pragma unroll 1
+        for (int i_active = 0; i_active < num_tile_active; ++i_active) {
+          int itile_seq_kv;
+          if constexpr (kHasMask) {
+            itile_seq_kv = shm_active_tiles[i_active];
+          } else {
+            itile_seq_kv = i_active;
+          }
+
+          // k
+          wait_barrier(writable_k[ismem_write], phase);
+
+          int iblock_ids[kNumBlockPerTileN];
+#pragma unroll
+          for (int iblock_kv = 0; iblock_kv < kNumBlockPerTileN; iblock_kv++) {
+            iblock_ids[iblock_kv] = -1;
+            int iblock_id = itile_seq_kv * kNumBlockPerTileN + iblock_kv;
+            if (iblock_id < num_blocks) {
+              iblock_ids[iblock_kv] = block_ids_ibatch_ptr[iblock_id];
+            }
+          }
+
+          if (elected) {
+#pragma unroll
+            for (int iblock_kv = 0; iblock_kv < kNumBlockPerTileN; iblock_kv++) {
+              int iblock_true = iblock_ids[iblock_kv];
+              cute::copy(tma_k.with(readable_k[ismem_write]), tKg(_, 0, _, ihead_kv, iblock_true),
+                         tKs(_, iblock_kv, _, ismem_write));
+            }
+            set_barrier_transaction_bytes(readable_k[ismem_write], kTransactionBytesK);
+          }
+
+          // v
+          wait_barrier(writable_v[ismem_write], phase);
+          if (elected) {
+#pragma unroll
+            for (int iblock_kv = 0; iblock_kv < kNumBlockPerTileN; iblock_kv++) {
+              int iblock_true = iblock_ids[iblock_kv];
+              cute::copy(tma_v.with(readable_v[ismem_write]), tVg(_, _, 0, ihead_kv, iblock_true),
+                         tVs(_, _, iblock_kv, ismem_write));
+            }
+            set_barrier_transaction_bytes(readable_v[ismem_write], kTransactionBytesV);
+          }
+
+          ++ismem_write;
+          if (ismem_write == kStage) {
+            ismem_write = 0;
+            phase ^= 1;
+          }
+        }
+        __syncwarp();
+      }
+    }
+  } else {  // Consumer Warpgroup
+    cutlass::arch::warpgroup_reg_alloc<192>();
+
+    int idx_in_warpgroup = idx % 128;
+    int idx_in_warp = idx % 32;
+    int iwarpgroup = idx / 128;
+    int iwarp_in_warpgroup = idx_in_warpgroup / 32;
+    int elected_idx_in_warpgroup = ((iwarp_in_warpgroup == 0) && elected);
+
+    auto tAttr_fp8 = make_tensor_like<Tin>(tAttr);
+    auto layout_asA = thr_mma_pv.partition_fragment_A(gAtt_fp8).layout();
+    auto tAttA_fp8 = make_tensor(tAttr_fp8.data(), layout_asA);
+
+    auto gI = make_identity_tensor(gAtt.shape());
+    auto tI = thr_mma_qk.partition_C(gI);
+
+    auto tAttr_mn = retile_fragment(tAttr);
+    constexpr int kM = size<0>(tAttr_mn);
+    constexpr int kN = size<1>(tAttr_mn);
+    Tensor gMax = make_tensor<float>(Int<kM>{});
+    Tensor gSum = make_tensor<float>(Int<kM>{});
+
+    constexpr int kTileTransV = 32;
+    constexpr int kTileTransN = 16;
+    auto sV_tile =
+        local_tile(sV, make_tile(Int<kTileTransV>{}, Int<kTileTransN>{}), make_coord(_, _, _));
+    auto sVT_tile =
+        local_tile(sVT, make_tile(Int<kTileTransV>{}, Int<kTileTransN>{}), make_coord(_, _, _));
+
+    tiled_mma_pv.accumulate_ = GMMA::ScaleOut::One;
+
+    int ismem_read = 0;
+    int phase = 0;
+    int phase_q = 0;
+    int phase_list = 0;
+
+    float tQS[kM];
+    float kscale = kscale_ptr[0];
+    float vscale = vscale_ptr[0];
+
+    while (true) {
+      if (iblock >= max_total_blocks) {
+        break;
+      }
+
+      auto [itile_m, ihead_q, ibatch] =
+          get_next_tile<kTileM>(shm_seqlens_q, iblock, num_head_q, num_batch, max_total_blocks,
+                                max_num_tile_m, head_q_divmod, tile_m_divmod);
+
+      if (itile_m < 0) {
+        continue;
+      }
+
+      int num_seq_kv = shm_seqlens_kv[ibatch];
+      int start_seq_q = shm_seqlens_qstart[ibatch];
+
+      int ihead_kv, res;
+      head_kv_divmod(ihead_kv, res, ihead_q);
+      int num_tile_kv = (start_seq_q + (itile_m + 1) * kTileM + kTileN - 1) / kTileN;
+      int num_tile_full = (start_seq_q + itile_m * kTileM) / kTileN;
+
+      clear(tYr);
+      clear(gSum);
+      fill(gMax, -std::numeric_limits<float>::infinity());
+
+      wait_barrier(readable_q, phase_q);
+
+      int num_tile_active;
+      if constexpr (kHasMask) {
+        wait_barrier(readable_list, phase_list);
+        phase_list ^= 1;
+        num_tile_active = *shm_num_active;
+      } else {
+        num_tile_active = num_tile_kv;
+      }
+
+      auto tI_mn = retile_fragment(tI);
+#pragma unroll
+      for (int im = 0; im < kM; im++) {
+        tQS[im] = sQS(get<0>(tI_mn(im, 0))) * kscale;
+      }
+
+#pragma unroll 1
+      for (int i_active = 0; i_active < num_tile_active; ++i_active) {
+        int itile_seq_kv;
+        if constexpr (kHasMask) {
+          itile_seq_kv = shm_active_tiles[i_active];
+        } else {
+          itile_seq_kv = i_active;
+        }
+
+        wait_barrier(readable_k[ismem_read], phase);
+
+        // P = QK
+        tiled_mma_qk.accumulate_ = GMMA::ScaleOut::Zero;
+
+        warpgroup_fence_operand(tAttr);
+        warpgroup_arrive();
+#pragma unroll
+        for (int ik = 0; ik < size<2>(tQr); ++ik) {
+          cute::gemm(tiled_mma_qk, tQr(_, _, ik), tKr(_, _, ik, ismem_read), tAttr(_, _, _));
+          tiled_mma_qk.accumulate_ = GMMA::ScaleOut::One;
+        }
+
+        warpgroup_commit_batch();
+        warpgroup_wait<0>();
+        warpgroup_fence_operand(tAttr);
+
+        if (elected_idx_in_warpgroup) {
+          arrive_barrier(writable_k[ismem_read]);
+        }
+
+        if (i_active == (num_tile_active - 1)) {
+          if (elected_idx_in_warpgroup) {
+            arrive_barrier(writable_q);
+          }
+          phase_q ^= 1;
+          if constexpr (kHasMask) {
+            arrive_barrier(writable_list);
+          }
+        }
+
+        if (itile_seq_kv >= num_tile_full) {
+#pragma unroll
+          for (int im = 0; im < kM; ++im) {
+#pragma unroll
+            for (int in = 0; in < kN; ++in) {
+              int irow = start_seq_q + itile_m * kTileM + get<0>(tI_mn(im, in));
+              int icol = itile_seq_kv * kTileN + get<1>(tI_mn(im, in));
+
+              if ((icol > irow) || (icol >= num_seq_kv)) {
+                tAttr_mn(im, in) = -std::numeric_limits<float>::infinity();
+              } else {
+                tAttr_mn(im, in) *= tQS[im];
+              }
+            }
+          }
+        } else {
+#pragma unroll
+          for (int im = 0; im < kM; ++im) {
+#pragma unroll
+            for (int in = 0; in < kN; ++in) {
+              tAttr_mn(im, in) *= tQS[im];
+            }
+          }
+        }
+
+        auto tYr_mn = retile_fragment(tYr);
+        // online softmax
+        // online_softmax_with_scale(tAttr_mn, gMax, gSum, tYr_mn, tQS, kM, kN, one_over_dk_log2e);
+        online_softmax(tAttr_mn, gMax, gSum, tYr_mn, kM, kN, one_over_dk_log2e);
+
+        // Scale P before FP8 quantization; epilogue applies the reciprocal.
+#pragma unroll
+        for (int i = 0; i < size(tAttr); ++i) {
+          tAttr(i) *= kFp8PrefillPScale;
+        }
+
+        // convert P to fp8 and permute for pv gemm
+        auto tAttr_float32x4 = recast<float4>(tAttr);
+        auto tAttr_fp8x4 = recast<__nv_fp8x4_e4m3>(tAttr_fp8);
+
+#pragma unroll
+        for (int i = 0; i < size(tAttr_float32x4); i++) {
+          tAttr_fp8x4(i) = __nv_fp8x4_e4m3(tAttr_float32x4(i));
+        }
+
+        auto tAttr_fp8_u64 = recast<uint2>(tAttr_fp8);
+#pragma unroll
+        for (int i = 0; i < size(tAttr_fp8_u64); i++) {
+          uint32_t upper = tAttr_fp8_u64(i).x;
+          uint32_t lower = tAttr_fp8_u64(i).y;
+          tAttr_fp8_u64(i).x = __byte_perm(upper, lower, 0x5410);
+          tAttr_fp8_u64(i).y = __byte_perm(upper, lower, 0x7632);
+        }
+
+        // Y = PV
+        wait_barrier(readable_v[ismem_read], phase);
+
+        constexpr int kNumTilePerWarp = 32 / kTileTransN;
+
+        warpgroup_fence_operand(tYr);
+#pragma unroll
+        for (int in = 0; in < size<2>(tVTr); in++) {
+#pragma unroll
+          for (int iin = 0; iin < kNumTilePerWarp; iin++) {
+            smem_trans_and_interleave0189_nm_nm(
+                sV_tile(_, _, iwarp_in_warpgroup, in * kNumTilePerWarp + iin, ismem_read),
+                sVT_tile(_, _, iwarp_in_warpgroup, in * kNumTilePerWarp + iin,
+                         iwarpgroup * kStage + ismem_read),
+                idx_in_warp);
+          }
+          cutlass::arch::fence_view_async_shared();
+
+          warpgroup_arrive();
+          cute::gemm(tiled_mma_pv, tAttA_fp8(_, _, in),
+                     tVTr(_, _, in, iwarpgroup * kStage + ismem_read), tYr);
+          warpgroup_commit_batch();
+        }
+
+        warpgroup_wait<0>();
+
+        if (elected_idx_in_warpgroup) {
+          arrive_barrier(writable_v[ismem_read]);
+        }
+
+        ++ismem_read;
+        if (ismem_read == kStage) {
+          phase ^= 1;
+          ismem_read = 0;
+        }
+      }
+
+      // Release Q barrier to prevent deadlock if violated.
+      if (num_tile_active == 0) {
+        if (elected_idx_in_warpgroup) {
+          arrive_barrier(writable_q);
+        }
+        phase_q ^= 1;
+      }
+
+      auto tYr_mn = retile_fragment(tYr);
+      // final online softmax
+      final_online_softmax(tYr_mn, gSum, kM);
+
+      // to bfloat16
+      auto tYr_bf16 = make_tensor_like<Tout>(tYr);
+
+      float vscale_eff = vscale * kFp8PrefillPScaleInv;
+#pragma unroll
+      for (int i = 0; i < size(tYr); ++i) {
+        tYr_bf16(i) = Tout(tYr(i) * vscale_eff);
+      }
+
+      // Epilogue: write register-C to global memory
+      using R2SCopyAtomC = Copy_Atom<cute::SM90_U32x4_STSM_N, Tout>;
+      auto r2s_tiled_copy = make_tiled_copy_C(R2SCopyAtomC{}, tiled_mma_pv);
+      auto r2s_thr_copy = r2s_tiled_copy.get_slice(idx);
+
+      auto tYr4s = r2s_thr_copy.retile_S(tYr_bf16);
+      auto tYs4r = r2s_thr_copy.partition_D(sY);
+
+      cute::copy(r2s_tiled_copy, tYr4s, tYs4r);
+      syncwarpgroup(iwarpgroup);
+      tma_store_fence();
+
+      // using TMA to store
+      if (is_leader_in_warpgroup) {
+        auto cY = tma_y.get_tma_tensor(make_shape(max_seq_q, num_dim_v, num_head_q));
+        auto btma_y = tma_y.get_slice(0);
+
+        auto tYss = btma_y.partition_S(sY);  // (TMA, TMA_M, TMA_N)
+        auto tYgg = btma_y.partition_D(cY);  // (TMA, TMA_M, TMA_N, b)
+
+        auto *td_y = td_qy + ibatch * 2 + 1;
+        cute::copy(tma_y.with(td_y), tYss(_, iwarpgroup, 0),
+                   tYgg(_, itile_m * 2 + iwarpgroup, 0, ihead_q));
+        tma_store_arrive();
+      }
+    }
+  }
+}
+
+// FP8 warp-specialization kernel with paged KV cache and Block-Sparse Attention support,
+// qkpertoken_perhead_vperhead scale layout, dim_qk=128, dim_v=128.
+template <typename Config, typename TmaQ, typename TmaK, typename TmaV, typename TmaY,
+          typename TmaQS, typename TmaKS, bool kHasMask>
+__global__ void __launch_bounds__(384, 1)
+    attention_with_kvcache_blocksparse_qkpertoken_perhead_vperhead_prefill_fp8_warp_specialization_kernel(  // NOLINT(whitespace/line_length)
+        cute::TmaDescriptor *td_qy, const __grid_constant__ TmaK tma_k,
+        const __grid_constant__ TmaV tma_v, const __grid_constant__ TmaQS tma_qs,
+        const __grid_constant__ TmaKS tma_ks, const float *qscale_ptr, const float *kscale_ptr,
+        const float *vscale_ptr, const int *cu_seqlens_q_ptr, const int *seqlens_kvcache_ptr,
+        const int *block_ids_ptr, int num_batch, int max_seq_q, int max_seq_q_pad, int num_dim_qk,
+        int num_dim_v, int num_dim_scale, int num_head_q, int num_head_kv, int num_kvcache_blocks,
+        int num_scale_blocks, int num_seq_max_blocks, float one_over_dk_log2e,
+        cutlass::FastDivmod head_kv_divmod, cutlass::FastDivmod head_q_divmod,
+        cutlass::FastDivmod tile_m_divmod, const uint8_t *block_mask_ptr, int num_tile_kv_in_mask) {
+  using namespace cute;  // NOLINT
+
+  using Tin = typename Config::Tin;
+  using Tout = typename Config::Tout;
+  using TiledMmaQK = typename Config::TiledMmaQK;
+  using TiledMmaPV = typename Config::TiledMmaPV;
+  using SLayoutQ = typename Config::SLayoutQ;
+  using SLayoutK = typename Config::SLayoutK;
+  using SLayoutV = typename Config::SLayoutV;
+  using SLayoutVT = typename Config::SLayoutVT;
+  using SLayoutY = typename Config::SLayoutY;
+  using SLayoutQS = typename Config::SLayoutQS;
+  using SLayoutKS = typename Config::SLayoutKS;
+  using SLayoutKSC = typename Config::SLayoutKSC;
+
+  constexpr int kTileM = Config::kTileM;
+  constexpr int kTileN = Config::kTileN;
+  constexpr int kTileK = Config::kTileK;
+  constexpr int kTileV = Config::kTileV;
+  constexpr int kStage = Config::kStage;
+  constexpr int kBlockSize = Config::kBlockSize;
+  constexpr int kScaleBlockSize = Config::kScaleBlockSize;
+
+  int idx = threadIdx.x;
+  int iblock = blockIdx.x;
+
+  int elected = cute::elect_one_sync();
+  int iwarp = __shfl_sync(0xFFFFFFFF, idx / 32, 0);
+  bool is_leader_in_block = (iwarp == 0) && elected;
+  bool is_leader_in_warpgroup = ((iwarp % 4) == 0) && elected;
+
+  __shared__ uint64_t readable_q;
+  __shared__ uint64_t writable_q;
+  __shared__ uint64_t readable_list;
+  __shared__ uint64_t writable_list;
+  __shared__ uint64_t readable_k[kStage];
+  __shared__ uint64_t writable_k[kStage];
+  __shared__ uint64_t readable_v[kStage];
+  __shared__ uint64_t writable_v[kStage];
+  extern __shared__ uint8_t shm_data[] alignas(128);
+
+  auto *shm_q = reinterpret_cast<Tin *>(shm_data);
+  auto *shm_k = shm_q + cosize(SLayoutQ{});
+  auto *shm_v = shm_k + cosize(SLayoutK{});
+  auto *shm_vt = shm_v + cosize(SLayoutV{});
+  auto *shm_y = reinterpret_cast<Tout *>(shm_vt + cosize(SLayoutVT{}));
+  auto *shm_qs = reinterpret_cast<float *>(shm_y + cosize(SLayoutY{}));
+  auto *shm_ks = reinterpret_cast<float *>(shm_qs + cosize(SLayoutQS{}));
+  auto *shm_seqlens_q = reinterpret_cast<int *>(shm_ks + cosize(SLayoutKSC{}));
+  auto *shm_seqlens_kv = shm_seqlens_q + num_batch;
+  auto *shm_seqlens_qstart = shm_seqlens_kv + num_batch;
+  // Active tile list: [num_tile_active (int)] [tile_indices (int[])]
+  auto *shm_num_active = reinterpret_cast<int *>(shm_seqlens_qstart + num_batch);
+  auto *shm_active_tiles = shm_num_active + 1;
+
+  TmaQ tma_q;
+  TmaY tma_y;
+
+  // Tensor Q/K/V/Y
+  auto gQ = tma_q.get_tma_tensor(make_shape(max_seq_q, num_dim_qk, num_head_q));
+  auto gK =
+      tma_k.get_tma_tensor(make_shape(kBlockSize, num_dim_qk, num_head_kv, num_kvcache_blocks));
+  auto gV =
+      tma_v.get_tma_tensor(make_shape(num_dim_v, kBlockSize, num_head_kv, num_kvcache_blocks));
+  auto gY = tma_y.get_tma_tensor(make_shape(max_seq_q, num_dim_v, num_head_q));
+  auto gQS = tma_qs.get_tma_tensor(make_shape(max_seq_q_pad, num_head_q, num_batch));
+  auto gKS = tma_ks.get_tma_tensor(
+      make_shape(kScaleBlockSize, num_dim_scale, num_head_kv, num_scale_blocks));
+
+  auto gAtt =
+      make_tensor(make_gmem_ptr(static_cast<float *>(nullptr)),
+                  make_shape(Int<kTileM>{}, Int<kTileN>{}), make_stride(Int<kTileN>{}, Int<1>{}));
+  auto gAtt_fp8 =
+      make_tensor(make_gmem_ptr(static_cast<Tin *>(nullptr)),
+                  make_shape(Int<kTileM>{}, Int<kTileN>{}), make_stride(Int<kTileN>{}, Int<1>{}));
+  auto gYY =
+      make_tensor(make_gmem_ptr(static_cast<Tout *>(nullptr)),
+                  make_shape(Int<kTileM>{}, Int<kTileV>{}), make_stride(Int<kTileV>{}, Int<1>{}));
+
+  // Tensor sQ/sK/sV
+  auto sQ = make_tensor(make_smem_ptr(shm_q), SLayoutQ{});
+  auto sK = make_tensor(make_smem_ptr(shm_k), SLayoutK{});
+  auto sV = make_tensor(make_smem_ptr(shm_v), SLayoutV{});
+  auto sVT = make_tensor(make_smem_ptr(shm_vt), SLayoutVT{});
+  auto sY = make_tensor(make_smem_ptr(shm_y), SLayoutY{});
+  auto sQS = make_tensor(make_smem_ptr(shm_qs), SLayoutQS{});
+  auto sKS = make_tensor(make_smem_ptr(shm_ks), SLayoutKS{});
+  auto sKSC = make_tensor(make_smem_ptr(shm_ks), SLayoutKSC{});
+
+  // Block Level tma
+  auto btma_q = tma_q.get_slice(0);
+  auto btma_k = tma_k.get_slice(0);
+  auto btma_v = tma_v.get_slice(0);
+  auto btma_y = tma_y.get_slice(0);
+  auto btma_qs = tma_qs.get_slice(0);
+  auto btma_ks = tma_ks.get_slice(0);
+
+  // Thread Level Tensor
+  auto tQg = btma_q.partition_S(gQ);     // (TMA, TMA_M, TMA_K, head, batch)
+  auto tKg = btma_k.partition_S(gK);     // (TMA, TMA_N, TMA_K, head, batch)
+  auto tVg = btma_v.partition_S(gV);     // (TMA, TMA_V, TMA_N, head, batch)
+  auto tQSg = btma_qs.partition_S(gQS);  // (TMA, TMA_M, head, batch)
+  auto tKSg = btma_ks.partition_S(gKS);  // (TMA, TMA_M, head, batch)
+
+  auto tQs = btma_q.partition_D(sQ);      // (TMA, _1, _1)
+  auto tKs = btma_k.partition_D(sK);      // (TMA, _1, _1, kStage)
+  auto tVs = btma_v.partition_D(sV);      // (TMA, _1, _1, kStage)
+  auto tQSs = btma_qs.partition_D(sQS);   // (TMA, _1)
+  auto tKSs = btma_ks.partition_D(sKSC);  // (TMA, _1)
+
+  TiledMmaQK tiled_mma_qk;
+  TiledMmaPV tiled_mma_pv;
+
+  auto thr_mma_qk = tiled_mma_qk.get_slice(idx);
+  auto thr_mma_pv = tiled_mma_pv.get_slice(idx);
+
+  auto tQs4r = thr_mma_qk.partition_A(sQ);
+  auto tKs4r = thr_mma_qk.partition_B(sK);
+  auto tVTs4r = thr_mma_pv.partition_B(sVT);
+
+  auto tQr = thr_mma_qk.make_fragment_A(tQs4r);    // (MMA, MMA_M, MMA_K)
+  auto tKr = thr_mma_qk.make_fragment_B(tKs4r);    // (MMA, MMA_N, MMA_K)
+  auto tVTr = thr_mma_pv.make_fragment_B(tVTs4r);  // (MMA, MMA_V, MMA_N, kStage)
+
+  auto tAttr = thr_mma_qk.partition_fragment_C(gAtt);
+  auto tYr = thr_mma_pv.partition_fragment_C(gYY);
+
+  // init k/v barrier
+  if (is_leader_in_block) {
+    initialize_barrier(readable_q, 1);
+    initialize_barrier(writable_q, 2);
+    initialize_barrier(readable_list, 32);
+    initialize_barrier(writable_list, 256);
+#pragma unroll
+    for (int i = 0; i < kStage; ++i) {
+      initialize_barrier(readable_k[i], 1);
+      initialize_barrier(writable_k[i], 2);
+      initialize_barrier(readable_v[i], 1);
+      initialize_barrier(writable_v[i], 2);
+    }
+  }
+
+  for (int i = idx; i < num_batch; i += blockDim.x) {
+    int num_seq_ibatch = cu_seqlens_q_ptr[i + 1] - cu_seqlens_q_ptr[i];
+    shm_seqlens_q[i] = num_seq_ibatch;
+    shm_seqlens_kv[i] = seqlens_kvcache_ptr[i];
+    shm_seqlens_qstart[i] = seqlens_kvcache_ptr[i] - num_seq_ibatch;
+  }
+
+  // sync to avoid ahead thread use(wait) readable when it is not initizlized yet
+  __syncthreads();
+
+  int max_num_tile_m = (max_seq_q + kTileM - 1) / kTileM;
+  int max_total_blocks = num_head_q * num_batch * max_num_tile_m;
+
+  constexpr int kNumBlockPerTileN = kTileN / kBlockSize;
+
+  // Producer Warpgroup
+  if (idx >= 256) {
+    cutlass::arch::warpgroup_reg_dealloc<32>();
+    idx -= 256;
+
+    int iwarp = __shfl_sync(0xFFFFFFFF, idx / 32, 0);
+    int idx_in_warp = idx % 32;
+
+    // 32 lanes enter for warp-parallel mask scan; single-thread ops guarded by `if (elected)`.
+    if (iwarp == 0) {
+      int phase = 1;         // start with ok
+      int phase_q = 1;       // start with ok
+      int phase_list_w = 1;  // start with ok
+      int ismem_write = 0;
+
+      while (true) {
+        if (iblock >= max_total_blocks) {
+          break;
+        }
+
+        auto [itile_m, ihead_q, ibatch] =
+            get_next_tile<kTileM>(shm_seqlens_q, iblock, num_head_q, num_batch, max_total_blocks,
+                                  max_num_tile_m, head_q_divmod, tile_m_divmod);
+
+        int num_seq_kv = seqlens_kvcache_ptr[ibatch];
+        int num_seq_q = shm_seqlens_q[ibatch];
+        if (itile_m < 0) {
+          continue;
+        }
+
+        int ihead_kv, res;
+        head_kv_divmod(ihead_kv, res, ihead_q);
+
+        auto *td_q = td_qy + ibatch * 2;
+
+        int start_seq_q = shm_seqlens_qstart[ibatch];
+        auto *block_ids_ibatch_ptr = block_ids_ptr + ibatch * num_seq_max_blocks;
+
+        // Load Q
+        wait_barrier(writable_q, phase_q);
+        if (elected) {
+          cute::copy(tma_q.with(td_q, readable_q), tQg(_, itile_m, _, ihead_q), tQs(_, 0, _));
+          cute::copy(tma_qs.with(readable_q), tQSg(_, itile_m, ihead_q, ibatch), tQSs(_, 0));
+        }
+
+        int num_tile_kv = (start_seq_q + (itile_m + 1) * kTileM + kTileN - 1) / kTileN;
+        int num_blocks = (num_seq_kv + kBlockSize - 1) / kBlockSize;
+        constexpr int kTransactionBytesK = sizeof(Tin) * kTileN * kTileK + sizeof(float) * kTileN;
+        constexpr int kTransactionBytesV = sizeof(Tin) * kTileV * kTileN;
+
+        // Build active tile list in SMEM (parallel with TMA Q in flight)
+        int num_tile_active = num_tile_kv;
+        if constexpr (kHasMask) {
+          wait_barrier(writable_list, phase_list_w);
+          phase_list_w ^= 1;
+
+          int block_mask_offset = ibatch * (num_head_q * max_num_tile_m * num_tile_kv_in_mask) +
+                                  ihead_q * (max_num_tile_m * num_tile_kv_in_mask) +
+                                  itile_m * num_tile_kv_in_mask;
+          int num_tile_with_mask = min(num_tile_kv, num_tile_kv_in_mask);
+
+          // Warp-parallel stream compaction of active tiles into SMEM.
+          num_tile_active = 0;
+#pragma unroll 1
+          for (int base = 0; base < num_tile_with_mask; base += 32) {
+            int i = base + idx_in_warp;
+            bool active = (i < num_tile_with_mask) && (block_mask_ptr[block_mask_offset + i] != 0);
+            uint32_t ballot = __ballot_sync(0xFFFFFFFF, active);
+            // rank within active lanes = popcount of earlier-lane bits in ballot
+            if (active) {
+              shm_active_tiles[num_tile_active + __popc(ballot & ((1u << idx_in_warp) - 1))] = i;
+            }
+            num_tile_active += __popc(ballot);
+          }
+
+          if (num_tile_with_mask < num_tile_kv) {
+            if (elected) {
+              shm_active_tiles[num_tile_active] = num_tile_with_mask;
+            }
+            num_tile_active += 1;
+          }
+
+          __syncwarp();
+
+          if (elected) {
+            *shm_num_active = num_tile_active;
+          }
+          arrive_barrier(readable_list);
+        }
+
+        if (elected) {
+          set_barrier_transaction_bytes(
+              readable_q, sizeof(Tin) * cosize(SLayoutQ{}) + sizeof(float) * cosize(SLayoutQS{}));
+        }
+        phase_q ^= 1;
+
+#pragma unroll 1
+        for (int i_active = 0; i_active < num_tile_active; ++i_active) {
+          int itile_seq_kv;
+          if constexpr (kHasMask) {
+            itile_seq_kv = shm_active_tiles[i_active];
+          } else {
+            itile_seq_kv = i_active;
+          }
+
+          // k
+          wait_barrier(writable_k[ismem_write], phase);
+
+          int iblock_ids[kNumBlockPerTileN];
+#pragma unroll
+          for (int iblock_kv = 0; iblock_kv < kNumBlockPerTileN; iblock_kv++) {
+            iblock_ids[iblock_kv] = -1;
+            int iblock_id = itile_seq_kv * kNumBlockPerTileN + iblock_kv;
+            if (iblock_id < num_blocks) {
+              iblock_ids[iblock_kv] = block_ids_ibatch_ptr[iblock_id];
+            }
+          }
+
+          if (elected) {
+#pragma unroll
+            for (int iblock_kv = 0; iblock_kv < kNumBlockPerTileN; iblock_kv++) {
+              int iblock_true = iblock_ids[iblock_kv];
+              cute::copy(tma_k.with(readable_k[ismem_write]), tKg(_, 0, _, ihead_kv, iblock_true),
+                         tKs(_, iblock_kv, _, ismem_write));
+              cute::copy(tma_ks.with(readable_k[ismem_write]), tKSg(_, 0, _, ihead_kv, iblock_true),
+                         tKSs(_, iblock_kv, _, ismem_write));
+            }
+            set_barrier_transaction_bytes(readable_k[ismem_write], kTransactionBytesK);
+          }
+
+          // v
+          wait_barrier(writable_v[ismem_write], phase);
+          if (elected) {
+#pragma unroll
+            for (int iblock_kv = 0; iblock_kv < kNumBlockPerTileN; iblock_kv++) {
+              int iblock_true = iblock_ids[iblock_kv];
+              cute::copy(tma_v.with(readable_v[ismem_write]), tVg(_, _, 0, ihead_kv, iblock_true),
+                         tVs(_, _, iblock_kv, ismem_write));
+            }
+            set_barrier_transaction_bytes(readable_v[ismem_write], kTransactionBytesV);
+          }
+
+          ++ismem_write;
+          if (ismem_write == kStage) {
+            ismem_write = 0;
+            phase ^= 1;
+          }
+        }
+        __syncwarp();
+      }
+    }
+  } else {  // Consumer Warpgroup
+    cutlass::arch::warpgroup_reg_alloc<224>();
+
+    int idx_in_warpgroup = idx % 128;
+    int idx_in_warp = idx % 32;
+    int iwarpgroup = idx / 128;
+    int iwarp_in_warpgroup = idx_in_warpgroup / 32;
+    int elected_idx_in_warpgroup = ((iwarp_in_warpgroup == 0) && elected);
+
+    auto tAttr_fp8 = make_tensor_like<Tin>(tAttr);
+    auto layout_asA = thr_mma_pv.partition_fragment_A(gAtt_fp8).layout();
+    auto tAttA_fp8 = make_tensor(tAttr_fp8.data(), layout_asA);
+
+    auto gI = make_identity_tensor(gAtt.shape());
+    auto tI = thr_mma_qk.partition_C(gI);
+
+    auto tAttr_mn = retile_fragment(tAttr);
+    constexpr int kM = size<0>(tAttr_mn);
+    constexpr int kN = size<1>(tAttr_mn);
+    Tensor gMax = make_tensor<float>(Int<kM>{});
+    Tensor gSum = make_tensor<float>(Int<kM>{});
+
+    constexpr int kTileTransV = 32;
+    constexpr int kTileTransN = 16;
+    auto sV_tile =
+        local_tile(sV, make_tile(Int<kTileTransV>{}, Int<kTileTransN>{}), make_coord(_, _, _));
+    auto sVT_tile =
+        local_tile(sVT, make_tile(Int<kTileTransV>{}, Int<kTileTransN>{}), make_coord(_, _, _));
+
+    tiled_mma_pv.accumulate_ = GMMA::ScaleOut::One;
+
+    int ismem_read = 0;
+    int phase = 0;
+    int phase_q = 0;
+    int phase_list = 0;
+
+    float tQS[kM];
+    float tKS[kN];
+
+    while (true) {
+      if (iblock >= max_total_blocks) {
+        break;
+      }
+
+      auto [itile_m, ihead_q, ibatch] =
+          get_next_tile<kTileM>(shm_seqlens_q, iblock, num_head_q, num_batch, max_total_blocks,
+                                max_num_tile_m, head_q_divmod, tile_m_divmod);
+
+      if (itile_m < 0) {
+        continue;
+      }
+
+      int num_seq_kv = shm_seqlens_kv[ibatch];
+      int start_seq_q = shm_seqlens_qstart[ibatch];
+
+      int ihead_kv, res;
+      head_kv_divmod(ihead_kv, res, ihead_q);
+      int num_tile_kv = (start_seq_q + (itile_m + 1) * kTileM + kTileN - 1) / kTileN;
+      int num_tile_full = (start_seq_q + itile_m * kTileM) / kTileN;
+
+      float vscale = vscale_ptr[ihead_kv];
+
+      clear(tYr);
+      clear(gSum);
+      fill(gMax, -std::numeric_limits<float>::infinity());
+
+      wait_barrier(readable_q, phase_q);
+
+      int num_tile_active;
+      if constexpr (kHasMask) {
+        wait_barrier(readable_list, phase_list);
+        phase_list ^= 1;
+        num_tile_active = *shm_num_active;
+      } else {
+        num_tile_active = num_tile_kv;
+      }
+
+      auto tI_mn = retile_fragment(tI);
+#pragma unroll
+      for (int im = 0; im < kM; im++) {
+        tQS[im] = sQS(get<0>(tI_mn(im, 0)));
+      }
+
+#pragma unroll 1
+      for (int i_active = 0; i_active < num_tile_active; ++i_active) {
+        int itile_seq_kv;
+        if constexpr (kHasMask) {
+          itile_seq_kv = shm_active_tiles[i_active];
+        } else {
+          itile_seq_kv = i_active;
+        }
+
+        wait_barrier(readable_k[ismem_read], phase);
+
+#pragma unroll
+        for (int ins = 0; ins < kN; ins++) {
+          tKS[ins] = sKS(get<1>(tI_mn(0, ins)), ismem_read);
+        }
+
+        // P = QK
+        tiled_mma_qk.accumulate_ = GMMA::ScaleOut::Zero;
+
+        warpgroup_fence_operand(tAttr);
+        warpgroup_arrive();
+#pragma unroll
+        for (int ik = 0; ik < size<2>(tQr); ++ik) {
+          cute::gemm(tiled_mma_qk, tQr(_, _, ik), tKr(_, _, ik, ismem_read), tAttr(_, _, _));
+          tiled_mma_qk.accumulate_ = GMMA::ScaleOut::One;
+        }
+
+        warpgroup_commit_batch();
+        warpgroup_wait<0>();
+        warpgroup_fence_operand(tAttr);
+
+        if (elected_idx_in_warpgroup) {
+          arrive_barrier(writable_k[ismem_read]);
+        }
+
+        if (i_active == (num_tile_active - 1)) {
+          if (elected_idx_in_warpgroup) {
+            arrive_barrier(writable_q);
+          }
+          phase_q ^= 1;
+          if constexpr (kHasMask) {
+            arrive_barrier(writable_list);
+          }
+        }
+
+        if (itile_seq_kv >= num_tile_full) {
+#pragma unroll
+          for (int im = 0; im < kM; ++im) {
+#pragma unroll
+            for (int in = 0; in < kN; ++in) {
+              int irow = start_seq_q + itile_m * kTileM + get<0>(tI_mn(im, in));
+              int icol = itile_seq_kv * kTileN + get<1>(tI_mn(im, in));
+
+              if ((icol > irow) || (icol >= num_seq_kv)) {
+                tAttr_mn(im, in) = -std::numeric_limits<float>::infinity();
+              } else {
+                tAttr_mn(im, in) *= tQS[im] * tKS[in];
+              }
+            }
+          }
+        } else {
+#pragma unroll
+          for (int im = 0; im < kM; ++im) {
+#pragma unroll
+            for (int in = 0; in < kN; ++in) {
+              tAttr_mn(im, in) *= tQS[im] * tKS[in];
+            }
+          }
+        }
+
+        auto tYr_mn = retile_fragment(tYr);
+        // online softmax
+        online_softmax(tAttr_mn, gMax, gSum, tYr_mn, kM, kN, one_over_dk_log2e);
+
+        // Scale P before FP8 quantization; epilogue applies the reciprocal.
+#pragma unroll
+        for (int i = 0; i < size(tAttr); ++i) {
+          tAttr(i) *= kFp8PrefillPScale;
+        }
+
+        // convert P to fp8 and permute for pv gemm
+        auto tAttr_float32x4 = recast<float4>(tAttr);
+        auto tAttr_fp8x4 = recast<__nv_fp8x4_e4m3>(tAttr_fp8);
+
+#pragma unroll
+        for (int i = 0; i < size(tAttr_float32x4); i++) {
+          tAttr_fp8x4(i) = __nv_fp8x4_e4m3(tAttr_float32x4(i));
+        }
+
+        auto tAttr_fp8_u64 = recast<uint2>(tAttr_fp8);
+#pragma unroll
+        for (int i = 0; i < size(tAttr_fp8_u64); i++) {
+          uint32_t upper = tAttr_fp8_u64(i).x;
+          uint32_t lower = tAttr_fp8_u64(i).y;
+          tAttr_fp8_u64(i).x = __byte_perm(upper, lower, 0x5410);
+          tAttr_fp8_u64(i).y = __byte_perm(upper, lower, 0x7632);
+        }
+
+        // Y = PV
+        wait_barrier(readable_v[ismem_read], phase);
+
+        constexpr int kNumTilePerWarp = 32 / kTileTransN;
+
+        warpgroup_fence_operand(tYr);
+#pragma unroll
+        for (int in = 0; in < size<2>(tVTr); in++) {
+#pragma unroll
+          for (int iin = 0; iin < kNumTilePerWarp; iin++) {
+            smem_trans_and_interleave0189_nm_nm(
+                sV_tile(_, _, iwarp_in_warpgroup, in * kNumTilePerWarp + iin, ismem_read),
+                sVT_tile(_, _, iwarp_in_warpgroup, in * kNumTilePerWarp + iin,
+                         iwarpgroup * kStage + ismem_read),
+                idx_in_warp);
+          }
+          cutlass::arch::fence_view_async_shared();
+
+          warpgroup_arrive();
+          cute::gemm(tiled_mma_pv, tAttA_fp8(_, _, in),
+                     tVTr(_, _, in, iwarpgroup * kStage + ismem_read), tYr);
+          warpgroup_commit_batch();
+        }
+
+        warpgroup_wait<0>();
+
+        if (elected_idx_in_warpgroup) {
+          arrive_barrier(writable_v[ismem_read]);
+        }
+
+        ++ismem_read;
+        if (ismem_read == kStage) {
+          phase ^= 1;
+          ismem_read = 0;
+        }
+      }
+
+      // Release Q barrier to prevent deadlock if violated.
+      if (num_tile_active == 0) {
+        if (elected_idx_in_warpgroup) {
+          arrive_barrier(writable_q);
+        }
+        phase_q ^= 1;
+      }
+
+      auto tYr_mn = retile_fragment(tYr);
+      // final online softmax
+      final_online_softmax(tYr_mn, gSum, kM);
+
+      // to bfloat16
+      auto tYr_bf16 = make_tensor_like<Tout>(tYr);
+
+      float vscale_eff = vscale * kFp8PrefillPScaleInv;
+#pragma unroll
+      for (int i = 0; i < size(tYr); ++i) {
+        tYr_bf16(i) = Tout(tYr(i) * vscale_eff);
       }
 
       // Epilogue: write register-C to global memory
@@ -1699,7 +3362,7 @@ __global__ void attention_prefill_bf16_multi_stage_kernel(cute::TmaDescriptor *t
     auto tAttAbf16 = make_tensor_like<cute::bfloat16_t>(tAttA);
 #pragma unroll
     for (int i = 0; i < size(tAttA); ++i) {
-      tAttAbf16(i) = (cute::bfloat16_t)(tAttA(i));
+      tAttAbf16(i) = static_cast<cute::bfloat16_t>(tAttA(i));
     }
 
     wait_barrier(bar_v[ismem_read], phase);
@@ -2038,7 +3701,7 @@ __global__ void attention_with_kvcache_prefill_bf16_multi_stage_kernel(
     auto tAttAbf16 = make_tensor_like<cute::bfloat16_t>(tAttA);
 #pragma unroll
     for (int i = 0; i < size(tAttA); ++i) {
-      tAttAbf16(i) = (cute::bfloat16_t)(tAttA(i));
+      tAttAbf16(i) = static_cast<cute::bfloat16_t>(tAttA(i));
     }
 
     wait_barrier(bar_v[ismem_read], phase);
@@ -2095,7 +3758,6 @@ __global__ void attention_with_kvcache_prefill_bf16_multi_stage_kernel(
     cute::copy(tma_y.with(td_y), tYss(_, 0, 0), tYgg(_, itile_m, 0, ihead_q));
   }
 }
-
 }  // namespace kernels
 }  // namespace attention
 }  // namespace hpc

--- a/src/attention/prefill/multi_stage_dim128.cu
+++ b/src/attention/prefill/multi_stage_dim128.cu
@@ -59,11 +59,12 @@ void multi_stage_dim128_async(void *y_ptr, const void *q_ptr, const void *k_ptr,
         *tma_v.get_tma_descriptor(),
         *tma_y.get_tma_descriptor(),
     };
-    kernels::update_batched_tma<Tin, decltype(tma_q), decltype(tma_k), decltype(tma_v),
+    kernels::update_batched_tma<Tin, Tout, decltype(tma_q), decltype(tma_k), decltype(tma_v),
                                 decltype(tma_y)><<<num_batch, 32, 0, stream>>>(
         td_qkvy, tma_qkvy, (const Tin *)q_ptr, (const Tin *)k_ptr, (const Tin *)v_ptr,
-        (const Tout *)y_ptr, (const int *)seqlens_q_ptr, (const int *)cu_seqlens_q_ptr, num_batch,
-        max_seq_q, num_dim_qk, num_dim_v, num_head_q, num_head_kv, ldQ, ldK, ldV, ldY);
+        (const Tout *)y_ptr, (const int *)seqlens_q_ptr, (const int *)cu_seqlens_q_ptr,
+        (const int *)nullptr, num_batch, num_dim_qk, num_dim_v, num_head_q, num_head_kv, ldQ, ldK,
+        ldV, ldY);
   }
 
   // 1. compute attention

--- a/src/attention/prefill/multi_stage_with_kvcache_dim128.cu
+++ b/src/attention/prefill/multi_stage_with_kvcache_dim128.cu
@@ -22,7 +22,8 @@ void launch_multi_stage_with_kvcache_dim128(
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
     void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int num_dim_qk, int num_dim_v,
     int num_head_q, int num_head_kv, int num_kvcache_blocks, int block_size, int num_seq_max_blocks,
-    int ldY, int ldQ, int ldK, int ldV, cudaStream_t stream) {
+    int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV, int ldV1, int ldV2,
+    cudaStream_t stream) {
   using namespace cute;  // NOLINT
 
   using Tin = cute::bfloat16_t;
@@ -33,10 +34,10 @@ void launch_multi_stage_with_kvcache_dim128(
                        make_stride(ldQ, Int<1>{}, num_dim_qk));
   auto K = make_tensor(make_gmem_ptr(reinterpret_cast<const Tin *>(kcache_ptr)),
                        make_shape(kBlockSize, num_dim_qk, num_head_kv, num_kvcache_blocks),
-                       make_stride(num_dim_qk * num_head_kv, Int<1>{}, num_dim_qk, ldK));
+                       make_stride(ldK1, Int<1>{}, ldK2, ldK));
   auto V = make_tensor(make_gmem_ptr(reinterpret_cast<const Tin *>(vcache_ptr)),
                        make_shape(num_dim_v, kBlockSize, num_head_kv, num_kvcache_blocks),
-                       make_stride(Int<1>{}, num_head_kv * num_dim_v, num_dim_v, ldV));
+                       make_stride(Int<1>{}, ldV1, ldV2, ldV));
   auto Y = make_tensor(make_gmem_ptr(reinterpret_cast<const Tout *>(y_ptr)),
                        make_shape(max_seq_q, num_dim_v, num_head_q),
                        make_stride(ldY, Int<1>{}, num_dim_v));
@@ -90,19 +91,22 @@ void multi_stage_with_kvcache_dim128_async(
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
     void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int num_dim_qk, int num_dim_v,
     int num_head_q, int num_head_kv, int num_kvcache_blocks, int block_size, int num_seq_max_blocks,
-    int ldY, int ldQ, int ldK, int ldV, cudaStream_t stream) {
+    int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV, int ldV1, int ldV2,
+    cudaStream_t stream) {
   if (block_size == 32) {
     constexpr int kBlockSize = 32;
     launch_multi_stage_with_kvcache_dim128<kBlockSize>(
         y_ptr, q_ptr, kcache_ptr, vcache_ptr, cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr,
         tmas_ptr, num_batch, total_seq_q, max_seq_q, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
-        num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldV, stream);
+        num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1,
+        ldV2, stream);
   } else if (block_size == 64) {
     constexpr int kBlockSize = 64;
     launch_multi_stage_with_kvcache_dim128<kBlockSize>(
         y_ptr, q_ptr, kcache_ptr, vcache_ptr, cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr,
         tmas_ptr, num_batch, total_seq_q, max_seq_q, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
-        num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldV, stream);
+        num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1,
+        ldV2, stream);
   }
 }
 

--- a/src/attention/prefill/multi_stage_with_kvcache_dim128.h
+++ b/src/attention/prefill/multi_stage_with_kvcache_dim128.h
@@ -15,7 +15,8 @@ void multi_stage_with_kvcache_dim128_async(
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
     void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int num_dim_qk, int num_dim_v,
     int num_head_q, int num_head_kv, int num_kvcache_blocks, int block_size, int num_seq_max_blocks,
-    int ldY, int ldQ, int ldK, int ldV, cudaStream_t stream);
+    int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV, int ldV1, int ldV2,
+    cudaStream_t stream);
 
 }  // namespace prefill
 }  // namespace attention

--- a/src/attention/prefill/prefill.cc
+++ b/src/attention/prefill/prefill.cc
@@ -9,6 +9,7 @@
 #include "src/attention/prefill/multi_stage_dim128.h"
 #include "src/attention/prefill/multi_stage_with_kvcache_dim128.h"
 #include "src/attention/prefill/warp_spec_dim128.h"
+#include "src/attention/prefill/warp_spec_with_kvcache_blocksparse_fp8_dim128.h"
 #include "src/attention/prefill/warp_spec_with_kvcache_dim128.h"
 #include "src/attention/prefill/warp_spec_with_kvcache_fp8_dim128.h"
 #include "src/utils/utils.h"
@@ -46,7 +47,8 @@ void attention_with_kvcache_prefill_bf16_async(
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
     void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int num_dim_qk, int num_dim_v,
     int num_head_q, int num_head_kv, int num_kvcache_blocks, int block_size, int num_seq_max_blocks,
-    int ldY, int ldQ, int ldK, int ldV, cudaStream_t stream) {
+    int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV, int ldV1, int ldV2,
+    cudaStream_t stream) {
   constexpr int kTileM = 64;
   int max_total_blocks = (max_seq_q + kTileM - 1) / kTileM * num_batch * num_head_q;
   if (max_total_blocks < get_sm_count() * 2) {
@@ -55,7 +57,7 @@ void attention_with_kvcache_prefill_bf16_async(
           y_ptr, q_ptr, kcache_ptr, vcache_ptr, cu_seqlens_q_ptr, block_ids_ptr,
           seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seq_q, num_dim_qk, num_dim_v,
           num_head_q, num_head_kv, num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ,
-          ldK, ldV, stream);
+          ldK, ldK1, ldK2, ldV, ldV1, ldV2, stream);
     }
   } else {
     if (num_dim_qk == 128 && num_dim_v == 128) {
@@ -63,24 +65,74 @@ void attention_with_kvcache_prefill_bf16_async(
           y_ptr, q_ptr, kcache_ptr, vcache_ptr, cu_seqlens_q_ptr, block_ids_ptr,
           seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seq_q, num_dim_qk, num_dim_v,
           num_head_q, num_head_kv, num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ,
-          ldK, ldV, stream);
+          ldK, ldK1, ldK2, ldV, ldV1, ldV2, stream);
     }
   }
 }
 
-void attention_with_kvcache_prefill_fp8_async(
+void attention_with_kvcache_prefill_qpertoken_perhead_kvpertensor_fp8_async(
     void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
     const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
     void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int max_seq_q_pad,
     int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
-    int block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK, int ldV,
-    cudaStream_t stream) {
-  prefill::warp_spec_with_kvcache_fp8_dim128_async(
+    int block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV,
+    int ldV1, int ldV2, cudaStream_t stream) {
+  prefill::warp_spec_with_kvcache_qpertoken_perhead_kvpertensor_fp8_dim128_async(
       y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
       block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seq_q,
       max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks, block_size,
-      num_seq_max_blocks, ldY, ldQ, ldK, ldV, stream);
+      num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1, ldV2, stream);
+}
+
+void attention_with_kvcache_prefill_qkpertoken_perhead_vperhead_fp8_async(
+    void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
+    const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
+    const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
+    void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int max_seq_q_pad,
+    int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
+    int block_size, int scale_block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK,
+    int ldK1, int ldK2, int ldV, int ldV1, int ldV2, int ldKS, int ldKS1, int ldKS2,
+    cudaStream_t stream) {
+  prefill::warp_spec_with_kvcache_qkpertoken_perhead_vperhead_fp8_dim128_async(
+      y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
+      block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seq_q,
+      max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks, block_size,
+      scale_block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1, ldV2, ldKS, ldKS1,
+      ldKS2, stream);
+}
+
+void attention_with_kvcache_blocksparse_prefill_qpertoken_perhead_kvpertensor_fp8_async(
+    void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
+    const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
+    const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
+    void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int max_seq_q_pad,
+    int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
+    int block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV,
+    int ldV1, int ldV2, const void *block_mask_ptr, int num_tile_kv_in_mask, cudaStream_t stream) {
+  prefill::warp_spec_with_kvcache_blocksparse_qpertoken_perhead_kvpertensor_fp8_dim128_async(
+      y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
+      block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seq_q,
+      max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks, block_size,
+      num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1, ldV2, block_mask_ptr,
+      num_tile_kv_in_mask, stream);
+}
+
+void attention_with_kvcache_blocksparse_prefill_qkpertoken_perhead_vperhead_fp8_async(
+    void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
+    const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
+    const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
+    void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int max_seq_q_pad,
+    int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
+    int block_size, int scale_block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK,
+    int ldK1, int ldK2, int ldV, int ldV1, int ldV2, int ldKS, int ldKS1, int ldKS2,
+    const void *block_mask_ptr, int num_tile_kv_in_mask, cudaStream_t stream) {
+  prefill::warp_spec_with_kvcache_blocksparse_qkpertoken_perhead_vperhead_fp8_dim128_async(
+      y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
+      block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seq_q,
+      max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks, block_size,
+      scale_block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1, ldV2, ldKS, ldKS1,
+      ldKS2, block_mask_ptr, num_tile_kv_in_mask, stream);
 }
 
 }  // namespace attention

--- a/src/attention/prefill/prefill.h
+++ b/src/attention/prefill/prefill.h
@@ -21,16 +21,46 @@ void attention_with_kvcache_prefill_bf16_async(
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *num_seq_kvcache_ptr,
     void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int num_dim_qk, int num_dim_v,
     int num_head_q, int num_head_kv, int num_kvcache_blocks, int block_size, int num_seq_max_blocks,
-    int ldY, int ldQ, int ldK, int ldV, cudaStream_t stream);
+    int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV, int ldV1, int ldV2,
+    cudaStream_t stream);
 
-void attention_with_kvcache_prefill_fp8_async(
+void attention_with_kvcache_prefill_qpertoken_perhead_kvpertensor_fp8_async(
     void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
     const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
     void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int max_seq_q_pad,
     int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
-    int block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK, int ldV,
+    int block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV,
+    int ldV1, int ldV2, cudaStream_t stream);
+
+void attention_with_kvcache_prefill_qkpertoken_perhead_vperhead_fp8_async(
+    void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
+    const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
+    const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
+    void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int max_seq_q_pad,
+    int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
+    int block_size, int scale_block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK,
+    int ldK1, int ldK2, int ldV, int ldV1, int ldV2, int ldKS, int ldKS1, int ldKS2,
     cudaStream_t stream);
+
+void attention_with_kvcache_blocksparse_prefill_qpertoken_perhead_kvpertensor_fp8_async(
+    void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
+    const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
+    const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
+    void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int max_seq_q_pad,
+    int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
+    int block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV,
+    int ldV1, int ldV2, const void *block_mask_ptr, int num_tile_kv_in_mask, cudaStream_t stream);
+
+void attention_with_kvcache_blocksparse_prefill_qkpertoken_perhead_vperhead_fp8_async(
+    void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
+    const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
+    const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
+    void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int max_seq_q_pad,
+    int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
+    int block_size, int scale_block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK,
+    int ldK1, int ldK2, int ldV, int ldV1, int ldV2, int ldKS, int ldKS1, int ldKS2,
+    const void *block_mask_ptr, int num_tile_kv_in_mask, cudaStream_t stream);
 
 }  // namespace attention
 }  // namespace hpc

--- a/src/attention/prefill/warp_spec_dim128.cu
+++ b/src/attention/prefill/warp_spec_dim128.cu
@@ -59,11 +59,12 @@ void warp_spec_dim128_async(void *y_ptr, const void *q_ptr, const void *k_ptr, c
         *tma_v.get_tma_descriptor(),
         *tma_y.get_tma_descriptor(),
     };
-    kernels::update_batched_tma<Tin, decltype(tma_q), decltype(tma_k), decltype(tma_v),
+    kernels::update_batched_tma<Tin, Tout, decltype(tma_q), decltype(tma_k), decltype(tma_v),
                                 decltype(tma_y)><<<num_batch, 32, 0, stream>>>(
         td_qkvy, tma_qkvy, (const Tin *)q_ptr, (const Tin *)k_ptr, (const Tin *)v_ptr,
-        (const Tout *)y_ptr, (const int *)seqlens_q_ptr, (const int *)cu_seqlens_q_ptr, num_batch,
-        max_seq_q, num_dim_qk, num_dim_v, num_head_q, num_head_kv, ldQ, ldK, ldV, ldY);
+        (const Tout *)y_ptr, (const int *)seqlens_q_ptr, (const int *)cu_seqlens_q_ptr,
+        (const int *)nullptr, num_batch, num_dim_qk, num_dim_v, num_head_q, num_head_kv, ldQ, ldK,
+        ldV, ldY);
   }
 
   // 1. compute attention

--- a/src/attention/prefill/warp_spec_with_kvcache_blocksparse_fp8_dim128.cu
+++ b/src/attention/prefill/warp_spec_with_kvcache_blocksparse_fp8_dim128.cu
@@ -8,7 +8,7 @@
 #include "cute/tensor.hpp"
 #include "src/attention/prefill/config.h"
 #include "src/attention/prefill/kernels.cuh"
-#include "src/attention/prefill/warp_spec_with_kvcache_fp8_dim128.h"
+#include "src/attention/prefill/warp_spec_with_kvcache_blocksparse_fp8_dim128.h"
 #include "src/utils/tma.cuh"
 #include "src/utils/utils.cuh"
 
@@ -16,15 +16,15 @@ namespace hpc {
 namespace attention {
 namespace prefill {
 
-template <int kBlockSize>
-void launch_warp_spec_with_kvcache_qpertoken_perhead_kvpertensor_fp8_dim128(
+template <int kBlockSize, bool kHasMask>
+void launch_warp_spec_with_kvcache_blocksparse_qpertoken_perhead_kvpertensor_fp8_dim128(
     void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
     const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
     void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int max_seq_q_pad,
     int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
     int block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV,
-    int ldV1, int ldV2, cudaStream_t stream) {
+    int ldV1, int ldV2, const void *block_mask_ptr, int num_tile_kv_in_mask, cudaStream_t stream) {
   using namespace cute;  // NOLINT
 
   using Tin = cute::float_e4m3_t;
@@ -71,7 +71,7 @@ void launch_warp_spec_with_kvcache_qpertoken_perhead_kvpertensor_fp8_dim128(
                                        num_dim_qk, num_dim_v, num_head_q, ldQ, ldY);
   }
 
-  // 1. compute attention
+  // 1. compute block-sparse attention
   {
     int kv_group = num_head_q / num_head_kv;
     cutlass::FastDivmod head_kv_divmod(kv_group);
@@ -80,25 +80,29 @@ void launch_warp_spec_with_kvcache_qpertoken_perhead_kvpertensor_fp8_dim128(
 
     int shm_size = config.get_shm_size();
     shm_size += sizeof(int) * num_batch * 3;
+    if constexpr (kHasMask) {
+      shm_size += (num_tile_kv_in_mask + 2) * sizeof(int);
+      shm_size = (shm_size + 15) & ~15;
+    }
 
     dim3 block(384);
     dim3 grid(get_sm_count());
     auto kernel = kernels::
-        attention_with_kvcache_qpertoken_perhead_kvpertensor_prefill_fp8_warp_specialization_kernel<
+        attention_with_kvcache_blocksparse_qpertoken_perhead_kvpertensor_prefill_fp8_warp_specialization_kernel<  // NOLINT
             decltype(config), decltype(tma_q), decltype(tma_k), decltype(tma_v), decltype(tma_y),
-            decltype(tma_qs)>;
+            decltype(tma_qs), kHasMask>;
     cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shm_size);
     kernel<<<grid, block, shm_size, stream>>>(
-        tma_qy, tma_k, tma_v, tma_qs, (const float *)qscale_ptr, (const float *)kscale_ptr,
-        (const float *)vscale_ptr, (const int *)cu_seqlens_q_ptr, (const int *)seqlens_kvcache_ptr,
-        (const int *)block_ids_ptr, num_batch, max_seq_q, max_seq_q_pad, num_dim_qk, num_dim_v,
-        num_head_q, num_head_kv, num_kvcache_blocks, block_size, num_seq_max_blocks,
-        one_over_dk_log2e, head_kv_divmod, head_q_divmod, tile_m_divmod);
+        tma_qy, tma_k, tma_v, tma_qs, (const float *)kscale_ptr, (const float *)vscale_ptr,
+        (const int *)cu_seqlens_q_ptr, (const int *)seqlens_kvcache_ptr, (const int *)block_ids_ptr,
+        num_batch, max_seq_q, max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
+        num_kvcache_blocks, num_seq_max_blocks, one_over_dk_log2e, head_kv_divmod, head_q_divmod,
+        tile_m_divmod, (const uint8_t *)block_mask_ptr, num_tile_kv_in_mask);
   }
 }
 
-template <int kBlockSize>
-void launch_warp_spec_with_kvcache_qkpertoken_perhead_vperhead_fp8_dim128(
+template <int kBlockSize, bool kHasMask>
+void launch_warp_spec_with_kvcache_blocksparse_qkpertoken_perhead_vperhead_fp8_dim128(
     void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
     const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
@@ -106,7 +110,7 @@ void launch_warp_spec_with_kvcache_qkpertoken_perhead_vperhead_fp8_dim128(
     int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
     int block_size, int scale_block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK,
     int ldK1, int ldK2, int ldV, int ldV1, int ldV2, int ldKS, int ldKS1, int ldKS2,
-    cudaStream_t stream) {
+    const void *block_mask_ptr, int num_tile_kv_in_mask, cudaStream_t stream) {
   using namespace cute;  // NOLINT
 
   using Tin = cute::float_e4m3_t;
@@ -167,7 +171,7 @@ void launch_warp_spec_with_kvcache_qkpertoken_perhead_vperhead_fp8_dim128(
                                        num_dim_qk, num_dim_v, num_head_q, ldQ, ldY);
   }
 
-  // 1. compute attention
+  // 1. compute block-sparse attention
   {
     int kv_group = num_head_q / num_head_kv;
     cutlass::FastDivmod head_kv_divmod(kv_group);
@@ -176,49 +180,79 @@ void launch_warp_spec_with_kvcache_qkpertoken_perhead_vperhead_fp8_dim128(
 
     int shm_size = config.get_shm_size();
     shm_size += sizeof(int) * num_batch * 3;
+    if constexpr (kHasMask) {
+      shm_size += (num_tile_kv_in_mask + 2) * sizeof(int);
+      shm_size = (shm_size + 15) & ~15;
+    }
 
     dim3 block(384);
     dim3 grid(get_sm_count());
     auto kernel = kernels::
-        attention_with_kvcache_qkpertoken_perhead_vperhead_prefill_fp8_warp_specialization_kernel<
+        attention_with_kvcache_blocksparse_qkpertoken_perhead_vperhead_prefill_fp8_warp_specialization_kernel<  // NOLINT(whitespace/line_length)
             decltype(config), decltype(tma_q), decltype(tma_k), decltype(tma_v), decltype(tma_y),
-            decltype(tma_qs), decltype(tma_ks)>;
+            decltype(tma_qs), decltype(tma_ks), kHasMask>;
     cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shm_size);
     kernel<<<grid, block, shm_size, stream>>>(
         tma_qy, tma_k, tma_v, tma_qs, tma_ks, (const float *)qscale_ptr, (const float *)kscale_ptr,
         (const float *)vscale_ptr, (const int *)cu_seqlens_q_ptr, (const int *)seqlens_kvcache_ptr,
         (const int *)block_ids_ptr, num_batch, max_seq_q, max_seq_q_pad, num_dim_qk, num_dim_v,
-        num_dim_scale, num_head_q, num_head_kv, num_kvcache_blocks, num_scale_blocks, block_size,
-        num_seq_max_blocks, one_over_dk_log2e, head_kv_divmod, head_q_divmod, tile_m_divmod);
+        num_dim_scale, num_head_q, num_head_kv, num_kvcache_blocks, num_scale_blocks,
+        num_seq_max_blocks, one_over_dk_log2e, head_kv_divmod, head_q_divmod, tile_m_divmod,
+        (const uint8_t *)block_mask_ptr, num_tile_kv_in_mask);
   }
 }
 
-void warp_spec_with_kvcache_qpertoken_perhead_kvpertensor_fp8_dim128_async(
+void warp_spec_with_kvcache_blocksparse_qpertoken_perhead_kvpertensor_fp8_dim128_async(
     void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
     const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
     void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int max_seq_q_pad,
     int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
     int block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV,
-    int ldV1, int ldV2, cudaStream_t stream) {
+    int ldV1, int ldV2, const void *block_mask_ptr, int num_tile_kv_in_mask, cudaStream_t stream) {
+  bool has_mask = block_mask_ptr != nullptr;
   if (block_size == 32) {
     constexpr int kBlockSize = 32;
-    launch_warp_spec_with_kvcache_qpertoken_perhead_kvpertensor_fp8_dim128<kBlockSize>(
-        y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
-        block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seq_q,
-        max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks,
-        block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1, ldV2, stream);
+    if (has_mask) {
+      launch_warp_spec_with_kvcache_blocksparse_qpertoken_perhead_kvpertensor_fp8_dim128<kBlockSize,
+                                                                                         true>(
+          y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr,
+          cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q,
+          max_seq_q, max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
+          num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1,
+          ldV2, block_mask_ptr, num_tile_kv_in_mask, stream);
+    } else {
+      launch_warp_spec_with_kvcache_blocksparse_qpertoken_perhead_kvpertensor_fp8_dim128<kBlockSize,
+                                                                                         false>(
+          y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr,
+          cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q,
+          max_seq_q, max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
+          num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1,
+          ldV2, nullptr, 0, stream);
+    }
   } else if (block_size == 64) {
     constexpr int kBlockSize = 64;
-    launch_warp_spec_with_kvcache_qpertoken_perhead_kvpertensor_fp8_dim128<kBlockSize>(
-        y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
-        block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seq_q,
-        max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks,
-        block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1, ldV2, stream);
+    if (has_mask) {
+      launch_warp_spec_with_kvcache_blocksparse_qpertoken_perhead_kvpertensor_fp8_dim128<kBlockSize,
+                                                                                         true>(
+          y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr,
+          cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q,
+          max_seq_q, max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
+          num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1,
+          ldV2, block_mask_ptr, num_tile_kv_in_mask, stream);
+    } else {
+      launch_warp_spec_with_kvcache_blocksparse_qpertoken_perhead_kvpertensor_fp8_dim128<kBlockSize,
+                                                                                         false>(
+          y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr,
+          cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q,
+          max_seq_q, max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
+          num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1,
+          ldV2, nullptr, 0, stream);
+    }
   }
 }
 
-void warp_spec_with_kvcache_qkpertoken_perhead_vperhead_fp8_dim128_async(
+void warp_spec_with_kvcache_blocksparse_qkpertoken_perhead_vperhead_fp8_dim128_async(
     void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
     const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
@@ -226,23 +260,46 @@ void warp_spec_with_kvcache_qkpertoken_perhead_vperhead_fp8_dim128_async(
     int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
     int block_size, int scale_block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK,
     int ldK1, int ldK2, int ldV, int ldV1, int ldV2, int ldKS, int ldKS1, int ldKS2,
-    cudaStream_t stream) {
+    const void *block_mask_ptr, int num_tile_kv_in_mask, cudaStream_t stream) {
+  bool has_mask = block_mask_ptr != nullptr;
   if (block_size == 32) {
     constexpr int kBlockSize = 32;
-    launch_warp_spec_with_kvcache_qkpertoken_perhead_vperhead_fp8_dim128<kBlockSize>(
-        y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
-        block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seq_q,
-        max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks,
-        block_size, scale_block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1,
-        ldV2, ldKS, ldKS1, ldKS2, stream);
+    if (has_mask) {
+      launch_warp_spec_with_kvcache_blocksparse_qkpertoken_perhead_vperhead_fp8_dim128<kBlockSize,
+                                                                                       true>(
+          y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr,
+          cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q,
+          max_seq_q, max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
+          num_kvcache_blocks, block_size, scale_block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1,
+          ldK2, ldV, ldV1, ldV2, ldKS, ldKS1, ldKS2, block_mask_ptr, num_tile_kv_in_mask, stream);
+    } else {
+      launch_warp_spec_with_kvcache_blocksparse_qkpertoken_perhead_vperhead_fp8_dim128<kBlockSize,
+                                                                                       false>(
+          y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr,
+          cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q,
+          max_seq_q, max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
+          num_kvcache_blocks, block_size, scale_block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1,
+          ldK2, ldV, ldV1, ldV2, ldKS, ldKS1, ldKS2, nullptr, 0, stream);
+    }
   } else if (block_size == 64) {
     constexpr int kBlockSize = 64;
-    launch_warp_spec_with_kvcache_qkpertoken_perhead_vperhead_fp8_dim128<kBlockSize>(
-        y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr, cu_seqlens_q_ptr,
-        block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q, max_seq_q,
-        max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv, num_kvcache_blocks,
-        block_size, scale_block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1,
-        ldV2, ldKS, ldKS1, ldKS2, stream);
+    if (has_mask) {
+      launch_warp_spec_with_kvcache_blocksparse_qkpertoken_perhead_vperhead_fp8_dim128<kBlockSize,
+                                                                                       true>(
+          y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr,
+          cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q,
+          max_seq_q, max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
+          num_kvcache_blocks, block_size, scale_block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1,
+          ldK2, ldV, ldV1, ldV2, ldKS, ldKS1, ldKS2, block_mask_ptr, num_tile_kv_in_mask, stream);
+    } else {
+      launch_warp_spec_with_kvcache_blocksparse_qkpertoken_perhead_vperhead_fp8_dim128<kBlockSize,
+                                                                                       false>(
+          y_ptr, q_ptr, kcache_ptr, vcache_ptr, qscale_ptr, kscale_ptr, vscale_ptr,
+          cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr, tmas_ptr, num_batch, total_seq_q,
+          max_seq_q, max_seq_q_pad, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
+          num_kvcache_blocks, block_size, scale_block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1,
+          ldK2, ldV, ldV1, ldV2, ldKS, ldKS1, ldKS2, nullptr, 0, stream);
+    }
   }
 }
 

--- a/src/attention/prefill/warp_spec_with_kvcache_blocksparse_fp8_dim128.h
+++ b/src/attention/prefill/warp_spec_with_kvcache_blocksparse_fp8_dim128.h
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Tencent.
 
-#ifndef SRC_ATTENTION_PREFILL_WARP_SPEC_WITH_KVCACHE_FP8_DIM128_H_
-#define SRC_ATTENTION_PREFILL_WARP_SPEC_WITH_KVCACHE_FP8_DIM128_H_
+#ifndef SRC_ATTENTION_PREFILL_WARP_SPEC_WITH_KVCACHE_BLOCKSPARSE_FP8_DIM128_H_
+#define SRC_ATTENTION_PREFILL_WARP_SPEC_WITH_KVCACHE_BLOCKSPARSE_FP8_DIM128_H_
 
 #include <cuda_runtime_api.h>
 #include <stdint.h>
@@ -10,16 +10,16 @@ namespace hpc {
 namespace attention {
 namespace prefill {
 
-void warp_spec_with_kvcache_qpertoken_perhead_kvpertensor_fp8_dim128_async(
+void warp_spec_with_kvcache_blocksparse_qpertoken_perhead_kvpertensor_fp8_dim128_async(
     void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
     const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
     void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int max_seq_q_pad,
     int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
     int block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV,
-    int ldV1, int ldV2, cudaStream_t stream);
+    int ldV1, int ldV2, const void *block_mask_ptr, int num_tile_kv_in_mask, cudaStream_t stream);
 
-void warp_spec_with_kvcache_qkpertoken_perhead_vperhead_fp8_dim128_async(
+void warp_spec_with_kvcache_blocksparse_qkpertoken_perhead_vperhead_fp8_dim128_async(
     void *y_ptr, const void *q_ptr, const void *kcache_ptr, const void *vcache_ptr,
     const void *qscale_ptr, const void *kscale_ptr, const void *vscale_ptr,
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
@@ -27,10 +27,10 @@ void warp_spec_with_kvcache_qkpertoken_perhead_vperhead_fp8_dim128_async(
     int num_dim_qk, int num_dim_v, int num_head_q, int num_head_kv, int num_kvcache_blocks,
     int block_size, int scale_block_size, int num_seq_max_blocks, int ldY, int ldQ, int ldK,
     int ldK1, int ldK2, int ldV, int ldV1, int ldV2, int ldKS, int ldKS1, int ldKS2,
-    cudaStream_t stream);
+    const void *block_mask_ptr, int num_tile_kv_in_mask, cudaStream_t stream);
 
 }  // namespace prefill
 }  // namespace attention
 }  // namespace hpc
 
-#endif  // SRC_ATTENTION_PREFILL_WARP_SPEC_WITH_KVCACHE_FP8_DIM128_H_
+#endif  // SRC_ATTENTION_PREFILL_WARP_SPEC_WITH_KVCACHE_BLOCKSPARSE_FP8_DIM128_H_

--- a/src/attention/prefill/warp_spec_with_kvcache_dim128.cu
+++ b/src/attention/prefill/warp_spec_with_kvcache_dim128.cu
@@ -22,7 +22,8 @@ void launch_warp_spec_with_kvcache_dim128(
     const void *cu_seqlens_q_ptr, const void *block_ids_ptr, const void *seqlens_kvcache_ptr,
     void *tmas_ptr, int num_batch, int total_seq_q, int max_seq_q, int num_dim_qk, int num_dim_v,
     int num_head_q, int num_head_kv, int num_kvcache_blocks, int block_size, int num_seq_max_blocks,
-    int ldY, int ldQ, int ldK, int ldV, cudaStream_t stream) {
+    int ldY, int ldQ, int ldK, int ldK1, int ldK2, int ldV, int ldV1, int ldV2,
+    cudaStream_t stream) {
   using namespace cute;  // NOLINT
 
   using Tin = cute::bfloat16_t;
@@ -33,10 +34,10 @@ void launch_warp_spec_with_kvcache_dim128(
                        make_stride(ldQ, Int<1>{}, num_dim_qk));
   auto K = make_tensor(make_gmem_ptr(reinterpret_cast<const Tin *>(kcache_ptr)),
                        make_shape(kBlockSize, num_dim_qk, num_head_kv, num_kvcache_blocks),
-                       make_stride(num_dim_qk * num_head_kv, Int<1>{}, num_dim_qk, ldK));
+                       make_stride(ldK1, Int<1>{}, ldK2, ldK));
   auto V = make_tensor(make_gmem_ptr(reinterpret_cast<const Tin *>(vcache_ptr)),
                        make_shape(num_dim_v, kBlockSize, num_head_kv, num_kvcache_blocks),
-                       make_stride(Int<1>{}, num_head_kv * num_dim_v, num_dim_v, ldV));
+                       make_stride(Int<1>{}, ldV1, ldV2, ldV));
   auto Y = make_tensor(make_gmem_ptr(reinterpret_cast<const Tout *>(y_ptr)),
                        make_shape(max_seq_q, num_dim_v, num_head_q),
                        make_stride(ldY, Int<1>{}, num_dim_v));
@@ -95,19 +96,22 @@ void warp_spec_with_kvcache_dim128_async(void *y_ptr, const void *q_ptr, const v
                                          int max_seq_q, int num_dim_qk, int num_dim_v,
                                          int num_head_q, int num_head_kv, int num_kvcache_blocks,
                                          int block_size, int num_seq_max_blocks, int ldY, int ldQ,
-                                         int ldK, int ldV, cudaStream_t stream) {
+                                         int ldK, int ldK1, int ldK2, int ldV, int ldV1, int ldV2,
+                                         cudaStream_t stream) {
   if (block_size == 32) {
     constexpr int kBlockSize = 32;
     launch_warp_spec_with_kvcache_dim128<kBlockSize>(
         y_ptr, q_ptr, kcache_ptr, vcache_ptr, cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr,
         tmas_ptr, num_batch, total_seq_q, max_seq_q, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
-        num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldV, stream);
+        num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1,
+        ldV2, stream);
   } else if (block_size == 64) {
     constexpr int kBlockSize = 64;
     launch_warp_spec_with_kvcache_dim128<kBlockSize>(
         y_ptr, q_ptr, kcache_ptr, vcache_ptr, cu_seqlens_q_ptr, block_ids_ptr, seqlens_kvcache_ptr,
         tmas_ptr, num_batch, total_seq_q, max_seq_q, num_dim_qk, num_dim_v, num_head_q, num_head_kv,
-        num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldV, stream);
+        num_kvcache_blocks, block_size, num_seq_max_blocks, ldY, ldQ, ldK, ldK1, ldK2, ldV, ldV1,
+        ldV2, stream);
   }
 }
 

--- a/src/attention/prefill/warp_spec_with_kvcache_dim128.h
+++ b/src/attention/prefill/warp_spec_with_kvcache_dim128.h
@@ -17,7 +17,8 @@ void warp_spec_with_kvcache_dim128_async(void *y_ptr, const void *q_ptr, const v
                                          int max_seq_q, int num_dim_qk, int num_dim_v,
                                          int num_head_q, int num_head_kv, int num_kvcache_blocks,
                                          int block_size, int num_seq_max_blocks, int ldY, int ldQ,
-                                         int ldK, int ldV, cudaStream_t stream);
+                                         int ldK, int ldK1, int ldK2, int ldV, int ldV1, int ldV2,
+                                         cudaStream_t stream);
 
 }  // namespace prefill
 }  // namespace attention

--- a/tests/test_attention_blocksparse_qkpertoken_perhead_vperhead_fp8.py
+++ b/tests/test_attention_blocksparse_qkpertoken_perhead_vperhead_fp8.py
@@ -1,0 +1,228 @@
+import sys
+import os
+import pytest
+from pathlib import Path
+
+sys.path.insert(0, os.path.realpath(list(Path(__file__).parent.glob("../build/lib.*/"))[0]))
+
+import hpc
+import torch
+import math
+from utils import allclose
+
+BSA_BLOCK = 128
+QUANT_TYPE_NEW = hpc.QuantType.QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD
+
+
+def generate_block_sparse_mask(batch, heads, nrow, ncol, skip_ratio, causal=True, device="cuda"):
+    """Block-level sparse mask.  True = attend.  Diagonal always kept under causal."""
+    mask = torch.rand(batch, heads, nrow, ncol, device=device) >= skip_ratio
+    row_idx = torch.arange(nrow, device=device).view(nrow, 1)
+    col_idx = torch.arange(ncol, device=device).view(1, ncol)
+    if causal:
+        causal_boundary = row_idx + (ncol - nrow)
+        valid_causal = col_idx <= causal_boundary
+        mask = mask & valid_causal
+        diag_col = torch.clamp(causal_boundary, max=ncol - 1)
+        mask = mask | (col_idx == diag_col)
+    return mask
+
+
+def naive_attn_with_kvcache_qkpv_sparse_fixed_pscale(
+    q,
+    k_cache,
+    v_cache,
+    qscale,
+    kscale,
+    vscale,
+    cache_seqlens,
+    page_table,
+    block_mask=None,
+    causal=True,
+):
+    """Sparse qkpertoken/vperhead reference for the fixed P-scale=256 FP8 path."""
+    num_batch, num_seq_q, num_head_q, num_dim_qk = q.shape
+    _, block_size, num_head_kv, _ = k_cache.shape
+    _, _, _, num_dim_v = v_cache.shape
+    num_group = num_head_q // num_head_kv
+    output = torch.empty_like(q).to(torch.bfloat16)
+
+    kvcache_blocks = (cache_seqlens + block_size - 1) // block_size
+
+    for i in range(num_batch):
+        BQ = q[i].transpose(0, 1).float()
+        blk_ids = page_table[i, : kvcache_blocks[i]]
+        num_seq_kv = cache_seqlens[i]
+        BK = (
+            k_cache[blk_ids]
+            .reshape(-1, num_head_kv, num_dim_qk)
+            .transpose(0, 1)[:, :num_seq_kv, :]
+            .repeat_interleave(num_group, dim=0)
+        ).float()
+        BV = (
+            v_cache[blk_ids]
+            .reshape(-1, num_head_kv, num_dim_v)
+            .transpose(0, 1)[:, :num_seq_kv, :]
+            .repeat_interleave(num_group, dim=0)
+        ).float()
+        BKS = (
+            kscale[blk_ids, :, :, :]
+            .permute(0, 1, 3, 2)
+            .reshape(-1, num_head_kv)
+            .transpose(0, 1)[:, :num_seq_kv]
+            .repeat_interleave(num_group, dim=0)
+        ).float()
+
+        scale = qscale[i, :, :].unsqueeze(-1)[:, :num_seq_q, :]
+        scores = torch.matmul(BQ, BK.transpose(-2, -1)) / math.sqrt(num_dim_qk)
+        scores = scores * scale * BKS.unsqueeze(1)
+
+        if block_mask is not None:
+            bm = block_mask[i]
+            elem_mask = bm.repeat_interleave(BSA_BLOCK, dim=-2)[:, :num_seq_q, :]
+            elem_mask = elem_mask.repeat_interleave(BSA_BLOCK, dim=-1)[:, :, :num_seq_kv]
+            scores = scores.masked_fill(~elem_mask, float("-inf"))
+
+        if causal:
+            cm = (
+                torch.tril(torch.ones(num_seq_kv, num_seq_kv, device=q.device, dtype=torch.bool))[
+                    (num_seq_kv - num_seq_q) :, :
+                ]
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
+            scores = scores.masked_fill(~cm, float("-inf"))
+
+        attn_weights = torch.exp(scores - scores.max(dim=-1, keepdim=True)[0])
+        gsum = attn_weights.sum(dim=-1, keepdim=True)
+        attn_weights = attn_weights * 256.0
+        attn_weights = attn_weights.to(torch.float8_e4m3fn).float()
+
+        out_head = torch.matmul(attn_weights, BV) / gsum
+        vscale_eff = vscale[:, None, None].repeat_interleave(num_group, dim=0)
+        vscale_eff = vscale_eff / 256.0
+        output[i] = (out_head * vscale_eff).transpose(1, 2)
+
+    return output
+
+
+@pytest.mark.parametrize("num_batch", [2])
+@pytest.mark.parametrize("num_seq", [1024, 2048])
+@pytest.mark.parametrize("num_head_q,num_head_kv", [(4, 1)])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("skip_ratio", [0.0, 0.5])
+@pytest.mark.parametrize("kv_layout", ["nhd", "hnd"])
+def test_kvcache_blocksparse_qkpertoken_perhead_vperhead_prefill_fp8(
+    kv_layout,
+    num_batch,
+    num_seq,
+    num_head_q,
+    num_head_kv,
+    head_dim,
+    skip_ratio,
+):
+    torch.manual_seed(10086)
+    torch.cuda.manual_seed(10086)
+
+    T_bf16 = torch.bfloat16
+    T_fp8 = torch.float8_e4m3fn
+    device = "cuda"
+    block_size = 64
+
+    # K-scale geometry (matches dense kernel): 32 tokens per scale-group, 4 dims per dim-group.
+    kScaleBlockSize = block_size // 32
+    num_dim_scale = head_dim // 4
+
+    num_seq_q_pad = (num_seq + 127) // 128 * 128
+
+    Q = (
+        torch.randn(num_batch, num_seq, num_head_q, head_dim, dtype=T_bf16, device=device)
+        / math.sqrt(head_dim)
+    ).to(T_fp8)
+    qscale = (
+        torch.abs(
+            torch.randn(num_batch, num_head_q, num_seq_q_pad, dtype=torch.float32, device=device)
+        )
+        / 10
+    )
+    vscale = torch.abs(torch.randn(num_head_kv, dtype=torch.float32, device=device))
+
+    seqlens_q = torch.full((num_batch,), num_seq, dtype=torch.int32, device=device)
+    seqlens_kvcache = torch.full((num_batch,), num_seq, dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.zeros(num_batch + 1, dtype=torch.int32, device=device)
+    cu_seqlens_q[1:] = torch.cumsum(seqlens_q, dim=0)
+
+    max_num_blocks = num_batch * ((num_seq + block_size - 1) // block_size) * 2
+    kvcache_blocks = (seqlens_kvcache + block_size - 1) // block_size
+    total_kb = kvcache_blocks.sum().item()
+    max_kb = kvcache_blocks.max().item()
+
+    kvcache = torch.randn(
+        max_num_blocks, 2, block_size, num_head_kv, head_dim, dtype=T_bf16, device=device
+    ).to(T_fp8)
+    if kv_layout == "hnd":
+        kcache = kvcache[:, 0].transpose(1, 2).contiguous().transpose(1, 2)
+        vcache = kvcache[:, 1].transpose(1, 2).contiguous().transpose(1, 2)
+    else:
+        kcache = kvcache[:, 0]
+        vcache = kvcache[:, 1]
+    packed_ids = torch.randperm(max_num_blocks, device=device)[:total_kb].to(torch.int32)
+    block_ids = torch.empty(num_batch, max_kb, dtype=torch.int32, device=device)
+    cu = 0
+    for i in range(num_batch):
+        nb = kvcache_blocks[i].item()
+        block_ids[i, :nb] = packed_ids[cu : cu + nb]
+        cu += nb
+
+    # K-scale: generated as fp32, viewed as fp8 to exercise the fp8-dtype dispatch path.
+    kscale = torch.abs(
+        torch.randn(
+            (max_num_blocks, kScaleBlockSize, num_head_kv, num_dim_scale),
+            dtype=torch.float32,
+            device=device,
+        )
+    ).view(torch.float8_e4m3fn)
+    kscale_f32 = kscale.view(torch.float32)
+
+    # Build block mask
+    block_mask = None
+    block_mask_u8 = None
+    if skip_ratio > 0:
+        ntiles = (num_seq + BSA_BLOCK - 1) // BSA_BLOCK
+        block_mask = generate_block_sparse_mask(
+            num_batch, num_head_q, ntiles, ntiles, skip_ratio, causal=True, device=device
+        )
+        block_mask_u8 = block_mask.to(torch.uint8).contiguous()
+
+    # Reference
+    gt = naive_attn_with_kvcache_qkpv_sparse_fixed_pscale(
+        Q,
+        kcache,
+        vcache,
+        qscale,
+        kscale_f32,
+        vscale,
+        seqlens_kvcache,
+        block_ids,
+        block_mask=block_mask,
+        causal=True,
+    ).reshape(-1, num_head_q, head_dim)
+
+    # HPC kernel
+    q_flat = Q.reshape(-1, num_head_q, head_dim)
+    my = hpc.attention_with_kvcache_blocksparse_prefill_fp8(
+        q_flat,
+        kcache,
+        vcache,
+        qscale,
+        kscale,
+        vscale,
+        cu_seqlens_q,
+        block_ids,
+        seqlens_kvcache,
+        num_seq,
+        quant_type=QUANT_TYPE_NEW,
+        block_mask=block_mask_u8,
+    )
+
+    assert allclose(gt, my, atol=0.1)

--- a/tests/test_attention_blocksparse_qpertoken_perhead_kvpertensor_fp8.py
+++ b/tests/test_attention_blocksparse_qpertoken_perhead_kvpertensor_fp8.py
@@ -1,0 +1,218 @@
+import sys
+import os
+import pytest
+from pathlib import Path
+
+sys.path.insert(0, os.path.realpath(list(Path(__file__).parent.glob("../build/lib.*/"))[0]))
+
+import hpc
+import torch
+import math
+from utils import allclose
+
+BSA_BLOCK = 128
+
+
+# ====================================================================
+# Shared helpers
+# ====================================================================
+
+
+def generate_block_sparse_mask(batch, heads, nrow, ncol, skip_ratio, causal=True, device="cuda"):
+    """Block-level sparse mask.  True = attend."""
+    mask = torch.rand(batch, heads, nrow, ncol, device=device) >= skip_ratio
+
+    row_idx = torch.arange(nrow, device=device).view(nrow, 1)
+    col_idx = torch.arange(ncol, device=device).view(1, ncol)
+
+    if causal:
+        causal_boundary = row_idx + (ncol - nrow)
+        valid_causal = col_idx <= causal_boundary
+        mask = mask & valid_causal
+        diag_col = torch.clamp(causal_boundary, max=ncol - 1)
+        mask = mask | (col_idx == diag_col)
+
+    return mask
+
+
+# ====================================================================
+# Kernel 1: paged KV cache blocksparse prefill fp8 (dim=128)
+# ====================================================================
+
+
+def naive_attn_with_kvcache_sparse_fixed_pscale(
+    q,
+    k_cache,
+    v_cache,
+    qscale,
+    kscale,
+    vscale,
+    cache_seqlens,
+    page_table,
+    block_mask=None,
+    causal=True,
+):
+    """Sparse reference for the kernel's fixed P-scale=256 FP8 path."""
+    num_batch, num_seq_q, num_head_q, num_dim_qk = q.shape
+    _, block_size, num_head_kv, _ = k_cache.shape
+    _, _, _, num_dim_v = v_cache.shape
+    num_group = num_head_q // num_head_kv
+    output = torch.empty_like(q).to(torch.bfloat16)
+
+    kvcache_blocks = (cache_seqlens + block_size - 1) // block_size
+
+    for i in range(num_batch):
+        BQ = q[i].transpose(0, 1).float()
+        blk_ids = page_table[i, : kvcache_blocks[i]]
+        num_seq_kv = cache_seqlens[i]
+        BK = (
+            k_cache[blk_ids]
+            .reshape(-1, num_head_kv, num_dim_qk)
+            .transpose(0, 1)[:, :num_seq_kv, :]
+            .repeat_interleave(num_group, dim=0)
+        ).float()
+        BV = (
+            v_cache[blk_ids]
+            .reshape(-1, num_head_kv, num_dim_v)
+            .transpose(0, 1)[:, :num_seq_kv, :]
+            .repeat_interleave(num_group, dim=0)
+        ).float()
+
+        scale = qscale[i, :, :].unsqueeze(-1)[:, :num_seq_q, :]
+        scores = torch.matmul(BQ, BK.transpose(-2, -1)) * scale * kscale[0] / math.sqrt(num_dim_qk)
+
+        if block_mask is not None:
+            bm = block_mask[i]
+            elem_mask = bm.repeat_interleave(BSA_BLOCK, dim=-2)[:, :num_seq_q, :]
+            elem_mask = elem_mask.repeat_interleave(BSA_BLOCK, dim=-1)[:, :, :num_seq_kv]
+            scores = scores.masked_fill(~elem_mask, float("-inf"))
+
+        if causal:
+            cm = (
+                torch.tril(torch.ones(num_seq_kv, num_seq_kv, device=q.device, dtype=torch.bool))[
+                    (num_seq_kv - num_seq_q) :, :
+                ]
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
+            scores = scores.masked_fill(~cm, float("-inf"))
+
+        attn_weights = torch.exp(scores - scores.max(dim=-1, keepdim=True)[0])
+        gsum = attn_weights.sum(dim=-1, keepdim=True)
+        attn_weights = attn_weights * 256.0
+        attn_weights = attn_weights.to(torch.float8_e4m3fn).float()
+
+        out_head = torch.matmul(attn_weights, BV) / gsum
+        out_head = out_head * (vscale[0] / 256.0)
+        output[i] = out_head.transpose(1, 2)
+
+    return output
+
+
+@pytest.mark.parametrize("num_batch", [2])
+@pytest.mark.parametrize("num_seq", [1024, 2048])
+@pytest.mark.parametrize("num_head_q,num_head_kv", [(4, 1)])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("skip_ratio", [0.0, 0.5])
+@pytest.mark.parametrize("kv_layout", ["nhd", "hnd"])
+def test_blocksparse_qpertoken_perhead_kvpertensor_fp8(
+    kv_layout,
+    num_batch,
+    num_seq,
+    num_head_q,
+    num_head_kv,
+    head_dim,
+    skip_ratio,
+):
+    torch.manual_seed(10086)
+    torch.cuda.manual_seed(10086)
+
+    T_bf16 = torch.bfloat16
+    T_fp8 = torch.float8_e4m3fn
+    device = "cuda"
+    block_size = 64
+
+    num_seq_q_pad = (num_seq + 127) // 128 * 128
+
+    Q = (
+        torch.randn(num_batch, num_seq, num_head_q, head_dim, dtype=T_bf16, device=device)
+        / math.sqrt(head_dim)
+    ).to(T_fp8)
+    qscale = (
+        torch.abs(
+            torch.randn(num_batch, num_head_q, num_seq_q_pad, dtype=torch.float32, device=device)
+        )
+        / 10
+    )
+    kscale = torch.rand(1, dtype=torch.float32, device=device) + 0.5
+    vscale = torch.randn(1, dtype=torch.float32, device=device)
+
+    seqlens_q = torch.full((num_batch,), num_seq, dtype=torch.int32, device=device)
+    seqlens_kvcache = torch.full((num_batch,), num_seq, dtype=torch.int32, device=device)
+    cu_seqlens_q = torch.zeros(num_batch + 1, dtype=torch.int32, device=device)
+    cu_seqlens_q[1:] = torch.cumsum(seqlens_q, dim=0)
+
+    max_num_blocks = num_batch * ((num_seq + block_size - 1) // block_size) * 2
+    kvcache_blocks = (seqlens_kvcache + block_size - 1) // block_size
+    total_kb = kvcache_blocks.sum().item()
+    max_kb = kvcache_blocks.max().item()
+
+    kvcache = torch.randn(
+        max_num_blocks, 2, block_size, num_head_kv, head_dim, dtype=T_bf16, device=device
+    ).to(T_fp8)
+    if kv_layout == "hnd":
+        kcache = kvcache[:, 0].transpose(1, 2).contiguous().transpose(1, 2)
+        vcache = kvcache[:, 1].transpose(1, 2).contiguous().transpose(1, 2)
+    else:
+        kcache = kvcache[:, 0]
+        vcache = kvcache[:, 1]
+    packed_ids = torch.randperm(max_num_blocks, device=device)[:total_kb].to(torch.int32)
+    block_ids = torch.empty(num_batch, max_kb, dtype=torch.int32, device=device)
+    cu = 0
+    for i in range(num_batch):
+        nb = kvcache_blocks[i].item()
+        block_ids[i, :nb] = packed_ids[cu : cu + nb]
+        cu += nb
+
+    # Build block mask
+    block_mask = None
+    block_mask_u8 = None
+    if skip_ratio > 0:
+        ntiles = (num_seq + BSA_BLOCK - 1) // BSA_BLOCK
+        block_mask = generate_block_sparse_mask(
+            num_batch, num_head_q, ntiles, ntiles, skip_ratio, causal=True, device=device
+        )
+        block_mask_u8 = block_mask.to(torch.uint8).contiguous()
+
+    # Reference
+    gt = naive_attn_with_kvcache_sparse_fixed_pscale(
+        Q,
+        kcache,
+        vcache,
+        qscale,
+        kscale,
+        vscale,
+        seqlens_kvcache,
+        block_ids,
+        block_mask=block_mask,
+        causal=True,
+    ).reshape(-1, num_head_q, head_dim)
+
+    # HPC kernel
+    q_flat = Q.reshape(-1, num_head_q, head_dim)
+    my = hpc.attention_with_kvcache_blocksparse_prefill_fp8(
+        q_flat,
+        kcache,
+        vcache,
+        qscale,
+        kscale,
+        vscale,
+        cu_seqlens_q,
+        block_ids,
+        seqlens_kvcache,
+        num_seq,
+        quant_type=hpc.QuantType.QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR,
+        block_mask=block_mask_u8,
+    )
+
+    assert allclose(gt, my, atol=0.1)

--- a/tests/test_attention_with_kvcache_qkpertoken_perhead_vperhead_prefill_fp8.py
+++ b/tests/test_attention_with_kvcache_qkpertoken_perhead_vperhead_prefill_fp8.py
@@ -1,0 +1,249 @@
+import sys
+import os
+import pytest
+from pathlib import Path
+
+sys.path.insert(0, os.path.realpath(list(Path(__file__).parent.glob("../build/lib.*/"))[0]))
+
+import hpc
+import torch
+import math
+import torch.nn.functional as F
+from utils import allclose
+
+
+def naive_attn_with_kvcache_func(
+    q,
+    k_cache,
+    v_cache,
+    qscale,
+    kscale,
+    vscale,
+    cache_seqlens,
+    page_table,
+    causal=True,
+):
+
+    num_batch, num_seq_q, num_head_q, num_dim_qk = q.shape
+    num_blocks, block_size, num_head_kv, _ = k_cache.shape
+    _, _, _, num_dim_v = v_cache.shape
+    _, _, max_seq_q_pad = qscale.shape
+
+    num_group = num_head_q // num_head_kv
+    output = torch.empty_like(q).to(torch.bfloat16)
+
+    kvcache_blocks = (cache_seqlens + block_size - 1) // block_size
+
+    for i in range(num_batch):
+        BQ = q[i].transpose(0, 1).float()  # [num_heads, sq, head_dim]
+        blk_ids = page_table[i, : kvcache_blocks[i]]
+        num_seq_kv = cache_seqlens[i]
+        BK = (
+            k_cache[blk_ids, :, :, :]
+            .reshape(-1, num_head_kv, num_dim_qk)
+            .transpose(0, 1)[:, :num_seq_kv, :]
+            .repeat_interleave(num_group, dim=0)
+        ).float()
+        BV = (
+            v_cache[blk_ids, :, :, :]
+            .reshape(-1, num_head_kv, num_dim_v)
+            .transpose(0, 1)[:, :num_seq_kv, :]
+            .repeat_interleave(num_group, dim=0)
+        ).float()
+
+        BKS = (
+            kscale[blk_ids, :, :, :]
+            # .view(torch.float32)
+            .permute(0, 1, 3, 2)
+            .reshape(-1, num_head_kv)
+            .transpose(0, 1)[:, :num_seq_kv]
+            .repeat_interleave(num_group, dim=0)
+        ).float()
+
+        scale = qscale[i, :, :].unsqueeze(-1)[:, :num_seq_q, :]
+
+        scores = BQ @ BK.transpose(-1, -2)
+        scores = (
+            scores / math.sqrt(num_dim_qk) * scale * BKS.unsqueeze(1)
+        )  # * qscale[i][:, None, None]
+
+        if causal:
+            causal_mask = (
+                torch.tril(torch.ones(num_seq_kv, num_seq_kv, device=q.device, dtype=torch.bool))[
+                    (num_seq_kv - num_seq_q) :, :
+                ]
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )  # (1, 1, num_seq_q, num_seq_kv)
+
+        scores = scores.masked_fill(~causal_mask, float("-inf"))
+
+        # Mirror the kernel's online-softmax + fixed-P-scale fp8 quant path.
+        attn_weights = torch.exp(scores - scores.max(dim=-1, keepdim=True)[0])
+        gSum = attn_weights.sum(dim=-1, keepdim=True)
+        attn_weights = attn_weights * 256.0
+        attn_weights = attn_weights.to(torch.float8_e4m3fn).float()
+
+        out_head = torch.matmul(attn_weights, BV)
+        out_head = out_head / gSum
+        v_scale_eff = vscale[:, None, None].repeat_interleave(num_group, dim=0)
+        out_head = out_head * (v_scale_eff / 256.0)
+
+        output[i] = out_head.transpose(1, 2)
+
+    return output
+
+
+try:
+    from flash_attn_interface import flash_attn_varlen_func, flash_attn_with_kvcache
+
+    gt_attention_func = naive_attn_with_kvcache_func  # flash_attn_with_kvcache
+except Exception as e:
+    print(f"execute naive_attn_func: {e}")
+    gt_attention_func = naive_attn_with_kvcache_func
+
+
+@pytest.mark.parametrize("kv_layout", ["nhd", "hnd"])
+@pytest.mark.parametrize("num_batch", [1])
+@pytest.mark.parametrize("num_seq_q", [3904])
+@pytest.mark.parametrize("num_seq_kv", [3904])
+@pytest.mark.parametrize("block_size", [64])
+@pytest.mark.parametrize("num_head_q", [8])
+@pytest.mark.parametrize("num_head_kv", [2])
+@pytest.mark.parametrize("num_dim_qk", [128])
+@pytest.mark.parametrize("num_dim_v", [128])
+@pytest.mark.parametrize("use_output", [False])
+def test_attention_with_kvcache_qkpertoken_perhead_vperhead_prefill_fp8(
+    kv_layout,
+    num_batch,
+    num_seq_q,
+    num_seq_kv,
+    block_size,
+    num_head_q,
+    num_head_kv,
+    num_dim_qk,
+    num_dim_v,
+    use_output,
+):
+
+    T = torch.bfloat16
+    T1 = torch.float8_e4m3fn
+
+    torch.cuda.manual_seed(10086)
+
+    num_seq_q_pad = (num_seq_q + 127) // 128 * 128
+
+    Q = (
+        torch.randn(
+            (num_batch, num_seq_q, num_head_q, num_dim_qk),
+            dtype=T,
+            device="cuda",
+        )
+        / math.sqrt(num_dim_qk)
+    ).to(T1)
+    K = (
+        torch.randn((num_batch * num_seq_q, num_head_kv, num_dim_qk), dtype=T, device="cuda")
+        / math.sqrt(num_dim_qk)
+    ).to(T1)
+    V = torch.randn((num_batch * num_seq_q, num_head_kv, num_dim_v), dtype=T, device="cuda").to(T1)
+    qscale = (
+        torch.abs(
+            torch.randn((num_batch, num_head_q, num_seq_q_pad), dtype=torch.float32, device="cuda")
+        )
+        / 10
+    )
+
+    # kscale = torch.randn((1), dtype=torch.float32, device="cuda").abs() * 10
+    vscale = torch.abs(torch.ones((num_head_kv), dtype=torch.float32, device="cuda"))
+    print("vscale:", vscale)
+
+    seqlens_q = torch.full((num_batch,), num_seq_q, dtype=torch.int32, device="cuda")
+    seqlens_kvcache = torch.full((num_batch,), num_seq_kv, dtype=torch.int32, device="cuda")
+    cu_seqlens_q = torch.cumsum(
+        torch.cat([torch.tensor([0], dtype=torch.int32, device="cuda"), seqlens_q]), dim=0
+    ).to(torch.int32)
+    cu_seqlens_kvcache = torch.cumsum(
+        torch.cat([torch.tensor([0], dtype=torch.int32, device="cuda"), seqlens_kvcache]), dim=0
+    ).to(torch.int32)
+
+    max_num_blocks = num_batch * (num_seq_kv + block_size - 1) // block_size * 2
+    kvcache_blocks = (seqlens_kvcache + block_size - 1) // block_size
+    total_kvcache_blocks = sum(kvcache_blocks)
+    max_kvcache_blocks = max(kvcache_blocks)
+    max_seqlens_q = max(seqlens_q)
+    max_seqlens_kvcache = max(seqlens_kvcache)
+
+    kvcache = torch.randn(
+        max_num_blocks, 2, block_size, num_head_kv, num_dim_qk, dtype=T, device="cuda"
+    ).to(T1)
+    if kv_layout == "hnd":
+        kcache = kvcache[:, 0].transpose(1, 2).contiguous().transpose(1, 2)
+        vcache = kvcache[:, 1].transpose(1, 2).contiguous().transpose(1, 2)
+    else:
+        kcache = kvcache[:, 0]
+        vcache = kvcache[:, 1]
+    packed_block_ids = torch.randperm(max_num_blocks)[:total_kvcache_blocks].to(torch.int32).cuda()
+
+    cu_blocks = 0
+    block_ids = torch.empty(num_batch, max_kvcache_blocks, dtype=torch.int32, device="cuda")
+    for i in range(num_batch):
+        block_ids[i, : kvcache_blocks[i]] = packed_block_ids[
+            cu_blocks : cu_blocks + kvcache_blocks[i]
+        ]
+        cu_blocks += kvcache_blocks[i]
+
+    kscale = torch.abs(
+        torch.randn((max_num_blocks, 2, num_head_kv, 32), dtype=torch.float32, device="cuda")
+    ).view(torch.float8_e4m3fn)
+
+    for i in range(1):
+        gt = gt_attention_func(
+            q=Q,
+            k_cache=kcache,
+            v_cache=vcache,
+            qscale=qscale,
+            kscale=kscale.view(torch.float32),
+            vscale=vscale,
+            cache_seqlens=seqlens_kvcache,
+            page_table=block_ids,
+            causal=True,
+        )
+
+        if use_output:
+            my = torch.empty_like(Q.reshape(-1, num_head_q, num_dim_qk))
+            hpc.attention_with_kvcache_prefill_fp8(
+                Q.reshape(-1, num_head_q, num_dim_qk),
+                kcache,
+                vcache,
+                qscale,
+                kscale,
+                vscale,
+                cu_seqlens_q,
+                block_ids,
+                seqlens_kvcache,
+                max_seqlens_q,
+                quant_type=hpc.QuantType.QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD,
+                output=my,
+            )
+        else:
+            my = hpc.attention_with_kvcache_prefill_fp8(
+                Q.reshape(-1, num_head_q, num_dim_qk),
+                kcache,
+                vcache,
+                qscale,
+                kscale,
+                vscale,
+                cu_seqlens_q,
+                block_ids,
+                seqlens_kvcache,
+                max_seqlens_q,
+                quant_type=hpc.QuantType.QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD,
+            )
+    gt = gt.reshape(-1, num_head_q, num_dim_v)
+
+    print("\ngt\n")
+    print(gt[:, 0, :])
+    print("\nmy\n")
+    print(my[:, 0, :])
+
+    assert allclose(gt, my, atol=0.05)

--- a/tests/test_attention_with_kvcache_qpertoken_perhead_kvpertensor_prefill_fp8.py
+++ b/tests/test_attention_with_kvcache_qpertoken_perhead_kvpertensor_prefill_fp8.py
@@ -1,22 +1,15 @@
-import os
 import sys
-from pathlib import Path
-
+import os
 import pytest
+from pathlib import Path
 
 sys.path.insert(0, os.path.realpath(list(Path(__file__).parent.glob("../build/lib.*/"))[0]))
 
-import math
-
-import torch
-import torch.nn.functional as F
-
 import hpc
+import torch
+import math
+import torch.nn.functional as F
 from utils import allclose
-
-# Set random seed for reproducibility
-torch.manual_seed(41)
-torch.cuda.manual_seed(41)
 
 
 def naive_attn_with_kvcache_func(
@@ -69,13 +62,20 @@ def naive_attn_with_kvcache_func(
                 .unsqueeze(0)
                 .unsqueeze(0)
             )  # (1, 1, num_seq_q, num_seq_kv)
-        else:
-            causal_mask = causal_mask.view(1, 1, num_seq_q, num_seq_kv)
 
         scores = scores.masked_fill(~causal_mask, float("-inf"))
-        attn_weights = F.softmax(scores, dim=-1)
 
-        output[i] = torch.matmul(attn_weights, BV).transpose(1, 2) * vscale[0]
+        # Mirror the kernel's online-softmax + fixed-P-scale fp8 quant path.
+        attn_weights = torch.exp(scores - scores.max(dim=-1, keepdim=True)[0])
+        gSum = attn_weights.sum(dim=-1, keepdim=True)
+        attn_weights = attn_weights * 256.0
+        attn_weights = attn_weights.to(torch.float8_e4m3fn).float()
+
+        out_head = torch.matmul(attn_weights, BV)
+        out_head = out_head / gSum
+        out_head = out_head * (vscale[0] / 256.0)
+
+        output[i] = out_head.transpose(1, 2)
 
     return output
 
@@ -89,6 +89,7 @@ except Exception as e:
     gt_attention_func = naive_attn_with_kvcache_func
 
 
+@pytest.mark.parametrize("kv_layout", ["nhd", "hnd"])
 @pytest.mark.parametrize("num_batch", [4])
 @pytest.mark.parametrize("num_seq_q", [100, 500, 1000, 1500, 3904])
 @pytest.mark.parametrize("num_seq_kv", [3904])
@@ -99,6 +100,7 @@ except Exception as e:
 @pytest.mark.parametrize("num_dim_v", [128])
 @pytest.mark.parametrize("use_output", [False])
 def test_attention_with_kvcache_prefill_fp8(
+    kv_layout,
     num_batch,
     num_seq_q,
     num_seq_kv,
@@ -110,32 +112,35 @@ def test_attention_with_kvcache_prefill_fp8(
     use_output,
 ):
 
+    torch.manual_seed(10086)
+    torch.cuda.manual_seed(10086)
+    T = torch.bfloat16
+    T1 = torch.float8_e4m3fn
+
     num_seq_q_pad = (num_seq_q + 127) // 128 * 128
 
-    q = (
+    Q = (
         torch.randn(
             (num_batch, num_seq_q, num_head_q, num_dim_qk),
-            dtype=torch.bfloat16,
+            dtype=T,
             device="cuda",
         )
         / math.sqrt(num_dim_qk)
-    ).to(torch.float8_e4m3fn)
-    k = (
-        torch.randn(
-            (num_batch * num_seq_q, num_head_kv, num_dim_qk), dtype=torch.bfloat16, device="cuda"
-        )
+    ).to(T1)
+    K = (
+        torch.randn((num_batch * num_seq_q, num_head_kv, num_dim_qk), dtype=T, device="cuda")
         / math.sqrt(num_dim_qk)
-    ).to(torch.float8_e4m3fn)
-    v = torch.randn(
-        (num_batch * num_seq_q, num_head_kv, num_dim_v), dtype=torch.bfloat16, device="cuda"
-    ).to(torch.float8_e4m3fn)
+    ).to(T1)
+    V = torch.randn((num_batch * num_seq_q, num_head_kv, num_dim_v), dtype=T, device="cuda").to(T1)
     qscale = (
         torch.abs(
             torch.randn((num_batch, num_head_q, num_seq_q_pad), dtype=torch.float32, device="cuda")
         )
         / 10
     )
+
     kscale = torch.randn((1), dtype=torch.float32, device="cuda").abs() * 10
+    print(f"kscale={kscale}")
     vscale = torch.randn((1), dtype=torch.float32, device="cuda")
 
     seqlens_q = torch.full((num_batch,), num_seq_q, dtype=torch.int32, device="cuda")
@@ -155,8 +160,14 @@ def test_attention_with_kvcache_prefill_fp8(
     max_seqlens_kvcache = max(seqlens_kvcache)
 
     kvcache = torch.randn(
-        max_num_blocks, 2, block_size, num_head_kv, num_dim_qk, dtype=torch.bfloat16, device="cuda"
-    ).to(torch.float8_e4m3fn)
+        max_num_blocks, 2, block_size, num_head_kv, num_dim_qk, dtype=T, device="cuda"
+    ).to(T1)
+    if kv_layout == "hnd":
+        kcache = kvcache[:, 0].transpose(1, 2).contiguous().transpose(1, 2)
+        vcache = kvcache[:, 1].transpose(1, 2).contiguous().transpose(1, 2)
+    else:
+        kcache = kvcache[:, 0]
+        vcache = kvcache[:, 1]
     packed_block_ids = torch.randperm(max_num_blocks)[:total_kvcache_blocks].to(torch.int32).cuda()
 
     cu_blocks = 0
@@ -167,31 +178,60 @@ def test_attention_with_kvcache_prefill_fp8(
         ]
         cu_blocks += kvcache_blocks[i]
 
-    gt = gt_attention_func(
-        q=q,
-        k_cache=kvcache[:, 0, :, :],
-        v_cache=kvcache[:, 1, :, :],
-        qscale=qscale,
-        kscale=kscale,
-        vscale=vscale,
-        cache_seqlens=seqlens_kvcache,
-        page_table=block_ids,
-        causal=True,
-    )
+    for i in range(10):
+        gt = gt_attention_func(
+            q=Q,
+            k_cache=kcache,
+            v_cache=vcache,
+            qscale=qscale,
+            kscale=kscale,
+            vscale=vscale,
+            cache_seqlens=seqlens_kvcache,
+            page_table=block_ids,
+            causal=True,
+        )
 
-    my = hpc.attention_with_kvcache_prefill_fp8(
-        q.reshape(-1, num_head_q, num_dim_qk),
-        kvcache[:, 0, :, :, :],
-        kvcache[:, 1, :, :, :],
-        qscale,
-        kscale,
-        vscale,
-        cu_seqlens_q,
-        block_ids,
-        seqlens_kvcache,
-        max_seqlens_q,
-    )
-
+        if use_output:
+            my = torch.empty_like(Q.reshape(-1, num_head_q, num_dim_qk))
+            hpc.attention_with_kvcache_prefill_fp8(
+                Q.reshape(-1, num_head_q, num_dim_qk),
+                kcache,
+                vcache,
+                qscale,
+                kscale,
+                vscale,
+                cu_seqlens_q,
+                block_ids,
+                seqlens_kvcache,
+                max_seqlens_q,
+                quant_type=hpc.QuantType.QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR,
+                output=my,
+            )
+        else:
+            my = hpc.attention_with_kvcache_prefill_fp8(
+                Q.reshape(-1, num_head_q, num_dim_qk),
+                kcache,
+                vcache,
+                qscale,
+                kscale,
+                vscale,
+                cu_seqlens_q,
+                block_ids,
+                seqlens_kvcache,
+                max_seqlens_q,
+                quant_type=hpc.QuantType.QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR,
+            )
     gt = gt.reshape(-1, num_head_q, num_dim_v)
 
-    assert allclose(gt, my, atol=0.1)
+    print("\ngt\n")
+    print(gt[:, 0, :])
+    print("\nmy\n")
+    print(my[:, 0, :])
+    print("\n diff \n")
+    print((gt - my)[:64, 0, :1])
+
+    assert allclose(gt, my, atol=0.05)
+
+
+# -----------------------------------------------------------------------------
+# Fixed P-scale coverage

--- a/tests/test_fuse_moe_pertensor.py
+++ b/tests/test_fuse_moe_pertensor.py
@@ -83,14 +83,9 @@ def naive_group_gemm(x, w, cu_seqlens, scale, expert_ids):
         x_group = x[start_idx:end_idx]
         w_group = w[i]
 
-        y_group = torch._scaled_mm(
-            x_group,
-            w_group.t(),
-            scale_a=scale[i],
-            scale_b=torch.ones((1), dtype=torch.float, device="cuda"),
-            bias=None,
-            out_dtype=torch.bfloat16,
-        )
+        y_group = (
+            (x_group.to(torch.float32) @ w_group.t().to(torch.float32)) * scale[i].to(torch.float32)
+        ).to(torch.bfloat16)
         y[start_idx:end_idx] = y_group
     return y
 


### PR DESCRIPTION
## Summary
  - Block-sparse paged-KV prefill attention for FP8, dim=128 (with kvcache)
  - Two quantization schemes via `quant_type` parameter:
    - `QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR` (default)
    - `QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD`
  - Updated existing dense FP8 prefill kernels to support both quant schemes.

## Test result
  - [x] `make wheel` builds clean on H20 / CUDA 13.0 / torch 2.10
  - [x] All 9 `test_attention_*.py` pass
  - [x] Full `pytest tests/` regression: all passed

## Benchmark
<img width="2671" height="1776" alt="fig_bsa_sparsity_line_new" src="https://github.com/user-attachments/assets/6ff3d232-2b7e-467f-8300-e2916a6a70e6" />
