### PR TITLE
Add stem scoring ops for pre-prefill (Prepare Q,K,V/OAM/TPD, two quant schemes, dim=128)

### DIFF
--- a/hpc/stem.py
+++ b/hpc/stem.py
@@ -1,0 +1,459 @@
+"""Stem sparse attention operators.
+
+This module provides CUDA-accelerated operators for the Stem sparse attention
+pipeline, including QKV preprocessing (prep), scoring (oam), and
+top-k/mask generation (tpd).
+"""
+
+from typing import Tuple
+
+import torch
+from torch import Tensor
+
+from .attention import QuantType
+
+
+def stem_oam_prep_paged_kv(
+    kcache: Tensor,
+    vcache: Tensor,
+    kscale: Tensor,
+    vscale: Tensor,
+    kv_indices: Tensor,
+    kv_seq_lens: Tensor,
+    lambda_mag: float = 0.3,
+    stem_block_size: int = 128,
+    stem_stride: int = 16,
+    quant_type: QuantType = QuantType.QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR,
+) -> Tuple[Tensor, Tensor]:
+    """Precompute K_flat and V_bias from paged FP8 KV cache.
+
+    First stage of the Stem sparse scoring pipeline:
+      - K_flat (BF16): group-summed K vectors (scaled by kscale) for OAM-GEMM.
+      - V_bias (FP32): per-block importance bias from V norm statistics.
+
+    Args:
+        kcache: Paged K cache.
+            Shape: [num_blocks, kv_block_size, num_kv_heads, dim_qk=128]
+            Dtype: float8_e4m3fn
+        vcache: Paged V cache.
+            Shape: [num_blocks, kv_block_size, num_kv_heads, dim_v=128]
+            Dtype: float8_e4m3fn
+        kscale: K FP8 dequantization scale.
+            Shape depends on `quant_type`:
+              - QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR: [1], fp32.
+              - QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD:
+                  [num_blocks, scale_block_size, num_kv_heads, num_dim_scale],
+                  fp32 dtype OR fp8 view of the same fp32 storage.
+        vscale: V FP8 dequantization scale.
+            QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR: [1], fp32.
+            QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD: per-head vector [num_kv_heads], fp32.
+        kv_indices: Paged block table mapping logical to physical blocks.
+            Shape: [num_batch, max_blocks_per_req], Dtype: int32
+        kv_seq_lens: KV sequence length per request.
+            Shape: [num_batch], Dtype: int32
+        lambda_mag: Scaling coefficient for V_bias (default 0.3).
+        stem_block_size: Stem sparse scoring block size (default 128).
+        stem_stride: Downsampling stride (default 16).
+        quant_type: Scale dispatch for the dim128 paged path.
+
+    Returns:
+        kflat: Group-summed K vectors with reversed group order for anti-diag scoring.
+            Shape: [num_batch, num_kv_heads, max_Kb, stem_stride * dim_qk]
+            Dtype: bfloat16
+        vbias: Per-block V importance bias scalar.
+            Shape: [num_batch, num_kv_heads, max_Kb]
+            Dtype: float32
+    """
+    return torch.ops.hpc.stem_oam_prep_paged_kv(
+        kcache,
+        vcache,
+        kscale,
+        vscale,
+        kv_indices,
+        kv_seq_lens,
+        lambda_mag,
+        stem_block_size,
+        stem_stride,
+        quant_type.value,
+    )
+
+
+def stem_oam_prep_varlen_q(
+    q_fp8: Tensor,
+    qscale: Tensor,
+    q_seq_lens: Tensor,
+    cu_seqlens_q: Tensor,
+    stem_block_size: int = 128,
+    stem_stride: int = 16,
+) -> Tensor:
+    """Precompute dim128 Q_flat from packed FP8 Q tensor.
+
+    Computes weighted group-sum of Q tokens using per-token qscale (Q FP8
+    dequantization scale). kscale is handled separately in KV prep.
+
+    Args:
+        q_fp8: Per-token query vectors (packed across requests).
+            Shape: [total_tokens, num_q_heads, dim_qk=128]
+            Dtype: float8_e4m3fn
+        qscale: Q FP8 dequantization scale.
+            Shape: [num_batch, num_q_heads, max_seq_q_pad]
+            Dtype: float32
+        q_seq_lens: Q sequence length per request.
+            Shape: [num_batch], Dtype: int32
+        cu_seqlens_q: Cumulative Q sequence lengths.
+            Shape: [num_batch + 1], Dtype: int32
+        stem_block_size: Stem sparse scoring block size (default 128).
+        stem_stride: Downsampling stride (default 16).
+
+    Returns:
+        qflat: Weighted group-summed Q vectors in natural group order.
+            Shape: [num_batch, num_q_heads, max_Qb, stem_stride * dim_qk]
+            Dtype: bfloat16
+    """
+    return torch.ops.hpc.stem_oam_prep_varlen_q(
+        q_fp8,
+        qscale,
+        q_seq_lens,
+        cu_seqlens_q,
+        stem_block_size,
+        stem_stride,
+    )
+
+
+def stem_oam_gemm(
+    qflat: Tensor,
+    kflat: Tensor,
+    vbias: Tensor,
+    q_seq_lens: Tensor,
+    kv_seq_lens: Tensor,
+    stem_block_size: int = 128,
+    stem_stride: int = 16,
+    causal: bool = True,
+) -> Tensor:
+    """Compute dim128 block_logits via OAM GEMM with fused causal mask epilogue.
+
+    Performs block_logits = FrobScale * (Qflat @ Kflat^T) + V_bias, with
+    optional causal masking. Invalid positions are set to -inf.
+
+    Args:
+        qflat: Precomputed Q flat vectors.
+            Shape: [num_batch, num_q_heads, max_Qb, stem_stride * dim_qk=128]
+            Dtype: bfloat16
+        kflat: Precomputed K flat vectors.
+            Shape: [num_batch, num_kv_heads, max_Kb, stem_stride * dim_qk=128]
+            Dtype: bfloat16
+        vbias: Per-block V importance bias.
+            Shape: [num_batch, num_kv_heads, max_Kb]
+            Dtype: float32
+        q_seq_lens: Q sequence length per request.
+            Shape: [num_batch], Dtype: int32
+        kv_seq_lens: KV sequence length per request.
+            Shape: [num_batch], Dtype: int32
+        stem_block_size: Stem sparse scoring block size (default 128).
+        stem_stride: Downsampling stride (default 16).
+        causal: Whether to apply causal masking (default True).
+
+    Returns:
+        block_logits: OAM GEMM scores + V_bias, -inf for masked positions.
+            Shape: [num_batch, num_q_heads, max_Qb, max_Kb]
+            Dtype: bfloat16
+    """
+    return torch.ops.hpc.stem_oam_gemm(
+        qflat,
+        kflat,
+        vbias,
+        q_seq_lens,
+        kv_seq_lens,
+        stem_block_size,
+        stem_stride,
+        causal,
+    )
+
+
+def stem_tpd(
+    block_logits: Tensor,
+    q_seq_lens: Tensor,
+    kv_seq_lens: Tensor,
+    num_prompt_tokens: Tensor,
+    block_size: int = 128,
+    alpha: float = 1.0,
+    initial_blocks: int = 4,
+    window_size: int = 4,
+    k_block_num_rate_medium: float = 0.2,
+    k_block_num_bias_medium: int = 30,
+    k_block_num_rate_large: float = 0.1,
+    k_block_num_bias_large: int = 30,
+) -> Tensor:
+    """Generate sparse block mask via top-k policy denoising.
+
+    Fuses per-row budget (3-regime k_schedule + linear decay, both keyed on
+    the full prompt KV length so the result is chunked-prefill invariant),
+    radix top-k threshold, and fixed retention (initial / window / diagonal).
+
+    Args:
+        block_logits: Block-level OAM scores.
+            Shape: [num_batch, num_q_heads, max_Qb, max_Kb]
+            Dtype: bfloat16 (invalid positions set to -inf)
+        q_seq_lens: Q sequence length per request (current chunk).
+            Shape: [num_batch], Dtype: int32
+        kv_seq_lens: KV sequence length per request (cumulative through current chunk).
+            Shape: [num_batch], Dtype: int32
+        num_prompt_tokens: Full prompt KV-token count per request. For
+            chunked prefill pass the same value for every chunk of one
+            prompt; for normal prefill pass ``kv_seq_lens``.
+            Shape: [num_batch], Dtype: int32
+        block_size: Stem sparse scoring block size (default 128).
+        alpha: Per-row budget decay factor (default 1.0 disables decay).
+        initial_blocks: Leading KV blocks always retained (default 4).
+        window_size: Recent diagonal-adjacent blocks always retained (default 4).
+        k_block_num_rate_medium: k_schedule multiplier when
+            56 <= prompt_kv_blocks < 160 (default 0.2).
+        k_block_num_bias_medium: k_schedule bias in the medium regime (default 30).
+        k_block_num_rate_large: k_schedule multiplier when
+            prompt_kv_blocks >= 160 (default 0.1).
+        k_block_num_bias_large: k_schedule bias in the large regime (default 30).
+
+    Returns:
+        mask: Per-block selection byte-mask.
+            Shape: [num_batch, num_q_heads, max_Qb, max_Kb]
+            Dtype: uint8  (1 = selected, 0 = skipped)
+    """
+    return torch.ops.hpc.stem_tpd(
+        block_logits,
+        q_seq_lens,
+        kv_seq_lens,
+        num_prompt_tokens,
+        block_size,
+        alpha,
+        initial_blocks,
+        window_size,
+        k_block_num_rate_medium,
+        k_block_num_bias_medium,
+        k_block_num_rate_large,
+        k_block_num_bias_large,
+    )
+
+
+def stem_paged_kv(
+    q_fp8: Tensor,
+    kcache: Tensor,
+    vcache: Tensor,
+    qscale: Tensor,
+    kscale: Tensor,
+    vscale: Tensor,
+    kv_indices: Tensor,
+    cu_seqlens_q: Tensor,
+    kv_seq_lens: Tensor,
+    num_prompt_tokens: Tensor,
+    lambda_mag: float = 0.3,
+    alpha: float = 1.0,
+    stem_block_size: int = 128,
+    stem_stride: int = 16,
+    causal: bool = True,
+    initial_blocks: int = 4,
+    window_size: int = 4,
+    k_block_num_rate_medium: float = 0.2,
+    k_block_num_bias_medium: int = 30,
+    k_block_num_rate_large: float = 0.1,
+    k_block_num_bias_large: int = 30,
+    quant_type: QuantType = QuantType.QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR,
+) -> Tensor:
+    """End-to-end Stem sparse mask generation for paged FP8 KV cache (dim_qk=128).
+
+    Fuses the full OAM + TPD pipeline into a single call:
+      1. prep_paged_kv  -> kflat, vbias
+      2. prep_varlen_q  -> qflat
+      3. oam_gemm       -> block_logits
+      4. tpd            -> u8 sparse mask
+
+    Args:
+        q_fp8: Packed query vectors.
+            Shape: [total_tokens, num_q_heads, 128], Dtype: float8_e4m3fn
+        kcache: Paged K cache.
+            Shape: [num_blocks, kv_block_size, num_kv_heads, dim_qk=128], Dtype: float8_e4m3fn
+        vcache: Paged V cache.
+            Shape: [num_blocks, kv_block_size, num_kv_heads, dim_v=128], Dtype: float8_e4m3fn
+        qscale: Per-token per-head Q dequantization scale.
+            Shape: [num_batch, num_q_heads, max_seq_q_pad], Dtype: float32
+        kscale: K dequantization scale (shape depends on `quant_type`, see
+            `stem_oam_prep_paged_kv` for details).
+        vscale: V dequantization scale (shape depends on `quant_type`).
+        kv_indices: Block table (logical -> physical).
+            Shape: [num_batch, max_blocks_per_req], Dtype: int32
+        cu_seqlens_q: Cumulative Q sequence lengths.
+            Shape: [num_batch + 1], Dtype: int32
+        kv_seq_lens: KV sequence length per request (cumulative through current chunk).
+            Shape: [num_batch], Dtype: int32
+        num_prompt_tokens: Full prompt KV-token count per request. For
+            chunked prefill pass the same value for every chunk of one
+            prompt; for normal prefill pass ``kv_seq_lens``.
+            Shape: [num_batch], Dtype: int32
+        lambda_mag: V-bias scaling coefficient (default 0.3).
+        alpha: TPD budget decay factor (default 1.0; see ``stem_tpd``).
+        stem_block_size: Sparse scoring block size (default 128).
+        stem_stride: Downsampling stride (default 16).
+        causal: Apply causal masking (default True).
+        initial_blocks: Leading KV blocks always retained (default 4).
+        window_size: Recent diagonal-adjacent blocks always retained (default 4).
+        k_block_num_rate_medium: k_schedule multiplier when
+            56 <= prompt_kv_blocks < 160 (default 0.2).
+        k_block_num_bias_medium: k_schedule bias in the medium regime (default 30).
+        k_block_num_rate_large: k_schedule multiplier when
+            prompt_kv_blocks >= 160 (default 0.1).
+        k_block_num_bias_large: k_schedule bias in the large regime (default 30).
+        quant_type: Scale dispatch for dim128. Defaults to
+            QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR; pass
+            QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD for per-token K-scale
+            and per-head V-scale.
+
+    Returns:
+        mask: Per-block selection byte-mask.
+            Shape: [num_batch, num_q_heads, max_Qb, max_Kb], Dtype: uint8
+    """
+    q_seq_lens = (cu_seqlens_q[1:] - cu_seqlens_q[:-1]).to(torch.int32)
+
+    kflat, vbias = stem_oam_prep_paged_kv(
+        kcache,
+        vcache,
+        kscale,
+        vscale,
+        kv_indices,
+        kv_seq_lens,
+        lambda_mag,
+        stem_block_size,
+        stem_stride,
+        quant_type,
+    )
+    qflat = stem_oam_prep_varlen_q(
+        q_fp8,
+        qscale,
+        q_seq_lens,
+        cu_seqlens_q,
+        stem_block_size,
+        stem_stride,
+    )
+    block_logits = stem_oam_gemm(
+        qflat,
+        kflat,
+        vbias,
+        q_seq_lens,
+        kv_seq_lens,
+        stem_block_size,
+        stem_stride,
+        causal,
+    )
+    mask = stem_tpd(
+        block_logits,
+        q_seq_lens,
+        kv_seq_lens,
+        num_prompt_tokens,
+        stem_block_size,
+        alpha,
+        initial_blocks,
+        window_size,
+        k_block_num_rate_medium,
+        k_block_num_bias_medium,
+        k_block_num_rate_large,
+        k_block_num_bias_large,
+    )
+    return mask
+
+
+@torch.library.register_fake("hpc::stem_oam_prep_paged_kv")
+def _stem_oam_prep_paged_kv_fake(
+    kcache,
+    vcache,
+    kscale,
+    vscale,
+    kv_indices,
+    kv_seq_lens,
+    lambda_mag,
+    stem_block_size,
+    stem_stride,
+    quant_type,
+):
+    num_batch = kv_seq_lens.size(0)
+    num_head_kv = kcache.size(2)
+    dim_qk = kcache.size(3)
+    # Conservative upper bound: assume max sequence fills all pages
+    max_blocks_per_req = kv_indices.size(1)
+    kv_block_size = kcache.size(1)
+    max_kv_len = max_blocks_per_req * kv_block_size
+    max_kv_padded = ((max_kv_len + stem_block_size - 1) // stem_block_size) * stem_block_size
+    max_Kb = max_kv_padded // stem_block_size
+    kflat_dim = stem_stride * dim_qk
+
+    kflat = torch.empty(
+        (num_batch, num_head_kv, max_Kb, kflat_dim),
+        dtype=torch.bfloat16,
+        device=kcache.device,
+    )
+    vbias = torch.empty(
+        (num_batch, num_head_kv, max_Kb),
+        dtype=torch.float32,
+        device=kcache.device,
+    )
+    return kflat, vbias
+
+
+@torch.library.register_fake("hpc::stem_oam_prep_varlen_q")
+def _stem_oam_prep_varlen_q_fake(
+    q_fp8,
+    qscale,
+    q_seq_lens,
+    cu_seqlens_q,
+    stem_block_size,
+    stem_stride,
+):
+    num_batch = q_seq_lens.size(0)
+    num_head_q = q_fp8.size(1)
+    dim_qk = q_fp8.size(2)
+    qflat_dim = stem_stride * dim_qk
+    max_seq_q_pad = qscale.size(2)
+    max_q_padded = ((max_seq_q_pad + stem_block_size - 1) // stem_block_size) * stem_block_size
+    max_Qb = max_q_padded // stem_block_size
+    return torch.empty(
+        (num_batch, num_head_q, max_Qb, qflat_dim),
+        dtype=torch.bfloat16,
+        device=q_fp8.device,
+    )
+
+
+@torch.library.register_fake("hpc::stem_oam_gemm")
+def _stem_oam_gemm_fake(
+    qflat,
+    kflat,
+    vbias,
+    q_seq_lens,
+    kv_seq_lens,
+    stem_block_size,
+    stem_stride,
+    causal,
+):
+    num_batch = qflat.size(0)
+    num_head_q = qflat.size(1)
+    max_Qb = qflat.size(2)
+    max_Kb = kflat.size(2)
+    return torch.empty(
+        (num_batch, num_head_q, max_Qb, max_Kb),
+        dtype=torch.bfloat16,
+        device=qflat.device,
+    )
+
+
+@torch.library.register_fake("hpc::stem_tpd")
+def _stem_tpd_fake(
+    block_logits,
+    q_seq_lens,
+    kv_seq_lens,
+    num_prompt_tokens,
+    block_size,
+    alpha,
+    initial_blocks,
+    window_size,
+    k_block_num_rate_medium,
+    k_block_num_bias_medium,
+    k_block_num_rate_large,
+    k_block_num_bias_large,
+):
+    return torch.empty_like(block_logits, dtype=torch.uint8)

--- a/src/stem/entry.cc
+++ b/src/stem/entry.cc
@@ -1,0 +1,298 @@
+// Copyright (C) 2026 Tencent.
+
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime_api.h>
+#include <torch/all.h>
+#include <torch/library.h>
+
+#include <algorithm>
+#include <tuple>
+
+#include "src/stem/stem_oam_gemm_dim128.h"
+#include "src/stem/stem_oam_prep_paged_kv_dim128.h"
+#include "src/stem/stem_oam_prep_varlen_q_dim128.h"
+#include "src/stem/stem_tpd.h"
+
+namespace hpc {
+namespace stem {
+
+// Returns (kflat, vbias) from paged KV cache.
+// kflat: [num_batch, num_head_kv, max_Kb, stem_stride * dim_qk]  BF16
+// vbias: [num_batch, num_head_kv, max_Kb]                        FP32
+std::tuple<torch::Tensor, torch::Tensor> stem_oam_prep_paged_kv_entry(
+    const torch::Tensor &kcache, const torch::Tensor &vcache, const torch::Tensor &kscale,
+    const torch::Tensor &vscale, const torch::Tensor &kv_indices, const torch::Tensor &kv_seq_lens,
+    double lambda_mag, int64_t stem_block_size, int64_t stem_stride, int64_t quant_type) {
+  auto stream = at::cuda::getCurrentCUDAStream(kcache.get_device());
+
+  TORCH_CHECK(kcache.device().is_cuda(), "kcache must be CUDA tensor");
+  TORCH_CHECK(vcache.device().is_cuda(), "vcache must be CUDA tensor");
+  TORCH_CHECK(kscale.device().is_cuda(), "kscale must be CUDA tensor");
+  TORCH_CHECK(vscale.device().is_cuda(), "vscale must be CUDA tensor");
+  TORCH_CHECK(kv_indices.device().is_cuda(), "kv_indices must be CUDA tensor");
+  TORCH_CHECK(kv_seq_lens.device().is_cuda(), "kv_seq_lens must be CUDA tensor");
+  TORCH_CHECK((quant_type == 0 || quant_type == 1), "quant_type only support 0/1");
+  TORCH_CHECK((kscale.dtype().itemsize() == 4 || kscale.dtype().itemsize() == 1),
+              "kscale dtype must be float or fp8");
+  TORCH_CHECK(stem_block_size == 128 && stem_stride == 16,
+              "stem_oam_prep_paged_kv: only stem_block_size=128, stem_stride=16 is supported");
+
+  // kcache: [num_kvcache_blocks, kv_block_size, num_head_kv, dim_qk]
+  int num_kvcache_blocks = kcache.size(0);
+  int block_size = kcache.size(1);
+  TORCH_CHECK(block_size == 32 || block_size == 64,
+              "stem_oam_prep_paged_kv: kv_block_size must be 32 or 64, got ", block_size);
+  int num_head_kv = kcache.size(2);
+  int num_dim_qk = kcache.size(3);
+  int num_dim_v = vcache.size(3);
+
+  int num_batch = kv_seq_lens.size(0);
+  int num_seq_max_blocks = kv_indices.size(1);
+
+  int ldK = kcache.stride(0);
+  int ldV = vcache.stride(0);
+
+  int64_t max_kv_len = kv_seq_lens.max().item<int64_t>();
+  int64_t max_kv_padded = ((max_kv_len + stem_block_size - 1) / stem_block_size) * stem_block_size;
+  int max_num_stem_blocks = static_cast<int>(max_kv_padded / stem_block_size);
+  int max_k_down_len = static_cast<int>(max_kv_padded / stem_stride);
+
+  int kflat_inner = static_cast<int>(stem_stride * num_dim_qk);
+
+  auto kflat = torch::empty({num_batch, num_head_kv, max_num_stem_blocks, kflat_inner},
+                            kcache.options().dtype(torch::kBFloat16));
+
+  auto vbias = torch::empty({num_batch, num_head_kv, max_num_stem_blocks},
+                            kcache.options().dtype(torch::kFloat32));
+
+  auto v_norm_down = torch::empty({num_batch, num_head_kv, max_k_down_len},
+                                  kcache.options().dtype(torch::kFloat32));
+
+  TORCH_CHECK(num_dim_qk == 128 && num_dim_v == 128,
+              "stem_oam_prep_paged_kv: unsupported dim_qk=", num_dim_qk, " dim_v=", num_dim_v,
+              " (expected dim_qk=128, dim_v=128)");
+
+  if (quant_type == 1) {
+    stem_oam_prep_paged_kv_qpertoken_perhead_kvpertensor_dim128_async(
+        kflat.data_ptr(), vbias.data_ptr(), kcache.const_data_ptr(), vcache.const_data_ptr(),
+        kscale.const_data_ptr(), vscale.const_data_ptr(), kv_indices.const_data_ptr(),
+        kv_seq_lens.const_data_ptr(), num_batch, num_dim_qk, num_dim_v, num_head_kv,
+        num_kvcache_blocks, block_size, num_seq_max_blocks, static_cast<int>(stem_block_size),
+        static_cast<int>(stem_stride), static_cast<float>(lambda_mag), max_num_stem_blocks,
+        max_k_down_len, ldK, ldV, v_norm_down.data_ptr(), stream);
+  } else if (quant_type == 0) {
+    int ldKS = 0;
+    int ldKS1 = 0;
+    int ldKS2 = 0;
+    if (kscale.dtype().itemsize() == 4) {
+      ldKS = kscale.stride(0);
+      ldKS1 = kscale.stride(1);
+      ldKS2 = kscale.stride(2);
+    } else if (kscale.dtype().itemsize() == 1) {
+      ldKS = kscale.stride(0) / sizeof(float);
+      ldKS1 = kscale.stride(1) / sizeof(float);
+      ldKS2 = kscale.stride(2) / sizeof(float);
+    }
+    int scale_block_size = static_cast<int>(kscale.size(1));
+    stem_oam_prep_paged_kv_qkpertoken_perhead_vperhead_dim128_async(
+        kflat.data_ptr(), vbias.data_ptr(), kcache.const_data_ptr(), vcache.const_data_ptr(),
+        kscale.const_data_ptr(), vscale.const_data_ptr(), kv_indices.const_data_ptr(),
+        kv_seq_lens.const_data_ptr(), num_batch, num_dim_qk, num_dim_v, num_head_kv,
+        num_kvcache_blocks, block_size, scale_block_size, num_seq_max_blocks,
+        static_cast<int>(stem_block_size), static_cast<int>(stem_stride),
+        static_cast<float>(lambda_mag), max_num_stem_blocks, max_k_down_len, ldK, ldV, ldKS, ldKS1,
+        ldKS2, v_norm_down.data_ptr(), stream);
+  }
+
+  return std::make_tuple(kflat, vbias);
+}
+
+// Returns (kflat, vbias) from ragged varlen FP8 KV.
+
+// Returns dim128 qflat [num_batch, num_head_q, max_Qb, stem_stride * dim_qk] BF16.
+torch::Tensor stem_oam_prep_varlen_q_entry(const torch::Tensor &q_fp8, const torch::Tensor &qscale,
+                                           const torch::Tensor &q_seq_lens,
+                                           const torch::Tensor &cu_seqlens_q,
+                                           int64_t stem_block_size, int64_t stem_stride) {
+  auto stream = at::cuda::getCurrentCUDAStream(q_fp8.get_device());
+
+  TORCH_CHECK(q_fp8.device().is_cuda(), "q_fp8 must be CUDA tensor");
+  TORCH_CHECK(q_fp8.is_contiguous(), "q_fp8 must be contiguous");
+  TORCH_CHECK(qscale.device().is_cuda(), "qscale must be CUDA tensor");
+  TORCH_CHECK(q_seq_lens.device().is_cuda(), "q_seq_lens must be CUDA tensor");
+  TORCH_CHECK(cu_seqlens_q.device().is_cuda(), "cu_seqlens_q must be CUDA tensor");
+  TORCH_CHECK(stem_block_size == 128 && stem_stride == 16,
+              "stem_oam_prep_varlen_q: only stem_block_size=128, stem_stride=16 is supported");
+
+  // q_fp8: [total_q, Hq, Dqk]
+  int num_head_q = q_fp8.size(1);
+  int num_dim_qk = q_fp8.size(2);
+  int num_batch = q_seq_lens.size(0);
+  int ldQ = q_fp8.stride(0);
+  TORCH_CHECK(num_dim_qk == 128, "stem_oam_prep_varlen_q: expected dim_qk=128, got ", num_dim_qk);
+  TORCH_CHECK(qscale.dim() == 3, "stem_oam_prep_varlen_q: qscale must be [B, Hq, max_q_pad]");
+
+  int64_t max_q_len = q_seq_lens.max().item<int64_t>();
+  int64_t max_q_padded = ((max_q_len + stem_block_size - 1) / stem_block_size) * stem_block_size;
+  int max_num_q_blocks = static_cast<int>(max_q_padded / stem_block_size);
+
+  int qflat_inner = static_cast<int>(stem_stride) * num_dim_qk;
+
+  auto qflat = torch::empty({num_batch, num_head_q, max_num_q_blocks, qflat_inner},
+                            q_fp8.options().dtype(torch::kBFloat16));
+
+  stem_oam_prep_varlen_q_dim128_async(
+      qflat.data_ptr(), q_fp8.const_data_ptr(), qscale.const_data_ptr(),
+      q_seq_lens.const_data_ptr(), cu_seqlens_q.const_data_ptr(), num_batch, num_head_q, ldQ,
+      static_cast<int>(stem_block_size), static_cast<int>(stem_stride), max_num_q_blocks, stream);
+
+  return qflat;
+}
+
+// Returns dim128 block_logits [num_batch, num_head_q, max_Qb, max_Kb] BF16.
+// All invalid positions (causal / OOB / padding) are set to -inf.
+torch::Tensor stem_oam_gemm_entry(const torch::Tensor &qflat, const torch::Tensor &kflat,
+                                  const torch::Tensor &vbias, const torch::Tensor &q_seq_lens,
+                                  const torch::Tensor &kv_seq_lens, int64_t stem_block_size,
+                                  int64_t stem_stride, bool causal) {
+  auto stream = at::cuda::getCurrentCUDAStream(qflat.get_device());
+
+  TORCH_CHECK(qflat.device().is_cuda(), "qflat must be CUDA tensor");
+  TORCH_CHECK(kflat.device().is_cuda(), "kflat must be CUDA tensor");
+  TORCH_CHECK(vbias.device().is_cuda(), "vbias must be CUDA tensor");
+  TORCH_CHECK(q_seq_lens.device().is_cuda(), "q_seq_lens must be CUDA tensor");
+  TORCH_CHECK(kv_seq_lens.device().is_cuda(), "kv_seq_lens must be CUDA tensor");
+  TORCH_CHECK(stem_block_size == 128 && stem_stride == 16,
+              "stem_oam_gemm: only stem_block_size=128, stem_stride=16 is supported");
+  TORCH_CHECK(kv_seq_lens.device().is_cuda(), "kv_seq_lens must be CUDA tensor");
+
+  // qflat:  [B, Hq,  max_num_qb, qFlatDim]
+  // kflat:  [B, Hkv, max_num_kb, kFlatDim]
+  // vbias:  [B, Hkv, max_num_kb]
+  int num_batch = qflat.size(0);
+  int num_head_q = qflat.size(1);
+  int max_num_qb = qflat.size(2);
+  int kflat_inner = qflat.size(3);
+
+  int num_head_kv = kflat.size(1);
+  int max_num_kb = kflat.size(2);
+
+  TORCH_CHECK(qflat.size(0) == kflat.size(0),
+              "stem_oam_gemm: batch size mismatch between qflat and kflat");
+  TORCH_CHECK(qflat.size(3) == kflat.size(3), "stem_oam_gemm: kFlatDim mismatch between qflat (",
+              qflat.size(3), ") and kflat (", kflat.size(3), ")");
+  TORCH_CHECK(num_head_q % num_head_kv == 0, "stem_oam_gemm: num_head_q (", num_head_q,
+              ") must be divisible by num_head_kv (", num_head_kv, ")");
+  TORCH_CHECK(
+      vbias.size(0) == num_batch && vbias.size(1) == num_head_kv && vbias.size(2) == max_num_kb,
+      "stem_oam_gemm: vbias shape mismatch, expected [", num_batch, ", ", num_head_kv, ", ",
+      max_num_kb, "]");
+
+  int num_dim_qk = kflat_inner / static_cast<int>(stem_stride);
+  TORCH_CHECK(num_dim_qk == 128, "stem_oam_gemm: expected dim_qk=128, got ", num_dim_qk);
+
+  // qflat/kflat are used directly — TMA Load zero-fills OOB reads.
+  // Only block_logits needs padding for TMA Store (copy box [64, 128]):
+  //   dim2 >= 64 and multiple of 64
+  //   dim3 >= 128 and multiple of 64 (for 128B stride alignment)
+  int logits_qb = std::max(((max_num_qb + 63) / 64) * 64, 64);
+  int logits_kb = std::max(((max_num_kb + 63) / 64) * 64, 128);
+
+  auto block_logits =
+      torch::full({num_batch, num_head_q, logits_qb, logits_kb},
+                  -std::numeric_limits<float>::infinity(), qflat.options().dtype(torch::kBFloat16));
+
+  stem_oam_gemm_dim128_async(
+      block_logits.data_ptr(), qflat.const_data_ptr(), kflat.const_data_ptr(),
+      vbias.const_data_ptr(), q_seq_lens.const_data_ptr(), kv_seq_lens.const_data_ptr(), num_batch,
+      num_head_q, num_head_kv, max_num_qb, max_num_kb, static_cast<int>(stem_block_size),
+      static_cast<int>(stem_stride), causal, stream);
+
+  // Slice back to real shape. No-op when no padding; cheap copy for short sequences.
+  if (logits_qb == max_num_qb && logits_kb == max_num_kb) {
+    return block_logits;
+  }
+  return block_logits.slice(2, 0, max_num_qb).slice(3, 0, max_num_kb).contiguous();
+}
+
+// Returns u8_mask [num_batch, num_heads, max_Qb, max_Kb] uint8.
+// `num_prompt_tokens` ([num_batch] int32) is the full prompt KV-token count
+// per request (chunked-invariant; pass kv_seq_lens for normal prefill).
+torch::Tensor stem_tpd_entry(const torch::Tensor &block_logits, const torch::Tensor &q_seq_lens,
+                             const torch::Tensor &kv_seq_lens,
+                             const torch::Tensor &num_prompt_tokens, int64_t block_size,
+                             double alpha, int64_t initial_blocks, int64_t window_size,
+                             double k_block_num_rate_medium, int64_t k_block_num_bias_medium,
+                             double k_block_num_rate_large, int64_t k_block_num_bias_large) {
+  auto stream = at::cuda::getCurrentCUDAStream(block_logits.get_device());
+
+  TORCH_CHECK(block_logits.device().is_cuda(), "block_logits must be CUDA tensor");
+  TORCH_CHECK(q_seq_lens.device().is_cuda(), "q_seq_lens must be CUDA tensor");
+  TORCH_CHECK(kv_seq_lens.device().is_cuda(), "kv_seq_lens must be CUDA tensor");
+  TORCH_CHECK(num_prompt_tokens.device().is_cuda(), "num_prompt_tokens must be CUDA tensor");
+  TORCH_CHECK(block_logits.dtype() == torch::kBFloat16, "block_logits must be bfloat16");
+  TORCH_CHECK(block_logits.is_contiguous(), "block_logits must be contiguous");
+  TORCH_CHECK(q_seq_lens.dtype() == torch::kInt32, "q_seq_lens must be int32, got ",
+              q_seq_lens.dtype());
+  TORCH_CHECK(kv_seq_lens.dtype() == torch::kInt32, "kv_seq_lens must be int32, got ",
+              kv_seq_lens.dtype());
+  TORCH_CHECK(num_prompt_tokens.dtype() == torch::kInt32, "num_prompt_tokens must be int32, got ",
+              num_prompt_tokens.dtype());
+
+  // block_logits: [B, Hq, max_Qb, max_Kb]
+  int num_batch = block_logits.size(0);
+  int num_heads = block_logits.size(1);
+  int max_Qb = block_logits.size(2);
+  int max_Kb = block_logits.size(3);
+
+  TORCH_CHECK(num_prompt_tokens.dim() == 1 && num_prompt_tokens.size(0) == num_batch,
+              "num_prompt_tokens must have shape [num_batch=", num_batch, "], got ",
+              num_prompt_tokens.sizes());
+
+  // Maximum number of blocks (4M tokens) supported by TPD kernel
+  TORCH_CHECK(max_Kb <= 32768, "stem_tpd: max_Kb=", max_Kb, " exceeds 32768 limit");
+
+  auto mask = torch::zeros({num_batch, num_heads, max_Qb, max_Kb},
+                           block_logits.options().dtype(torch::kUInt8));
+
+  stem_tpd_async(
+      mask.data_ptr(), block_logits.const_data_ptr(), q_seq_lens.const_data_ptr(),
+      kv_seq_lens.const_data_ptr(), num_prompt_tokens.const_data_ptr(), num_batch, num_heads,
+      max_Qb, max_Kb, static_cast<int>(block_size), static_cast<float>(alpha),
+      static_cast<int>(initial_blocks), static_cast<int>(window_size),
+      static_cast<float>(k_block_num_rate_medium), static_cast<int>(k_block_num_bias_medium),
+      static_cast<float>(k_block_num_rate_large), static_cast<int>(k_block_num_bias_large), stream);
+
+  return mask;
+}
+
+TORCH_LIBRARY_FRAGMENT(hpc, m) {
+  m.def(
+      "stem_oam_prep_paged_kv(Tensor kcache, Tensor vcache, "
+      "Tensor kscale, Tensor vscale, Tensor kv_indices, Tensor kv_seq_lens, "
+      "float lambda_mag, int stem_block_size, int stem_stride, int quant_type) "
+      "-> (Tensor, Tensor)");
+  m.impl("stem_oam_prep_paged_kv", torch::kCUDA, &hpc::stem::stem_oam_prep_paged_kv_entry);
+
+  m.def(
+      "stem_oam_prep_varlen_q(Tensor q_fp8, Tensor qscale, Tensor q_seq_lens, "
+      "Tensor cu_seqlens_q, int stem_block_size, int stem_stride) -> Tensor");
+  m.impl("stem_oam_prep_varlen_q", torch::kCUDA, &hpc::stem::stem_oam_prep_varlen_q_entry);
+
+  m.def(
+      "stem_oam_gemm(Tensor qflat, Tensor kflat, Tensor vbias, "
+      "Tensor q_seq_lens, Tensor kv_seq_lens, "
+      "int stem_block_size, int stem_stride, bool causal) -> Tensor");
+  m.impl("stem_oam_gemm", torch::kCUDA, &hpc::stem::stem_oam_gemm_entry);
+
+  m.def(
+      "stem_tpd(Tensor block_logits, Tensor q_seq_lens, Tensor kv_seq_lens, "
+      "Tensor num_prompt_tokens, "
+      "int block_size, float alpha, int initial_blocks, int window_size, "
+      "float k_block_num_rate_medium, int k_block_num_bias_medium, "
+      "float k_block_num_rate_large, int k_block_num_bias_large) -> Tensor");
+  m.impl("stem_tpd", torch::kCUDA, &hpc::stem::stem_tpd_entry);
+}
+
+}  // namespace stem
+}  // namespace hpc

--- a/src/stem/stem_kernels.cuh
+++ b/src/stem/stem_kernels.cuh
@@ -1,0 +1,1244 @@
+// Copyright (C) 2026 Tencent.
+
+#ifndef SRC_STEM_STEM_KERNELS_CUH_
+#define SRC_STEM_STEM_KERNELS_CUH_
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#include <algorithm>
+
+#include "cute/tensor.hpp"
+#include "cutlass/arch/reg_reconfig.h"
+#include "cutlass/fast_math.h"
+#include "src/utils/tma.cuh"
+#include "src/utils/utils.cuh"
+
+namespace hpc {
+namespace stem {
+namespace kernels {
+
+//  stem_prep_paged_kv_qpertoken_perhead_kvpertensor_kernel — K flat + V norm down (paged KV cache)
+//
+// Legacy quant_type=1 path: K-scale and V-scale are per-tensor scalars.
+//
+// K processing:
+//   Group g sums kSamplePerBlock rows at positions {g, g+stride, g+2*stride, ...}
+//   FP8 → FP32 accumulate × kscale → BF16.  Stored to Kflat segment (kStride-1-g) for GEMM
+//
+// V processing:
+//   Warp g computes max L2 norm over kStride consecutive rows
+//   [g*kStride .. (g+1)*kStride-1].  Writes FP32 to v_norm_down buffer.
+template <int kBlockSize, int kStemBlockSize, int kStride, int kDimQK, int kDimV>
+__global__ void __launch_bounds__(kStemBlockSize / kStride * 32)
+    stem_prep_paged_kv_qpertoken_perhead_kvpertensor_kernel(
+        const __nv_fp8_e4m3* __restrict__ kcache, const __nv_fp8_e4m3* __restrict__ vcache,
+        const float* __restrict__ kscale_ptr, const float* __restrict__ vscale_ptr,
+        const int* __restrict__ block_ids, const int* __restrict__ kv_seq_lens,
+        __nv_bfloat16* __restrict__ kflat, float* __restrict__ v_norm_down, int num_head_kv,
+        int max_blocks_per_req, int ldK, int ldV, int max_num_stem_blocks, int max_k_down_len) {
+  constexpr int kSamplePerBlock = kStemBlockSize / kStride;
+  constexpr int kElemsPerThread_K = kDimQK / 32;
+  constexpr int kElemsPerThread_V = kDimV / 32;
+
+  static_assert(kStemBlockSize % kStride == 0, "kStemBlockSize must be divisible by kStride");
+  static_assert(kStemBlockSize % kBlockSize == 0, "kStemBlockSize must be divisible by kBlockSize");
+  static_assert(kDimQK % 32 == 0, "kDimQK must be divisible by warp size");
+  static_assert(kDimV % 32 == 0, "kDimV must be divisible by warp size");
+  static_assert(kSamplePerBlock >= 1 && kSamplePerBlock <= 32,
+                "kSamplePerBlock warps must be in [1, 32] for a valid CTA");
+
+  const int stem_block_idx = blockIdx.x;
+  const int ibatch = blockIdx.y / num_head_kv;
+  const int ihead_kv = blockIdx.y % num_head_kv;
+  const int iwarp = threadIdx.x / 32;
+  const int ilane = threadIdx.x % 32;
+
+  const int kv_len = kv_seq_lens[ibatch];
+  const int k_padded_len = ((kv_len + kStemBlockSize - 1) / kStemBlockSize) * kStemBlockSize;
+  const int num_stem_blocks_req = k_padded_len / kStemBlockSize;
+  if (stem_block_idx >= num_stem_blocks_req) {
+    return;
+  }
+
+  const int stem_row_base = stem_block_idx * kStemBlockSize;
+
+  // K processing
+  const float kscale_val = kscale_ptr[0];
+#pragma unroll
+  for (int group_id = iwarp; group_id < kStride; group_id += kSamplePerBlock) {
+    vec_t<float, kElemsPerThread_K> k_acc;
+#pragma unroll
+    for (int j = 0; j < kElemsPerThread_K; j++) {
+      k_acc[j] = 0.0f;
+    }
+
+#pragma unroll
+    for (int isample = 0; isample < kSamplePerBlock; isample++) {
+      const int global_row = stem_row_base + group_id + isample * kStride;
+      if (global_row >= kv_len) {
+        continue;
+      }
+
+      const int page_idx = global_row / kBlockSize;
+      const int row_in_page = global_row % kBlockSize;
+      const int physical_block_number = block_ids[ibatch * max_blocks_per_req + page_idx];
+
+      const __nv_fp8_e4m3* k_ptr = kcache + static_cast<int64_t>(physical_block_number) * ldK +
+                                   static_cast<int64_t>(row_in_page) * num_head_kv * kDimQK +
+                                   ihead_kv * kDimQK + ilane * kElemsPerThread_K;
+
+      auto packed_fp8 = load<__nv_fp8x4_e4m3, 1>(k_ptr);
+      auto fp32_vals = to<float>(packed_fp8);
+
+#pragma unroll
+      for (int j = 0; j < kElemsPerThread_K; j++) {
+        k_acc[j] += fp32_vals[j];
+      }
+    }
+
+#pragma unroll
+    for (int j = 0; j < kElemsPerThread_K; j++) {
+      k_acc[j] *= kscale_val;
+    }
+
+    // FP32 → BF16, store with reversed group order.
+    auto k_bf16 = to<__nv_bfloat16>(k_acc);
+
+    __nv_bfloat16* kflat_out_ptr = kflat +
+                                   (static_cast<int64_t>(ibatch) * num_head_kv + ihead_kv) *
+                                       static_cast<int64_t>(max_num_stem_blocks) * kStride *
+                                       kDimQK +
+                                   static_cast<int64_t>(stem_block_idx) * kStride * kDimQK +
+                                   (kStride - 1 - group_id) * kDimQK + ilane * kElemsPerThread_K;
+
+    store(kflat_out_ptr, k_bf16);
+  }
+
+  // V processing
+  const float vscale_val = vscale_ptr[0];
+  float max_norm = 0.0f;
+
+#pragma unroll
+  for (int istep = 0; istep < kStride; istep++) {
+    const int global_row = stem_row_base + iwarp * kStride + istep;
+    if (global_row >= kv_len) {
+      continue;
+    }
+
+    const int page_idx = global_row / kBlockSize;
+    const int row_in_page = global_row % kBlockSize;
+    const int physical_block_number = block_ids[ibatch * max_blocks_per_req + page_idx];
+
+    const __nv_fp8_e4m3* v_ptr = vcache + static_cast<int64_t>(physical_block_number) * ldV +
+                                 static_cast<int64_t>(row_in_page) * num_head_kv * kDimV +
+                                 ihead_kv * kDimV + ilane * kElemsPerThread_V;
+
+    auto packed_fp8 = load<__nv_fp8x4_e4m3, 1>(v_ptr);
+    auto fp32_vals = to<float>(packed_fp8);
+
+    float partial_square = 0.0f;
+#pragma unroll
+    for (int j = 0; j < kElemsPerThread_V; j++) {
+      float val = fp32_vals[j] * vscale_val;
+      partial_square += val * val;
+    }
+
+    float norm_square = warp_reduce_sum_xor(partial_square);
+    float norm = sqrtf(norm_square);
+    max_norm = fmaxf(max_norm, norm);
+  }
+
+  // warp_reduce_sum_xor broadcasts to all lanes; only lane 0 writes.
+  if (ilane == 0) {
+    const int k_down_len = k_padded_len / kStride;
+    const int down_idx = stem_block_idx * kSamplePerBlock + iwarp;
+    if (down_idx < k_down_len) {
+      v_norm_down[(static_cast<int64_t>(ibatch) * num_head_kv + ihead_kv) * max_k_down_len +
+                  down_idx] = max_norm;
+    }
+  }
+}
+
+//  stem_prep_paged_kv_qkpertoken_perhead_vperhead_kernel — K flat + V norm down (paged KV cache)
+//
+// New quant_type=0 path: per-KV-token K-scale + per-head V-scale, mirroring the attention
+// qkpertoken_perhead_vperhead scale layout.  K-scale GMEM shape is
+// [num_blocks, kScaleBlockSize, num_head_kv, num_dim_scale] with strides ldKS / ldKS1 / ldKS2
+// (in fp32 elements); V-scale is vscale_ptr[ihead_kv].
+template <int kBlockSize, int kStemBlockSize, int kStride, int kDimQK, int kDimV>
+__global__ void __launch_bounds__(kStemBlockSize / kStride * 32)
+    stem_prep_paged_kv_qkpertoken_perhead_vperhead_kernel(
+        const __nv_fp8_e4m3* __restrict__ kcache, const __nv_fp8_e4m3* __restrict__ vcache,
+        const float* __restrict__ kscale_ptr, const float* __restrict__ vscale_ptr,
+        const int* __restrict__ block_ids, const int* __restrict__ kv_seq_lens,
+        __nv_bfloat16* __restrict__ kflat, float* __restrict__ v_norm_down, int num_head_kv,
+        int max_blocks_per_req, int ldK, int ldV, int ldKS, int ldKS1, int ldKS2,
+        int max_num_stem_blocks, int max_k_down_len) {
+  constexpr int kSamplePerBlock = kStemBlockSize / kStride;
+  constexpr int kElemsPerThread_K = kDimQK / 32;
+  constexpr int kElemsPerThread_V = kDimV / 32;
+  // kRowsPerScaleChunk mirrors attention's num_dim_scale (the row-group fan-out of
+  // the per-token K-scale layout); the historical name num_dim_scale is kept on the
+  // attention side for interface continuity.
+  constexpr int kRowsPerScaleChunk = kDimV / static_cast<int>(sizeof(float));
+
+  static_assert(kStemBlockSize % kStride == 0, "kStemBlockSize must be divisible by kStride");
+  static_assert(kStemBlockSize % kBlockSize == 0, "kStemBlockSize must be divisible by kBlockSize");
+  static_assert(kDimQK % 32 == 0, "kDimQK must be divisible by warp size");
+  static_assert(kDimV % 32 == 0, "kDimV must be divisible by warp size");
+  static_assert(kSamplePerBlock >= 1 && kSamplePerBlock <= 32,
+                "kSamplePerBlock warps must be in [1, 32] for a valid CTA");
+  static_assert(kBlockSize % kRowsPerScaleChunk == 0,
+                "kBlockSize must be a multiple of kRowsPerScaleChunk (= kDimV / sizeof(float))");
+
+  const int stem_block_idx = blockIdx.x;
+  const int ibatch = blockIdx.y / num_head_kv;
+  const int ihead_kv = blockIdx.y % num_head_kv;
+  const int iwarp = threadIdx.x / 32;
+  const int ilane = threadIdx.x % 32;
+
+  const int kv_len = kv_seq_lens[ibatch];
+  const int k_padded_len = ((kv_len + kStemBlockSize - 1) / kStemBlockSize) * kStemBlockSize;
+  const int num_stem_blocks_req = k_padded_len / kStemBlockSize;
+  if (stem_block_idx >= num_stem_blocks_req) {
+    return;
+  }
+
+  const int stem_row_base = stem_block_idx * kStemBlockSize;
+
+  // Per-token K-scales for this stem block preloaded to SMEM; padding rows get 0.0f
+  // (harmless because the K accumulator skips them below).
+  __shared__ float s_kscale[kStemBlockSize];
+#pragma unroll
+  for (int i = threadIdx.x; i < kStemBlockSize; i += blockDim.x) {
+    const int global_row = stem_row_base + i;
+    if (global_row < kv_len) {
+      const int page_idx = global_row / kBlockSize;
+      const int row_in_page = global_row % kBlockSize;
+      const int row_chunk = row_in_page / kRowsPerScaleChunk;
+      const int row_offset = row_in_page % kRowsPerScaleChunk;
+      const int phys_block = block_ids[ibatch * max_blocks_per_req + page_idx];
+      const int64_t kscale_offset =
+          static_cast<int64_t>(phys_block) * ldKS + static_cast<int64_t>(row_chunk) * ldKS1 +
+          static_cast<int64_t>(ihead_kv) * ldKS2 + static_cast<int64_t>(row_offset);
+      s_kscale[i] = kscale_ptr[kscale_offset];
+    } else {
+      s_kscale[i] = 0.0f;
+    }
+  }
+  __syncthreads();
+
+  // K processing
+#pragma unroll
+  for (int group_id = iwarp; group_id < kStride; group_id += kSamplePerBlock) {
+    vec_t<float, kElemsPerThread_K> k_acc;
+#pragma unroll
+    for (int j = 0; j < kElemsPerThread_K; j++) {
+      k_acc[j] = 0.0f;
+    }
+
+#pragma unroll
+    for (int isample = 0; isample < kSamplePerBlock; isample++) {
+      const int row_in_stem = group_id + isample * kStride;
+      const int global_row = stem_row_base + row_in_stem;
+      if (global_row >= kv_len) {
+        continue;
+      }
+
+      const int page_idx = global_row / kBlockSize;
+      const int row_in_page = global_row % kBlockSize;
+      const int physical_block_number = block_ids[ibatch * max_blocks_per_req + page_idx];
+
+      const __nv_fp8_e4m3* k_ptr = kcache + static_cast<int64_t>(physical_block_number) * ldK +
+                                   static_cast<int64_t>(row_in_page) * num_head_kv * kDimQK +
+                                   ihead_kv * kDimQK + ilane * kElemsPerThread_K;
+
+      auto packed_fp8 = load<__nv_fp8x4_e4m3, 1>(k_ptr);
+      auto fp32_vals = to<float>(packed_fp8);
+
+      const float kscale_row = s_kscale[row_in_stem];
+#pragma unroll
+      for (int j = 0; j < kElemsPerThread_K; j++) {
+        k_acc[j] += kscale_row * fp32_vals[j];
+      }
+    }
+
+    // FP32 → BF16, store with reversed group order.
+    auto k_bf16 = to<__nv_bfloat16>(k_acc);
+
+    __nv_bfloat16* kflat_out_ptr = kflat +
+                                   (static_cast<int64_t>(ibatch) * num_head_kv + ihead_kv) *
+                                       static_cast<int64_t>(max_num_stem_blocks) * kStride *
+                                       kDimQK +
+                                   static_cast<int64_t>(stem_block_idx) * kStride * kDimQK +
+                                   (kStride - 1 - group_id) * kDimQK + ilane * kElemsPerThread_K;
+
+    store(kflat_out_ptr, k_bf16);
+  }
+
+  // V processing
+  const float vscale_val = vscale_ptr[ihead_kv];
+  float max_norm = 0.0f;
+
+#pragma unroll
+  for (int istep = 0; istep < kStride; istep++) {
+    const int global_row = stem_row_base + iwarp * kStride + istep;
+    if (global_row >= kv_len) {
+      continue;
+    }
+
+    const int page_idx = global_row / kBlockSize;
+    const int row_in_page = global_row % kBlockSize;
+    const int physical_block_number = block_ids[ibatch * max_blocks_per_req + page_idx];
+
+    const __nv_fp8_e4m3* v_ptr = vcache + static_cast<int64_t>(physical_block_number) * ldV +
+                                 static_cast<int64_t>(row_in_page) * num_head_kv * kDimV +
+                                 ihead_kv * kDimV + ilane * kElemsPerThread_V;
+
+    auto packed_fp8 = load<__nv_fp8x4_e4m3, 1>(v_ptr);
+    auto fp32_vals = to<float>(packed_fp8);
+
+    float partial_square = 0.0f;
+#pragma unroll
+    for (int j = 0; j < kElemsPerThread_V; j++) {
+      float val = fp32_vals[j] * vscale_val;
+      partial_square += val * val;
+    }
+
+    float norm_square = warp_reduce_sum_xor(partial_square);
+    float norm = sqrtf(norm_square);
+    max_norm = fmaxf(max_norm, norm);
+  }
+
+  // warp_reduce_sum_xor broadcasts to all lanes; only lane 0 writes.
+  if (ilane == 0) {
+    const int k_down_len = k_padded_len / kStride;
+    const int down_idx = stem_block_idx * kSamplePerBlock + iwarp;
+    if (down_idx < k_down_len) {
+      v_norm_down[(static_cast<int64_t>(ibatch) * num_head_kv + ihead_kv) * max_k_down_len +
+                  down_idx] = max_norm;
+    }
+  }
+}
+
+//  stem_prep_varlen_kv_kernel — K flat + V norm down (ragged varlen)
+//
+// K: FP8 group-sum × kscale, reversed group order → kflat BF16.
+// V: FP8 × vscale → L2 norm → v_norm_down FP32.
+template <int kStemBlockSize, int kStride, int kDimQK, int kDimV>
+__global__ void __launch_bounds__(kStemBlockSize / kStride * 32) stem_prep_varlen_kv_kernel(
+    const __nv_fp8_e4m3* __restrict__ k_fp8, const __nv_fp8_e4m3* __restrict__ v_fp8,
+    const float* __restrict__ kscale_ptr, const float* __restrict__ vscale_ptr,
+    const int* __restrict__ kv_seq_lens, const int* __restrict__ cu_seqlens_kv,
+    __nv_bfloat16* __restrict__ kflat, float* __restrict__ v_norm_down, int num_head_kv, int ldK,
+    int ldV, int max_num_stem_blocks, int max_k_down_len) {
+  constexpr int kSamplePerBlock = kStemBlockSize / kStride;
+  constexpr int kElemsPerThread_K = kDimQK / 32;
+  constexpr int kElemsPerThread_V = kDimV / 32;
+
+  static_assert(kStemBlockSize % kStride == 0, "kStemBlockSize must be divisible by kStride");
+  static_assert(kDimQK % 32 == 0, "kDimQK must be divisible by warp size");
+  static_assert(kDimV % 32 == 0, "kDimV must be divisible by warp size");
+  static_assert(kSamplePerBlock >= 1 && kSamplePerBlock <= 32,
+                "kSamplePerBlock warps must be in [1, 32] for a valid CTA");
+
+  const int stem_block_idx = blockIdx.x;
+  const int ibatch = blockIdx.y / num_head_kv;
+  const int ihead_kv = blockIdx.y % num_head_kv;
+  const int iwarp = threadIdx.x / 32;
+  const int ilane = threadIdx.x % 32;
+
+  const int kv_len = kv_seq_lens[ibatch];
+  const int k_padded_len = ((kv_len + kStemBlockSize - 1) / kStemBlockSize) * kStemBlockSize;
+  const int num_stem_blocks_req = k_padded_len / kStemBlockSize;
+  if (stem_block_idx >= num_stem_blocks_req) {
+    return;
+  }
+
+  const int kv_start_offset = cu_seqlens_kv[ibatch];
+  const int stem_row_base = stem_block_idx * kStemBlockSize;
+
+  // K processing
+  const float kscale_val = kscale_ptr[0];
+#pragma unroll
+  for (int group_id = iwarp; group_id < kStride; group_id += kSamplePerBlock) {
+    vec_t<float, kElemsPerThread_K> k_acc;
+#pragma unroll
+    for (int j = 0; j < kElemsPerThread_K; j++) {
+      k_acc[j] = 0.0f;
+    }
+
+#pragma unroll
+    for (int isample = 0; isample < kSamplePerBlock; isample++) {
+      const int global_row = stem_row_base + group_id + isample * kStride;
+      if (global_row >= kv_len) {
+        continue;
+      }
+
+      const __nv_fp8_e4m3* k_ptr = k_fp8 +
+                                   static_cast<int64_t>(kv_start_offset + global_row) * ldK +
+                                   ihead_kv * kDimQK + ilane * kElemsPerThread_K;
+
+      if constexpr (kElemsPerThread_K == 4) {
+        auto packed_fp8 = load<__nv_fp8x4_e4m3, 1>(k_ptr);
+        auto fp32_vals = to<float>(packed_fp8);
+#pragma unroll
+        for (int j = 0; j < kElemsPerThread_K; j++) {
+          k_acc[j] += fp32_vals[j];
+        }
+      } else if constexpr (kElemsPerThread_K == 6) {
+        // ilane*6 not 4B-aligned for odd lanes; use 3 × 2B loads.
+        auto fp32_seg0 = to<float>(load<__nv_fp8_e4m3, 2>(k_ptr));
+        auto fp32_seg1 = to<float>(load<__nv_fp8_e4m3, 2>(k_ptr + 2));
+        auto fp32_seg2 = to<float>(load<__nv_fp8_e4m3, 2>(k_ptr + 4));
+#pragma unroll
+        for (int j = 0; j < 2; j++) {
+          k_acc[j] += fp32_seg0[j];
+          k_acc[j + 2] += fp32_seg1[j];
+          k_acc[j + 4] += fp32_seg2[j];
+        }
+      }
+    }
+
+#pragma unroll
+    for (int j = 0; j < kElemsPerThread_K; j++) {
+      k_acc[j] *= kscale_val;
+    }
+
+    __nv_bfloat16* kflat_out_ptr = kflat +
+                                   (static_cast<int64_t>(ibatch) * num_head_kv + ihead_kv) *
+                                       static_cast<int64_t>(max_num_stem_blocks) * kStride *
+                                       kDimQK +
+                                   static_cast<int64_t>(stem_block_idx) * kStride * kDimQK +
+                                   (kStride - 1 - group_id) * kDimQK + ilane * kElemsPerThread_K;
+
+    auto k_bf16 = to<__nv_bfloat16>(k_acc);
+    if constexpr (kElemsPerThread_K == 4) {
+      store(kflat_out_ptr, k_bf16);
+    } else if constexpr (kElemsPerThread_K == 6) {
+      // ilane*12 not 8B-aligned for odd lanes; use 3 × 4B stores.
+      store(kflat_out_ptr, k_bf16[0], k_bf16[1]);
+      store(kflat_out_ptr + 2, k_bf16[2], k_bf16[3]);
+      store(kflat_out_ptr + 4, k_bf16[4], k_bf16[5]);
+    }
+  }
+
+  // V processing
+  const float vscale_val = vscale_ptr[0];
+  float max_norm = 0.0f;
+
+#pragma unroll
+  for (int istep = 0; istep < kStride; istep++) {
+    const int global_row = stem_row_base + iwarp * kStride + istep;
+    if (global_row >= kv_len) {
+      continue;
+    }
+
+    const __nv_fp8_e4m3* v_ptr = v_fp8 + static_cast<int64_t>(kv_start_offset + global_row) * ldV +
+                                 ihead_kv * kDimV + ilane * kElemsPerThread_V;
+
+    auto packed_fp8 = load<__nv_fp8x4_e4m3, 1>(v_ptr);
+    auto fp32_vals = to<float>(packed_fp8);
+
+    float partial_square = 0.0f;
+#pragma unroll
+    for (int j = 0; j < kElemsPerThread_V; j++) {
+      float val = fp32_vals[j] * vscale_val;
+      partial_square += val * val;
+    }
+
+    float norm_square = warp_reduce_sum_xor(partial_square);
+    float norm = sqrtf(norm_square);
+    max_norm = fmaxf(max_norm, norm);
+  }
+
+  if (ilane == 0) {
+    const int k_down_len = k_padded_len / kStride;
+    const int down_idx = stem_block_idx * kSamplePerBlock + iwarp;
+    if (down_idx < k_down_len) {
+      v_norm_down[(static_cast<int64_t>(ibatch) * num_head_kv + ihead_kv) * max_k_down_len +
+                  down_idx] = max_norm;
+    }
+  }
+}
+
+// Block-level sum reduction (256 threads) for vbias_reduce_kernel
+__device__ __forceinline__ float block_reduce_sum_256(float val, float* smem) {
+  __syncthreads();  // isolate from any prior use of this smem buffer by the caller
+  constexpr int kNumWarps = 8;
+  val = warp_reduce_sum_xor(val);
+  const int iwarp = threadIdx.x / 32;
+  const int ilane = threadIdx.x % 32;
+  if (ilane == 0) {
+    smem[iwarp] = val;
+  }
+  __syncthreads();
+  if (iwarp == 0) {
+    float tmp = (ilane < kNumWarps) ? smem[ilane] : 0.0f;
+    tmp = warp_reduce_sum_xor(tmp);
+    if (ilane == 0) {
+      smem[0] = tmp;
+    }
+  }
+  __syncthreads();
+  return smem[0];
+}
+
+// vbias_reduce_kernel — global normalize + block average → V_bias
+//
+// Part of stem_oam_prep_paged_kv / prep_varlen_kv (sub-kernel 2 of 2).
+template <int kStemBlockSize, int kStride>
+__global__ void __launch_bounds__(256)
+    vbias_reduce_kernel(const float* __restrict__ v_norm_down, const int* __restrict__ kv_seq_lens,
+                        float* __restrict__ vbias, int num_head_kv, int max_k_down_len,
+                        int max_num_stem_blocks, float lambda_mag) {
+  constexpr int kSamplePerBlock = kStemBlockSize / kStride;
+  constexpr int kBlockDim = 256;
+
+  const int ibatch = blockIdx.x / num_head_kv;
+  const int ihead_kv = blockIdx.x % num_head_kv;
+
+  const int kv_len = kv_seq_lens[ibatch];
+  const int k_padded_len = ((kv_len + kStemBlockSize - 1) / kStemBlockSize) * kStemBlockSize;
+  const int k_down_len = k_padded_len / kStride;
+  if (k_down_len == 0) {
+    return;
+  }
+
+  const float* v_norm_down_base =
+      v_norm_down + (static_cast<int64_t>(ibatch) * num_head_kv + ihead_kv) * max_k_down_len;
+
+  __shared__ float smem[8];
+
+  // 1: mean of log values
+  float local_sum = 0.0f;
+  for (int i = threadIdx.x; i < k_down_len; i += kBlockDim) {
+    local_sum += logf(v_norm_down_base[i] + 1e-6f);
+  }
+  const float mean = block_reduce_sum_256(local_sum, smem) / static_cast<float>(k_down_len);
+
+  // 2: std of log values
+  float local_square = 0.0f;
+  for (int i = threadIdx.x; i < k_down_len; i += kBlockDim) {
+    float diff = logf(v_norm_down_base[i] + 1e-6f) - mean;
+    local_square += diff * diff;
+  }
+  const float variance = block_reduce_sum_256(local_square, smem);
+  const float std_val =
+      (k_down_len > 1) ? sqrtf(variance / static_cast<float>(k_down_len - 1)) : 0.0f;
+  const float inv_std = 1.0f / (std_val + 1e-6f);
+
+  // 3: normalize + ReLU + scale + block average
+  const int num_stem_blocks = k_padded_len / kStemBlockSize;
+
+  float* vbias_base =
+      vbias + (static_cast<int64_t>(ibatch) * num_head_kv + ihead_kv) * max_num_stem_blocks;
+
+  for (int iblock = threadIdx.x; iblock < num_stem_blocks; iblock += kBlockDim) {
+    float block_sum = 0.0f;
+#pragma unroll
+    for (int isample = 0; isample < kSamplePerBlock; isample++) {
+      const int idx = iblock * kSamplePerBlock + isample;
+      if (idx < k_down_len) {
+        float log_val = logf(v_norm_down_base[idx] + 1e-6f);
+        float normalized = (log_val - mean) * inv_std;
+        block_sum += lambda_mag * fmaxf(0.0f, normalized);
+      }
+    }
+    vbias_base[iblock] = block_sum / static_cast<float>(kSamplePerBlock);
+  }
+}
+
+// stem_prep_varlen_q_kernel — Q flat precompute
+//
+// Weighted group-sum of Q tokens with qscale (FP8 dequant scale).
+//
+// Scale loading strategy (compile-time, via kIsPerTensorQscale):
+//   false: per-token qscale[B, Hq, seq] → shared memory (kStemBlockSize floats)
+//   true:  scalar qscale[0] → register (L1 broadcast)
+template <int kStemBlockSize, int kStride, int kDimQK, bool kIsPerTensorQscale>
+__global__ void __launch_bounds__(kStemBlockSize / kStride * 32)
+    stem_prep_varlen_q_kernel(const __nv_fp8_e4m3* __restrict__ q_fp8,
+                              const float* __restrict__ qscale_ptr,
+                              const int* __restrict__ q_seq_lens,
+                              const int* __restrict__ cu_seqlens_q,
+                              __nv_bfloat16* __restrict__ qflat, int num_head_q, int ldQ,
+                              int max_num_q_blocks) {
+  constexpr int kSamplePerBlock = kStemBlockSize / kStride;
+  constexpr int kElemsPerThread = kDimQK / 32;
+  constexpr int kFlatDim = kStride * kDimQK;
+
+  static_assert(kStemBlockSize % kStride == 0, "kStemBlockSize must be divisible by kStride");
+  static_assert(kDimQK % 32 == 0, "kDimQK must be divisible by warp size");
+  static_assert(kSamplePerBlock >= 1 && kSamplePerBlock <= 32,
+                "kSamplePerBlock warps must be in [1, 32] for a valid CTA");
+  static_assert(kElemsPerThread == 4, "only dim128 (kElemsPerThread=4) is supported");
+
+  const int q_block_idx = blockIdx.x;
+  const int ibatch = blockIdx.y / num_head_q;
+  const int ihead_q = blockIdx.y % num_head_q;
+  const int iwarp = threadIdx.x / 32;
+  const int ilane = threadIdx.x % 32;
+
+  const int q_len = q_seq_lens[ibatch];
+  const int q_padded_len = ((q_len + kStemBlockSize - 1) / kStemBlockSize) * kStemBlockSize;
+  const int num_q_blocks_req = q_padded_len / kStemBlockSize;
+  if (q_block_idx >= num_q_blocks_req) {
+    return;
+  }
+
+  const int q_start_offset = cu_seqlens_q[ibatch];
+
+  // Preload qscale: per-token in smem, or scalar in register.
+  __shared__ float qscale_per_token[kIsPerTensorQscale ? 1 : kStemBlockSize];
+  float qscale_per_tensor = 0.0f;
+  if constexpr (kIsPerTensorQscale) {
+    qscale_per_tensor = qscale_ptr[0];
+  } else {
+    const int block_start_idx = q_block_idx * kStemBlockSize;
+    const int qs_seq_len = max_num_q_blocks * kStemBlockSize;
+    const float* scale_base =
+        qscale_ptr + ibatch * (num_head_q * qs_seq_len) + ihead_q * qs_seq_len;
+#pragma unroll
+    for (int i = threadIdx.x; i < kStemBlockSize; i += blockDim.x) {
+      const int token_idx = block_start_idx + i;
+      qscale_per_token[i] = (token_idx < q_len) ? scale_base[token_idx] : 0.0f;
+    }
+    __syncthreads();
+  }
+
+#pragma unroll
+  for (int group_id = iwarp; group_id < kStride; group_id += kSamplePerBlock) {
+    vec_t<float, kElemsPerThread> q_acc;
+#pragma unroll
+    for (int j = 0; j < kElemsPerThread; j++) {
+      q_acc[j] = 0.0f;
+    }
+
+#pragma unroll
+    for (int isample = 0; isample < kSamplePerBlock; isample++) {
+      const int token_idx = q_block_idx * kStemBlockSize + group_id + isample * kStride;
+      if (token_idx >= q_len) {
+        continue;
+      }
+
+      const int global_token_idx = q_start_offset + token_idx;
+      const __nv_fp8_e4m3* q_ptr = q_fp8 + static_cast<int64_t>(global_token_idx) * ldQ +
+                                   ihead_q * kDimQK + ilane * kElemsPerThread;
+
+      const float scale =
+          kIsPerTensorQscale ? qscale_per_tensor : qscale_per_token[group_id + isample * kStride];
+
+      if constexpr (kElemsPerThread == 4) {
+        auto packed_fp8 = load<__nv_fp8x4_e4m3, 1>(q_ptr);
+        auto fp32_vals = to<float>(packed_fp8);
+#pragma unroll
+        for (int j = 0; j < kElemsPerThread; j++) {
+          q_acc[j] += scale * fp32_vals[j];
+        }
+      } else if constexpr (kElemsPerThread == 6) {
+        // ilane*6 not 4B-aligned for odd lanes; use 3 × 2B loads.
+        auto fp32_seg0 = to<float>(load<__nv_fp8_e4m3, 2>(q_ptr));
+        auto fp32_seg1 = to<float>(load<__nv_fp8_e4m3, 2>(q_ptr + 2));
+        auto fp32_seg2 = to<float>(load<__nv_fp8_e4m3, 2>(q_ptr + 4));
+#pragma unroll
+        for (int j = 0; j < 2; j++) {
+          q_acc[j] += scale * fp32_seg0[j];
+          q_acc[j + 2] += scale * fp32_seg1[j];
+          q_acc[j + 4] += scale * fp32_seg2[j];
+        }
+      }
+    }
+
+    // FP32 → BF16, store Q flat with natural group order.
+    __nv_bfloat16* qflat_out_ptr = qflat +
+                                   (static_cast<int64_t>(ibatch) * num_head_q + ihead_q) *
+                                       static_cast<int64_t>(max_num_q_blocks) * kFlatDim +
+                                   static_cast<int64_t>(q_block_idx) * kFlatDim +
+                                   group_id * kDimQK + ilane * kElemsPerThread;
+
+    auto q_bf16 = to<__nv_bfloat16>(q_acc);
+    if constexpr (kElemsPerThread == 4) {
+      store(qflat_out_ptr, q_bf16);
+    } else if constexpr (kElemsPerThread == 6) {
+      // ilane*12 not 8B-aligned for odd lanes; use 3 × 4B stores.
+      store(qflat_out_ptr, q_bf16[0], q_bf16[1]);
+      store(qflat_out_ptr + 2, q_bf16[2], q_bf16[3]);
+      store(qflat_out_ptr + 4, q_bf16[4], q_bf16[5]);
+    }
+  }
+}
+
+// get_next_tile — persistent GEMM tile dispatcher
+template <int kTileM, int kTileN, int kStemBlockSize>
+__device__ __forceinline__ auto get_next_tile(int iblock, cutlass::FastDivmod const& qk_tile_divmod,
+                                              cutlass::FastDivmod const& k_tile_divmod,
+                                              cutlass::FastDivmod const& head_q_divmod) {
+  int ibatch_head_q, qk_rem;
+  qk_tile_divmod(ibatch_head_q, qk_rem, iblock);
+
+  int itile_q, itile_k;
+  k_tile_divmod(itile_q, itile_k, qk_rem);
+
+  int ibatch, ihead_q;
+  head_q_divmod(ibatch, ihead_q, ibatch_head_q);
+
+  return cute::make_tuple(ibatch, ihead_q, itile_q, itile_k);
+}
+
+// stem_oam_gemm_kernel — Frobenius GEMM (warp-spec persistent)
+//
+// block_logits = FrobScale × (Qflat @ Kflat^T) + V_bias,  optional causal mask.
+// FrobScale = 1 / (kSamplePerBlock²) = 1/64 when stem_block=128, stride=16.
+//
+// Producer: TMA-only. Loads Qflat + Kflat chunks to SMEM.
+// Consumer: WGMMA BF16 SS + custom epilogue.
+template <bool kCausal, typename TiledMma, typename TmaQ, typename TmaK, typename TmaLogits,
+          int kTileM, int kTileN, int kStage, int kStemBlockSize, int kStride, int kDimQK,
+          typename SLayoutQ, typename SLayoutK, typename SLayoutLogits>
+__global__ void __launch_bounds__(384, 1)
+    stem_oam_gemm_kernel(const __grid_constant__ TmaQ tma_q, const __grid_constant__ TmaK tma_k,
+                         const __grid_constant__ TmaLogits tma_logits,
+                         const int* __restrict__ q_seq_lens, const int* __restrict__ kv_seq_lens,
+                         const float* __restrict__ vbias_ptr, int num_batch, int num_head_q,
+                         int num_heads_per_kv, int max_num_qb, int max_num_kb, int max_total_tiles,
+                         cutlass::FastDivmod qk_tile_divmod, cutlass::FastDivmod k_tile_divmod,
+                         cutlass::FastDivmod head_q_divmod) {
+  using namespace cute;  // NOLINT
+
+  using Tbf16 = cute::bfloat16_t;
+
+  constexpr int kFlatDim = kStride * kDimQK;
+  constexpr int kSamplePerBlock = kStemBlockSize / kStride;
+  constexpr float kFrobScale = 1.0f / static_cast<float>(kSamplePerBlock * kSamplePerBlock);
+
+  int idx = threadIdx.x;
+
+  int iwarp = __shfl_sync(0xFFFFFFFF, idx / 32, 0);
+  int elected = cute::elect_one_sync();
+  bool is_leader_in_block = (iwarp == 0) && elected;
+  bool is_leader_in_warpgroup = ((iwarp % 4) == 0) && elected;
+
+  __shared__ uint64_t writable[kStage];
+  __shared__ uint64_t readable[kStage];
+
+  extern __shared__ uint8_t shm_data[] alignas(128);
+  auto* shm_q = reinterpret_cast<Tbf16*>(shm_data);
+  auto* shm_k = reinterpret_cast<Tbf16*>(shm_q + cosize(SLayoutQ{}));
+  auto* shm_logits = reinterpret_cast<Tbf16*>(shm_k + cosize(SLayoutK{}));
+
+  auto sQ = make_tensor(make_smem_ptr(shm_q), SLayoutQ{});
+  auto sK = make_tensor(make_smem_ptr(shm_k), SLayoutK{});
+
+  // get_tma_tensor coordinate space: >= kTileM/kTileN to cover at least 1 tile.
+  auto gQ =
+      tma_q.get_tma_tensor(make_shape(max(max_num_qb, kTileM), kFlatDim, num_head_q, num_batch));
+  auto gK = tma_k.get_tma_tensor(
+      make_shape(max(max_num_kb, kTileN), kFlatDim, num_head_q / num_heads_per_kv, num_batch));
+
+  // Identity tensor for epilogue coordinate mapping
+  auto gC =
+      make_tensor(make_gmem_ptr(static_cast<Tbf16*>(nullptr)),
+                  make_shape(Int<kTileM>{}, Int<kTileN>{}), make_stride(Int<kTileN>{}, Int<1>{}));
+
+  auto tQg = tma_q.get_slice(0).partition_S(gQ);  // (TMA, TMA_Qb, TMA_K, Hq, B)
+  auto tQs = tma_q.get_slice(0).partition_D(sQ);  // (TMA, _1, _1, kStage)
+
+  auto tKg = tma_k.get_slice(0).partition_S(gK);  // (TMA, TMA_Kb, TMA_K, Hkv, B)
+  auto tKs = tma_k.get_slice(0).partition_D(sK);  // (TMA, _1, _1, kStage)
+
+  if (is_leader_in_block) {
+#pragma unroll
+    for (int i = 0; i < kStage; ++i) {
+      initialize_barrier(readable[i], 1);
+      initialize_barrier(writable[i], size(TiledMma{}) / 128);
+    }
+  }
+
+  __syncthreads();
+
+  // Producer WG (threads 256-383)
+  if (idx >= 256) {
+    cutlass::arch::warpgroup_reg_dealloc<24>();
+    idx -= 256;
+    constexpr int kTransactionBytes =
+        sizeof(Tbf16) * cosize(SLayoutQ{}(_, _, 0)) + sizeof(Tbf16) * cosize(SLayoutK{}(_, _, 0));
+
+    int iwarp = __shfl_sync(0xFFFFFFFF, idx / 32, 0);
+    int is_leader_in_load = ((iwarp == 0) && elected);
+
+    if (is_leader_in_load) {
+      int phase = 1;
+      int ismem_write = __shfl_sync(0xFFFFFFFF, 0, 0);
+      int iblock = blockIdx.x;
+      int ntile_k = size<2>(tQg);
+
+      while (iblock < max_total_tiles) {
+        auto [ibatch, ihead_q, itile_q, itile_k] = get_next_tile<kTileM, kTileN, kStemBlockSize>(
+            iblock, qk_tile_divmod, k_tile_divmod, head_q_divmod);
+
+        int ihead_kv = ihead_q / num_heads_per_kv;
+
+        int q_len = q_seq_lens[ibatch];
+        int kv_len = kv_seq_lens[ibatch];
+        int q_padded = ((q_len + kStemBlockSize - 1) / kStemBlockSize) * kStemBlockSize;
+        int kv_padded = ((kv_len + kStemBlockSize - 1) / kStemBlockSize) * kStemBlockSize;
+        int num_qb = q_padded / kStemBlockSize;
+        int num_kb = kv_padded / kStemBlockSize;
+
+        // Skip tiles outside this request
+        if (itile_q * kTileM >= num_qb || itile_k * kTileN >= num_kb) {
+          iblock += gridDim.x;
+          continue;
+        }
+
+        // Causal tile-level skip
+        if constexpr (kCausal) {
+          int block_offset = num_kb - num_qb;
+          int qb_max = itile_q * kTileM + kTileM - 1;
+          int kb_min = itile_k * kTileN;
+          if (qb_max + block_offset < kb_min) {
+            iblock += gridDim.x;
+            continue;
+          }
+        }
+
+        iblock += gridDim.x;
+
+#pragma unroll 1
+        for (int ik = 0; ik < ntile_k; ++ik) {
+          wait_barrier(writable[ismem_write], phase);
+
+          cute::copy(tma_q.with(readable[ismem_write]), tQg(_, itile_q, ik, ihead_q, ibatch),
+                     tQs(_, 0, 0, ismem_write));
+
+          cute::copy(tma_k.with(readable[ismem_write]), tKg(_, itile_k, ik, ihead_kv, ibatch),
+                     tKs(_, 0, 0, ismem_write));
+
+          set_barrier_transaction_bytes(readable[ismem_write], kTransactionBytes);
+
+          ++ismem_write;
+          if (ismem_write == kStage) {
+            ismem_write = 0;
+            phase ^= 1;
+          }
+        }
+      }
+    }
+
+  } else {
+    // Consumer WG ×2 (threads 0-255)
+    cutlass::arch::warpgroup_reg_alloc<168>();
+
+    int idx_in_warpgroup = idx % 128;
+    int iwarpgroup = idx / 128;
+    int iwarp_in_warpgroup = idx_in_warpgroup / 32;
+    int elected_idx_in_warpgroup = ((iwarp_in_warpgroup == 0) && elected);
+
+    TiledMma tiled_mma;
+
+    auto thr_mma = tiled_mma.get_slice(idx);
+    auto tQs4r = thr_mma.partition_A(sQ);
+    auto tKs4r = thr_mma.partition_B(sK);
+
+    auto tQr = thr_mma.make_fragment_A(tQs4r);  // (MMA, MMA_M, MMA_K, kStage)
+    auto tKr = thr_mma.make_fragment_B(tKs4r);  // (MMA, MMA_N, MMA_K, kStage)
+
+    auto tCr = thr_mma.partition_fragment_C(gC);
+
+    // Identity tensor for epilogue coordinate mapping
+    auto gI = make_identity_tensor(gC.shape());
+    auto tI = thr_mma.partition_C(gI);
+    auto tCr_mn = retile_fragment(tCr);  // (M, N) view of accumulator
+    auto tI_mn = retile_fragment(tI);    // (M, N) view of identity
+    constexpr int kM = size<0>(tCr_mn);
+    constexpr int kN = size<1>(tCr_mn);
+
+    int ismem_read = 0;
+    int phase = 0;
+
+    int iblock = blockIdx.x;
+    while (iblock < max_total_tiles) {
+      auto [ibatch, ihead_q, itile_q, itile_k] = get_next_tile<kTileM, kTileN, kStemBlockSize>(
+          iblock, qk_tile_divmod, k_tile_divmod, head_q_divmod);
+
+      int ihead_kv = ihead_q / num_heads_per_kv;
+
+      int q_len = q_seq_lens[ibatch];
+      int kv_len = kv_seq_lens[ibatch];
+      int q_padded = ((q_len + kStemBlockSize - 1) / kStemBlockSize) * kStemBlockSize;
+      int kv_padded = ((kv_len + kStemBlockSize - 1) / kStemBlockSize) * kStemBlockSize;
+      int num_qb = q_padded / kStemBlockSize;
+      int num_kb = kv_padded / kStemBlockSize;
+
+      if (itile_q * kTileM >= num_qb || itile_k * kTileN >= num_kb) {
+        iblock += gridDim.x;
+        continue;
+      }
+
+      if constexpr (kCausal) {
+        int block_offset = num_kb - num_qb;
+        int qb_max = itile_q * kTileM + kTileM - 1;
+        int kb_min = itile_k * kTileN;
+        if (qb_max + block_offset < kb_min) {
+          iblock += gridDim.x;
+          continue;
+        }
+      }
+
+      iblock += gridDim.x;
+
+      tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
+
+      int ntile_k = size<2>(tQg);
+      int ntile_todo = ntile_k;
+#pragma unroll 1
+      for (; ntile_todo > 0; --ntile_todo) {
+        if (elected_idx_in_warpgroup) {
+          wait_barrier(readable[ismem_read], phase);
+        }
+
+        warpgroup_fence_operand(tCr);
+        warpgroup_arrive();
+#pragma unroll
+        for (int ik = 0; ik < size<2>(tQr); ++ik) {
+          cute::gemm(tiled_mma, tQr(_, _, ik, ismem_read), tKr(_, _, ik, ismem_read), tCr(_, _, _));
+          tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+        }
+
+        warpgroup_commit_batch();
+        warpgroup_wait<0>();
+        warpgroup_fence_operand(tCr);
+
+        if (elected_idx_in_warpgroup) {
+          arrive_barrier(writable[ismem_read]);
+        }
+
+        ++ismem_read;
+        if (ismem_read == kStage) {
+          phase ^= 1;
+          ismem_read = 0;
+        }
+      }
+
+      // Epilogue: FrobScale + V_bias + causal mask
+      constexpr float kNegInf = -std::numeric_limits<float>::infinity();
+
+      // Precompute causal boundary info for this tile
+      [[maybe_unused]] int block_offset = 0;
+      [[maybe_unused]] bool need_mask = false;
+      if constexpr (kCausal) {
+        block_offset = num_kb - num_qb;
+        int qb_start = itile_q * kTileM;
+        int kb_start = itile_k * kTileN;
+        need_mask = (qb_start + block_offset < kb_start + kTileN) &&
+                    (qb_start + kTileM - 1 + block_offset >= kb_start);
+      }
+
+      // V_bias base pointer for this (batch, head_kv)
+      const float* vbias_base =
+          vbias_ptr + static_cast<int64_t>(ibatch) * (num_head_q / num_heads_per_kv) * max_num_kb +
+          static_cast<int64_t>(ihead_kv) * max_num_kb;
+
+#pragma unroll
+      for (int im = 0; im < kM; ++im) {
+        int m_local = get<0>(tI_mn(im, 0));
+        int qb_idx = itile_q * kTileM + m_local;
+
+#pragma unroll
+        for (int in = 0; in < kN; ++in) {
+          int n_local = get<1>(tI_mn(im, in));
+          int kb_idx = itile_k * kTileN + n_local;
+
+          float val = tCr_mn(im, in);
+
+          if (qb_idx >= max_num_qb || kb_idx >= max_num_kb) {
+            val = kNegInf;
+          } else if (qb_idx >= num_qb || kb_idx >= num_kb) {
+            val = kNegInf;
+          } else if constexpr (kCausal) {
+            if (need_mask && (qb_idx + block_offset < kb_idx)) {
+              val = kNegInf;
+            } else {
+              val = val * kFrobScale + vbias_base[kb_idx];
+            }
+          } else {
+            val = val * kFrobScale + vbias_base[kb_idx];
+          }
+
+          tCr_mn(im, in) = val;
+        }
+      }
+
+      // FP32 → BF16 → STSM → TMA store
+      auto tCrh = make_tensor_like<Tbf16>(tCr);
+
+#pragma unroll
+      for (int i = 0; i < size(tCr); ++i) {
+        tCrh(i) = static_cast<Tbf16>(tCr(i));
+      }
+
+      // STSM: registers → shared memory
+      auto sLogits =
+          make_tensor(make_smem_ptr(reinterpret_cast<Tbf16*>(shm_logits)), SLayoutLogits{});
+      using R2SCopyAtomC = Copy_Atom<cute::SM90_U32x4_STSM_N, Tbf16>;
+      auto tiled_copy_c = make_tiled_copy_C(R2SCopyAtomC{}, tiled_mma);
+      auto thr_copy_c = tiled_copy_c.get_slice(idx);
+
+      auto tCr4s = thr_copy_c.retile_S(tCrh);
+      auto tLogitsS4r = thr_copy_c.partition_D(sLogits);
+
+      cute::tma_store_wait<0>();
+      syncwarpgroup(iwarpgroup);
+
+      cute::copy(tiled_copy_c, tCr4s, tLogitsS4r);
+      syncwarpgroup(iwarpgroup);
+      cute::tma_store_fence();
+
+      // TMA store: shared memory → global memory (1 WG stores TileM/2 rows)
+      if (is_leader_in_warpgroup) {
+        auto gLogits = tma_logits.get_tma_tensor(
+            make_shape(max(max_num_qb, kTileM), max(max_num_kb, kTileN), num_head_q, num_batch));
+        auto tLogitsS = tma_logits.get_slice(0).partition_S(sLogits);  // (TMA, _2, _1)
+        auto tLogitsG =
+            tma_logits.get_slice(0).partition_D(gLogits);  // (TMA, TMA_Qb, TMA_Kb, Hq, B)
+
+        cute::copy(tma_logits, tLogitsS(_, iwarpgroup, Int<0>{}),
+                   tLogitsG(_, itile_q * 2 + iwarpgroup, itile_k, ihead_q, ibatch));
+        tma_store_arrive();
+      }
+    }
+  }
+}
+
+// Warp-level int32 sum reduction; result broadcast to all 32 lanes.
+__device__ __forceinline__ int warp_reduce_sum_xor_i32(int x) {
+#pragma unroll
+  for (int offset = 16; offset >= 1; offset /= 2) {
+    x += __shfl_xor_sync(0xFFFFFFFF, x, offset);
+  }
+  return x;
+}
+
+// Map bf16 bits to a monotonic uint16: ordered-int comparison matches float comparison.
+// Positive: flip sign bit;  Negative: invert all bits.
+__device__ __forceinline__ uint16_t bf16_to_ordered(uint16_t bits) {
+  return (bits & 0x8000) ? ~bits : (bits ^ 0x8000);
+}
+
+// bf16 isfinite: exponent (bits 14-7) not all ones.
+__device__ __forceinline__ bool bf16_isfinite(uint16_t bits) { return (bits & 0x7F80) != 0x7F80; }
+
+// Per-row top-k budget: 3-regime k_schedule + linspace decay, both keyed on
+// the FULL prompt KV length (`prompt_kv_blocks`) so the result is chunked-
+// prefill invariant. `ki_blocks` only feeds `kb_offset` for absolute q_pos.
+__device__ __forceinline__ int compute_budget(int q_row, int qi_blocks, int ki_blocks,
+                                              int prompt_kv_blocks, float alpha,
+                                              float k_block_num_rate_medium,
+                                              int k_block_num_bias_medium,
+                                              float k_block_num_rate_large,
+                                              int k_block_num_bias_large) {
+  constexpr int kSmallSeqMax = 56;
+  constexpr int kMediumSeqMax = 160;
+
+  int k_val;
+  if (prompt_kv_blocks < kSmallSeqMax) {
+    k_val = prompt_kv_blocks;
+  } else if (prompt_kv_blocks < kMediumSeqMax) {
+    k_val = static_cast<int>(prompt_kv_blocks * k_block_num_rate_medium) + k_block_num_bias_medium;
+  } else {
+    k_val = static_cast<int>(prompt_kv_blocks * k_block_num_rate_large) + k_block_num_bias_large;
+  }
+
+  const int kb_offset = ki_blocks - qi_blocks;
+  const int q_pos = q_row + kb_offset;
+
+  int decay_len = prompt_kv_blocks - k_val;
+  if (q_pos < k_val || decay_len <= 1) {
+    return k_val;
+  }
+
+  float k_end = k_val * alpha;
+  float t = static_cast<float>(q_pos - k_val) / (decay_len - 1);
+  int budget = static_cast<int>(floorf(k_val + t * (k_end - k_val)));
+  return budget < 1 ? 1 : (budget > k_val ? k_val : budget);
+}
+
+// Find the largest threshold T such that count(ordered >= T) >= budget.
+//   For each bit MSB→LSB: probe candidate = threshold | (1<<bit); keep the bit
+//   if count(ordered >= candidate) >= budget.  After 16 rounds T is exact.
+// kWPR=1: pure warp shuffle (zero smem, zero sync).
+// kWPR>1: warp shuffle + smem aggregation across kWPR warps.
+template <int kEPT, int kWPR>
+__device__ __forceinline__ uint16_t radix_find_threshold(const uint16_t ordered[kEPT], int budget,
+                                                         int* smem_warp_counts, int warp_in_group) {
+  const int ilane = threadIdx.x % 32;
+
+  uint16_t threshold = 0;
+
+#pragma unroll 1
+  for (int bit = 15; bit >= 0; --bit) {
+    uint16_t candidate = threshold | (1u << bit);
+
+    int local_count = 0;
+#pragma unroll
+    for (int j = 0; j < kEPT; ++j) {
+      local_count += (ordered[j] >= candidate);
+    }
+
+    int total;
+    if constexpr (kWPR == 1) {
+      total = warp_reduce_sum_xor_i32(local_count);
+    } else {
+      int warp_count = warp_reduce_sum_xor_i32(local_count);
+      if (ilane == 0) {
+        smem_warp_counts[warp_in_group] = warp_count;
+      }
+      __syncthreads();
+
+      total = 0;
+#pragma unroll
+      for (int iw = 0; iw < kWPR; ++iw) {
+        total += smem_warp_counts[iw];
+      }
+      __syncthreads();
+    }
+
+    // keep this bit
+    if (total >= budget) {
+      threshold = candidate;
+    }
+  }
+  return threshold;
+}
+
+// stem_tpd_kernel — fused budget + radix-select + mask generation
+//
+// Per-row: compute budget → radix top-k threshold → apply fixed patterns → write u8 mask.
+//
+// Scale to wider rows by increasing kWPR, not kEPT.
+// Only the extreme >1M-token variant uses kEPT=128.
+//
+//   kEPT   elements per thread   (controls register usage)
+//   kWPR   warps per row         (1 = independent, >1 = cooperative)
+//   kWPC   warps per CTA         (= kWPR when cooperative, = 8 when independent)
+//
+//   kWPR = 1  →  kWPC = 8,    8 rows/CTA, warp-shuffle only, no __syncthreads
+//   kWPR > 1  →  kWPC = kWPR, 1 row/CTA,  cross-warp radix via smem + __syncthreads
+//
+// launch_bounds:
+//   kWPR=1: minBlocks=0 (unspecified) → compiler targets max occupancy.
+//   kWPR>1: minBlocks=1 → relaxes register pressure (max 255 regs),
+//           prevents spilling; runtime still places 2+ blk/SM when regs permit.
+template <int kEPT, int kWPR, int kWPC>
+__global__ void __launch_bounds__(kWPC * 32, (kWPR == 1) ? 0 : 1)
+    stem_tpd_kernel(const __nv_bfloat16* __restrict__ block_logits, uint8_t* __restrict__ mask,
+                    const int* __restrict__ q_seq_lens, const int* __restrict__ kv_seq_lens,
+                    const int* __restrict__ num_prompt_tokens, float alpha, int block_size,
+                    int initial_blocks, int window_size, float k_block_num_rate_medium,
+                    int k_block_num_bias_medium, float k_block_num_rate_large,
+                    int k_block_num_bias_large, int num_heads, int max_Qb, int max_Kb) {
+  static_assert(kWPR == 1 || kWPC == kWPR, "cooperative mode requires kWPC == kWPR");
+  constexpr int kRowsPerCta = kWPC / kWPR;
+  constexpr int kThreadsPerRow = kWPR * 32;
+  constexpr uint16_t kNegInfBits = 0xFF80;
+  constexpr uint16_t kNonFiniteOrdered = 0x007Fu;
+
+  const int iwarp = threadIdx.x / 32;
+  const int ilane = threadIdx.x % 32;
+
+  const int row_group = (kWPR == 1) ? iwarp : (iwarp / kWPR);
+  const int warp_in_group = (kWPR == 1) ? 0 : (iwarp % kWPR);
+
+  const int q_row = blockIdx.x * kRowsPerCta + row_group;
+  const int ihead = blockIdx.y;
+  const int ireq = blockIdx.z;
+
+  // Number of stem blocks for this request (matches host-side max_Qb / max_Kb derivation).
+  const int qi_blocks = (q_seq_lens[ireq] + block_size - 1) / block_size;
+  const int ki_blocks = (kv_seq_lens[ireq] + block_size - 1) / block_size;
+  const int prompt_kv_blocks = (num_prompt_tokens[ireq] + block_size - 1) / block_size;
+  if (qi_blocks == 0 || ki_blocks == 0 || q_row >= qi_blocks) {
+    return;
+  }
+
+  const int64_t row_offset = static_cast<int64_t>(ireq) * num_heads * max_Qb * max_Kb +
+                             static_cast<int64_t>(ihead) * max_Qb * max_Kb +
+                             static_cast<int64_t>(q_row) * max_Kb;
+  const __nv_bfloat16* row_ptr = block_logits + row_offset;
+  uint8_t* mask_ptr = mask + row_offset;
+
+  const int linear_id = warp_in_group * 32 + ilane;
+
+  // Strided load: thread t reads cols t, t+kThreadsPerRow, ... → 32 lanes hit one cache line.
+  // Non-finite (-inf / NaN) maps to kNonFiniteOrdered (smaller than any finite ordered value).
+  uint16_t ordered[kEPT];
+  int local_finite = 0;
+#pragma unroll
+  for (int j = 0; j < kEPT; ++j) {
+    int col = linear_id + j * kThreadsPerRow;
+    uint16_t bits = (col < ki_blocks) ? __bfloat16_as_ushort(row_ptr[col]) : kNegInfBits;
+    bool is_finite = bf16_isfinite(bits);
+    ordered[j] = is_finite ? bf16_to_ordered(bits) : kNonFiniteOrdered;
+    local_finite += is_finite;
+  }
+
+  const int budget =
+      compute_budget(q_row, qi_blocks, ki_blocks, prompt_kv_blocks, alpha, k_block_num_rate_medium,
+                     k_block_num_bias_medium, k_block_num_rate_large, k_block_num_bias_large);
+
+  // Sum local_finite across all threads in this row.  Reuses smem_warp_counts in radix below.
+  // kWPR==1 path elides the smem allocation.
+  __shared__ int smem_warp_counts[kWPR];
+  int total_finite;
+  if constexpr (kWPR == 1) {
+    total_finite = warp_reduce_sum_xor_i32(local_finite);
+  } else {
+    int warp_finite = warp_reduce_sum_xor_i32(local_finite);
+    if (ilane == 0) {
+      smem_warp_counts[warp_in_group] = warp_finite;
+    }
+    __syncthreads();
+
+    total_finite = 0;
+#pragma unroll
+    for (int iw = 0; iw < kWPR; ++iw) {
+      total_finite += smem_warp_counts[iw];
+    }
+    __syncthreads();
+  }
+
+  // Skip radix when budget covers all finite values (threshold = 0x0080 selects every finite).
+  uint16_t threshold = kNonFiniteOrdered + 1;
+  if (budget < total_finite) {
+    threshold = radix_find_threshold<kEPT, kWPR>(ordered, budget, smem_warp_counts, warp_in_group);
+  }
+
+  // mask = top-k & initial sink & recent window & diagonal.
+  //
+  // Chunked-prefill alignment: Q is the tail of a longer KV, so a Q-block at
+  // local index q_row corresponds to KV-block index (q_row + kb_offset).
+  const int kb_offset = ki_blocks - qi_blocks;
+  const int diag_col = q_row + kb_offset;
+#pragma unroll
+  for (int j = 0; j < kEPT; ++j) {
+    int col = linear_id + j * kThreadsPerRow;
+    if (col >= ki_blocks) {
+      continue;
+    }
+
+    bool selected = (ordered[j] >= threshold);
+    selected |= (col < initial_blocks);                               // initial sink (KV head)
+    selected |= (col <= diag_col) && (col > diag_col - window_size);  // recent window (KV-aligned)
+    selected |= (col == diag_col);                                    // diagonal (KV-aligned)
+
+    mask_ptr[col] = static_cast<uint8_t>(selected);
+  }
+}
+
+}  // namespace kernels
+}  // namespace stem
+}  // namespace hpc
+
+#endif  // SRC_STEM_STEM_KERNELS_CUH_

--- a/src/stem/stem_oam_gemm_dim128.cu
+++ b/src/stem/stem_oam_gemm_dim128.cu
@@ -1,0 +1,140 @@
+// Copyright (C) 2026 Tencent.
+
+#include <cuda.h>
+
+#include <algorithm>
+#include <type_traits>
+
+#include "cute/tensor.hpp"
+#include "src/stem/stem_kernels.cuh"
+#include "src/stem/stem_oam_gemm_dim128.h"
+#include "src/utils/utils.cuh"
+
+namespace hpc {
+namespace stem {
+
+template <int kStemBlockSize, int kStride, int kDimQK>
+void launch_stem_oam_gemm_dim128(void *block_logits_ptr, const void *qflat_ptr,
+                                 const void *kflat_ptr, const void *vbias_ptr,
+                                 const void *q_seq_lens_ptr, const void *kv_seq_lens_ptr,
+                                 int num_batch, int num_head_q, int num_head_kv, int max_num_qb,
+                                 int max_num_kb, bool causal, cudaStream_t stream) {
+  using namespace cute;  // NOLINT
+
+  using Tbf16 = cute::bfloat16_t;
+
+  constexpr int kFlatDim = kStride * kDimQK;
+  constexpr int kTileM = 128;
+  constexpr int kTileN = 128;
+  constexpr int kTileK = 64;
+  constexpr int kStage = 4;
+
+  // SMEM layouts: K-major SW128 for BF16
+  auto slayout_q = tile_to_shape(GMMA::Layout_K_SW128_Atom<Tbf16>{},
+                                 make_shape(Int<kTileM>{}, Int<kTileK>{}, Int<kStage>{}));
+  auto slayout_k = tile_to_shape(GMMA::Layout_K_SW128_Atom<Tbf16>{},
+                                 make_shape(Int<kTileN>{}, Int<kTileK>{}, Int<kStage>{}));
+
+  auto cpbox_logits = tile_to_shape(GMMA::Layout_K_SW128_Atom<Tbf16>{},
+                                    make_shape(Int<kTileM / 2>{}, Int<kTileN>{}));
+  auto slayout_logits =
+      tile_to_shape(GMMA::Layout_K_SW128_Atom<Tbf16>{}, make_shape(Int<kTileM>{}, Int<kTileN>{}));
+
+  // SMEM size
+  int shm_qk = sizeof(Tbf16) * (cosize(slayout_q) + cosize(slayout_k));
+  int shm_logits = sizeof(Tbf16) * cosize(slayout_logits);
+  int shm_size = shm_qk + shm_logits;
+
+  // TMA Load: use REAL qflat/kflat shapes. TMA hardware zero-fills OOB reads.
+  // Qflat: [B, Hq, max_num_qb, kFlatDim] — real shape, real stride
+  auto gQflat = make_tensor(make_gmem_ptr(reinterpret_cast<const Tbf16 *>(qflat_ptr)),
+                            make_shape(max_num_qb, kFlatDim, num_head_q, num_batch),
+                            make_stride(static_cast<int64_t>(kFlatDim), Int<1>{},
+                                        static_cast<int64_t>(max_num_qb) * kFlatDim,
+                                        static_cast<int64_t>(num_head_q) * max_num_qb * kFlatDim));
+
+  // Kflat: [B, Hkv, max_num_kb, kFlatDim] — real shape, real stride
+  auto gKflat = make_tensor(make_gmem_ptr(reinterpret_cast<const Tbf16 *>(kflat_ptr)),
+                            make_shape(max_num_kb, kFlatDim, num_head_kv, num_batch),
+                            make_stride(static_cast<int64_t>(kFlatDim), Int<1>{},
+                                        static_cast<int64_t>(max_num_kb) * kFlatDim,
+                                        static_cast<int64_t>(num_head_kv) * max_num_kb * kFlatDim));
+
+  // TMA Store: block_logits needs minimal padding for TMA copy box [64, 128].
+  //   logits_qb: >= 64 (copy box M/2), multiple of 64
+  //   logits_kb: >= 128 (copy box N), multiple of 64 (for 128B stride alignment)
+  // entry.cc allocates block_logits with exactly these dimensions.
+  int logits_qb = std::max(((max_num_qb + 63) / 64) * 64, 64);
+  int logits_kb = std::max(((max_num_kb + 63) / 64) * 64, 128);
+
+  auto gLogits = make_tensor(make_gmem_ptr(reinterpret_cast<Tbf16 *>(block_logits_ptr)),
+                             make_shape(logits_qb, logits_kb, num_head_q, num_batch),
+                             make_stride(static_cast<int64_t>(logits_kb), Int<1>{},
+                                         static_cast<int64_t>(logits_qb) * logits_kb,
+                                         static_cast<int64_t>(num_head_q) * logits_qb * logits_kb));
+
+  // TMA descriptors
+  auto tma_q = make_tma_copy(SM90_TMA_LOAD{}, gQflat, slayout_q(_, _, 0),
+                             Tile<Int<kTileM>, Int<kTileK>>{}, Int<1>{});
+  auto tma_k = make_tma_copy(SM90_TMA_LOAD{}, gKflat, slayout_k(_, _, 0),
+                             Tile<Int<kTileN>, Int<kTileK>>{}, Int<1>{});
+  auto tma_logits = make_tma_copy(SM90_TMA_STORE{}, gLogits, cpbox_logits);
+
+  // MMA configuration: BF16 SS, 2 warpgroups along M
+  auto warpgroup_layout = make_layout(make_shape(Int<2>{}, Int<1>{}, Int<1>{}));
+  auto tiled_mma = make_tiled_mma(SM90_64x128x16_F32BF16BF16_SS<GMMA::Major::K, GMMA::Major::K>{},
+                                  warpgroup_layout);
+
+  // Tile dispatch covers the output allocation range.
+  int num_q_tiles = (logits_qb + kTileM - 1) / kTileM;
+  int num_k_tiles = (logits_kb + kTileN - 1) / kTileN;
+  int tiles_per_head = num_q_tiles * num_k_tiles;
+  int total_tiles = num_batch * num_head_q * tiles_per_head;
+
+  cutlass::FastDivmod qk_tile_divmod(tiles_per_head);
+  cutlass::FastDivmod k_tile_divmod(num_k_tiles);
+  cutlass::FastDivmod head_q_divmod(num_head_q);
+
+  int num_heads_per_kv = num_head_q / num_head_kv;
+
+  dim3 block(size(tiled_mma) + 128);
+  dim3 grid(std::min(get_sm_count(), total_tiles));
+
+  // Causal dispatch: two template instantiations
+  auto do_launch = [&](auto causal_tag) {
+    constexpr bool kCausal = decltype(causal_tag)::value;
+    auto kernel =
+        kernels::stem_oam_gemm_kernel<kCausal, decltype(tiled_mma), decltype(tma_q),
+                                      decltype(tma_k), decltype(tma_logits), kTileM, kTileN, kStage,
+                                      kStemBlockSize, kStride, kDimQK, decltype(slayout_q),
+                                      decltype(slayout_k), decltype(slayout_logits)>;
+
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shm_size);
+
+    kernel<<<grid, block, shm_size, stream>>>(
+        tma_q, tma_k, tma_logits, reinterpret_cast<const int *>(q_seq_lens_ptr),
+        reinterpret_cast<const int *>(kv_seq_lens_ptr), reinterpret_cast<const float *>(vbias_ptr),
+        num_batch, num_head_q, num_heads_per_kv, max_num_qb, max_num_kb, total_tiles,
+        qk_tile_divmod, k_tile_divmod, head_q_divmod);
+  };
+
+  if (causal) {
+    do_launch(std::true_type{});
+  } else {
+    do_launch(std::false_type{});
+  }
+}
+
+void stem_oam_gemm_dim128_async(void *block_logits_ptr, const void *qflat_ptr,
+                                const void *kflat_ptr, const void *vbias_ptr,
+                                const void *q_seq_lens_ptr, const void *kv_seq_lens_ptr,
+                                int num_batch, int num_head_q, int num_head_kv, int max_num_qb,
+                                int max_num_kb, int stem_block_size, int stem_stride, bool causal,
+                                cudaStream_t stream) {
+  launch_stem_oam_gemm_dim128<128, 16, 128>(block_logits_ptr, qflat_ptr, kflat_ptr, vbias_ptr,
+                                            q_seq_lens_ptr, kv_seq_lens_ptr, num_batch, num_head_q,
+                                            num_head_kv, max_num_qb, max_num_kb, causal, stream);
+}
+
+}  // namespace stem
+}  // namespace hpc

--- a/src/stem/stem_oam_gemm_dim128.h
+++ b/src/stem/stem_oam_gemm_dim128.h
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Tencent.
+
+#ifndef SRC_STEM_STEM_OAM_GEMM_DIM128_H_
+#define SRC_STEM_STEM_OAM_GEMM_DIM128_H_
+
+#include <cuda_runtime_api.h>
+#include <stdint.h>
+
+namespace hpc {
+namespace stem {
+
+void stem_oam_gemm_dim128_async(void *block_logits_ptr, const void *qflat_ptr,
+                                const void *kflat_ptr, const void *vbias_ptr,
+                                const void *q_seq_lens_ptr, const void *kv_seq_lens_ptr,
+                                int num_batch, int num_head_q, int num_head_kv, int max_num_qb,
+                                int max_num_kb, int stem_block_size, int stem_stride, bool causal,
+                                cudaStream_t stream);
+
+}  // namespace stem
+}  // namespace hpc
+
+#endif  // SRC_STEM_STEM_OAM_GEMM_DIM128_H_

--- a/src/stem/stem_oam_prep_paged_kv_dim128.cu
+++ b/src/stem/stem_oam_prep_paged_kv_dim128.cu
@@ -1,0 +1,148 @@
+// Copyright (C) 2026 Tencent.
+
+#include <cuda.h>
+
+#include "cute/tensor.hpp"
+#include "src/stem/stem_kernels.cuh"
+#include "src/stem/stem_oam_prep_paged_kv_dim128.h"
+#include "src/utils/utils.cuh"
+
+namespace hpc {
+namespace stem {
+
+// Legacy qpertoken_perhead_kvpertensor path (quant_type=1).
+template <int kBlockSize, int kStemBlockSize, int kStride, int kDimQK, int kDimV>
+void launch_stem_oam_prep_paged_kv_qpertoken_perhead_kvpertensor_dim128(
+    void *kflat_ptr, void *vbias_ptr, const void *kcache_ptr, const void *vcache_ptr,
+    const void *kscale_ptr, const void *vscale_ptr, const void *block_ids_ptr,
+    const void *kv_seq_lens_ptr, int num_batch, int num_dim_qk, int num_dim_v, int num_head_kv,
+    int num_kvcache_blocks, int num_seq_max_blocks, float lambda_mag, int max_num_stem_blocks,
+    int max_k_down_len, int ldK, int ldV, void *v_norm_down_ptr, cudaStream_t stream) {
+  using namespace cute;  // NOLINT
+
+  using Tfp8 = cute::float_e4m3_t;
+  using Tbf16 = cute::bfloat16_t;
+
+  // Sub-kernel 1: paged KV prep (K group-sum + V L2 norm)
+  {
+    constexpr int kSamplePerBlock = kStemBlockSize / kStride;
+    dim3 grid(max_num_stem_blocks, num_batch * num_head_kv);
+    dim3 block(kSamplePerBlock * 32);
+
+    kernels::stem_prep_paged_kv_qpertoken_perhead_kvpertensor_kernel<
+        kBlockSize, kStemBlockSize, kStride, kDimQK, kDimV><<<grid, block, 0, stream>>>(
+        reinterpret_cast<const __nv_fp8_e4m3 *>(kcache_ptr),
+        reinterpret_cast<const __nv_fp8_e4m3 *>(vcache_ptr),
+        reinterpret_cast<const float *>(kscale_ptr), reinterpret_cast<const float *>(vscale_ptr),
+        reinterpret_cast<const int *>(block_ids_ptr),
+        reinterpret_cast<const int *>(kv_seq_lens_ptr),
+        reinterpret_cast<__nv_bfloat16 *>(kflat_ptr), reinterpret_cast<float *>(v_norm_down_ptr),
+        num_head_kv, num_seq_max_blocks, ldK, ldV, max_num_stem_blocks, max_k_down_len);
+  }
+
+  // Sub-kernel 2: Vbias reduce (shared between both quant_type paths).
+  {
+    dim3 grid(num_batch * num_head_kv);
+    dim3 block(256);
+
+    kernels::vbias_reduce_kernel<kStemBlockSize, kStride><<<grid, block, 0, stream>>>(
+        reinterpret_cast<const float *>(v_norm_down_ptr),
+        reinterpret_cast<const int *>(kv_seq_lens_ptr), reinterpret_cast<float *>(vbias_ptr),
+        num_head_kv, max_k_down_len, max_num_stem_blocks, lambda_mag);
+  }
+}
+
+void stem_oam_prep_paged_kv_qpertoken_perhead_kvpertensor_dim128_async(
+    void *kflat_ptr, void *vbias_ptr, const void *kcache_ptr, const void *vcache_ptr,
+    const void *kscale_ptr, const void *vscale_ptr, const void *block_ids_ptr,
+    const void *kv_seq_lens_ptr, int num_batch, int num_dim_qk, int num_dim_v, int num_head_kv,
+    int num_kvcache_blocks, int block_size, int num_seq_max_blocks, int stem_block_size,
+    int stem_stride, float lambda_mag, int max_num_stem_blocks, int max_k_down_len, int ldK,
+    int ldV, void *v_norm_down_ptr, cudaStream_t stream) {
+  if (block_size == 32) {
+    launch_stem_oam_prep_paged_kv_qpertoken_perhead_kvpertensor_dim128<32, 128, 16, 128, 128>(
+        kflat_ptr, vbias_ptr, kcache_ptr, vcache_ptr, kscale_ptr, vscale_ptr, block_ids_ptr,
+        kv_seq_lens_ptr, num_batch, num_dim_qk, num_dim_v, num_head_kv, num_kvcache_blocks,
+        num_seq_max_blocks, lambda_mag, max_num_stem_blocks, max_k_down_len, ldK, ldV,
+        v_norm_down_ptr, stream);
+  } else if (block_size == 64) {
+    launch_stem_oam_prep_paged_kv_qpertoken_perhead_kvpertensor_dim128<64, 128, 16, 128, 128>(
+        kflat_ptr, vbias_ptr, kcache_ptr, vcache_ptr, kscale_ptr, vscale_ptr, block_ids_ptr,
+        kv_seq_lens_ptr, num_batch, num_dim_qk, num_dim_v, num_head_kv, num_kvcache_blocks,
+        num_seq_max_blocks, lambda_mag, max_num_stem_blocks, max_k_down_len, ldK, ldV,
+        v_norm_down_ptr, stream);
+  }
+}
+
+// New qkpertoken_perhead_vperhead path (quant_type=0).
+template <int kBlockSize, int kStemBlockSize, int kStride, int kDimQK, int kDimV>
+void launch_stem_oam_prep_paged_kv_qkpertoken_perhead_vperhead_dim128(
+    void *kflat_ptr, void *vbias_ptr, const void *kcache_ptr, const void *vcache_ptr,
+    const void *kscale_ptr, const void *vscale_ptr, const void *block_ids_ptr,
+    const void *kv_seq_lens_ptr, int num_batch, int num_dim_qk, int num_dim_v, int num_head_kv,
+    int num_kvcache_blocks, int num_seq_max_blocks, float lambda_mag, int max_num_stem_blocks,
+    int max_k_down_len, int ldK, int ldV, int ldKS, int ldKS1, int ldKS2, void *v_norm_down_ptr,
+    cudaStream_t stream) {
+  using namespace cute;  // NOLINT
+
+  using Tfp8 = cute::float_e4m3_t;
+  using Tbf16 = cute::bfloat16_t;
+
+  // Sub-kernel 1: paged KV prep with per-token K-scale + per-head V-scale.
+  {
+    constexpr int kSamplePerBlock = kStemBlockSize / kStride;
+    dim3 grid(max_num_stem_blocks, num_batch * num_head_kv);
+    dim3 block(kSamplePerBlock * 32);
+
+    kernels::stem_prep_paged_kv_qkpertoken_perhead_vperhead_kernel<kBlockSize, kStemBlockSize,
+                                                                   kStride, kDimQK, kDimV>
+        <<<grid, block, 0, stream>>>(reinterpret_cast<const __nv_fp8_e4m3 *>(kcache_ptr),
+                                     reinterpret_cast<const __nv_fp8_e4m3 *>(vcache_ptr),
+                                     reinterpret_cast<const float *>(kscale_ptr),
+                                     reinterpret_cast<const float *>(vscale_ptr),
+                                     reinterpret_cast<const int *>(block_ids_ptr),
+                                     reinterpret_cast<const int *>(kv_seq_lens_ptr),
+                                     reinterpret_cast<__nv_bfloat16 *>(kflat_ptr),
+                                     reinterpret_cast<float *>(v_norm_down_ptr), num_head_kv,
+                                     num_seq_max_blocks, ldK, ldV, ldKS, ldKS1, ldKS2,
+                                     max_num_stem_blocks, max_k_down_len);
+  }
+
+  // Sub-kernel 2: Vbias reduce (shared between both quant_type paths; log normalize
+  // is invariant to the global per-head V-scale).
+  {
+    dim3 grid(num_batch * num_head_kv);
+    dim3 block(256);
+
+    kernels::vbias_reduce_kernel<kStemBlockSize, kStride><<<grid, block, 0, stream>>>(
+        reinterpret_cast<const float *>(v_norm_down_ptr),
+        reinterpret_cast<const int *>(kv_seq_lens_ptr), reinterpret_cast<float *>(vbias_ptr),
+        num_head_kv, max_k_down_len, max_num_stem_blocks, lambda_mag);
+  }
+}
+
+void stem_oam_prep_paged_kv_qkpertoken_perhead_vperhead_dim128_async(
+    void *kflat_ptr, void *vbias_ptr, const void *kcache_ptr, const void *vcache_ptr,
+    const void *kscale_ptr, const void *vscale_ptr, const void *block_ids_ptr,
+    const void *kv_seq_lens_ptr, int num_batch, int num_dim_qk, int num_dim_v, int num_head_kv,
+    int num_kvcache_blocks, int block_size, int scale_block_size, int num_seq_max_blocks,
+    int stem_block_size, int stem_stride, float lambda_mag, int max_num_stem_blocks,
+    int max_k_down_len, int ldK, int ldV, int ldKS, int ldKS1, int ldKS2, void *v_norm_down_ptr,
+    cudaStream_t stream) {
+  if (block_size == 32) {
+    launch_stem_oam_prep_paged_kv_qkpertoken_perhead_vperhead_dim128<32, 128, 16, 128, 128>(
+        kflat_ptr, vbias_ptr, kcache_ptr, vcache_ptr, kscale_ptr, vscale_ptr, block_ids_ptr,
+        kv_seq_lens_ptr, num_batch, num_dim_qk, num_dim_v, num_head_kv, num_kvcache_blocks,
+        num_seq_max_blocks, lambda_mag, max_num_stem_blocks, max_k_down_len, ldK, ldV, ldKS, ldKS1,
+        ldKS2, v_norm_down_ptr, stream);
+  } else if (block_size == 64) {
+    launch_stem_oam_prep_paged_kv_qkpertoken_perhead_vperhead_dim128<64, 128, 16, 128, 128>(
+        kflat_ptr, vbias_ptr, kcache_ptr, vcache_ptr, kscale_ptr, vscale_ptr, block_ids_ptr,
+        kv_seq_lens_ptr, num_batch, num_dim_qk, num_dim_v, num_head_kv, num_kvcache_blocks,
+        num_seq_max_blocks, lambda_mag, max_num_stem_blocks, max_k_down_len, ldK, ldV, ldKS, ldKS1,
+        ldKS2, v_norm_down_ptr, stream);
+  }
+}
+
+}  // namespace stem
+}  // namespace hpc

--- a/src/stem/stem_oam_prep_paged_kv_dim128.h
+++ b/src/stem/stem_oam_prep_paged_kv_dim128.h
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Tencent.
+
+#ifndef SRC_STEM_STEM_OAM_PREP_PAGED_KV_DIM128_H_
+#define SRC_STEM_STEM_OAM_PREP_PAGED_KV_DIM128_H_
+
+#include <cuda_runtime_api.h>
+#include <stdint.h>
+
+namespace hpc {
+namespace stem {
+
+// Legacy quant_type=1 path: per-tensor K-scale + per-tensor V-scale.
+void stem_oam_prep_paged_kv_qpertoken_perhead_kvpertensor_dim128_async(
+    void *kflat_ptr, void *vbias_ptr, const void *kcache_ptr, const void *vcache_ptr,
+    const void *kscale_ptr, const void *vscale_ptr, const void *block_ids_ptr,
+    const void *kv_seq_lens_ptr, int num_batch, int num_dim_qk, int num_dim_v, int num_head_kv,
+    int num_kvcache_blocks, int block_size, int num_seq_max_blocks, int stem_block_size,
+    int stem_stride, float lambda_mag, int max_num_stem_blocks, int max_k_down_len, int ldK,
+    int ldV, void *v_norm_down_ptr, cudaStream_t stream);
+
+// New quant_type=0 path: per-token K-scale (4D fp32, strides ldKS/ldKS1/ldKS2 in fp32 elements)
+// + per-head V-scale (vscale_ptr is a vector of length num_head_kv).
+void stem_oam_prep_paged_kv_qkpertoken_perhead_vperhead_dim128_async(
+    void *kflat_ptr, void *vbias_ptr, const void *kcache_ptr, const void *vcache_ptr,
+    const void *kscale_ptr, const void *vscale_ptr, const void *block_ids_ptr,
+    const void *kv_seq_lens_ptr, int num_batch, int num_dim_qk, int num_dim_v, int num_head_kv,
+    int num_kvcache_blocks, int block_size, int scale_block_size, int num_seq_max_blocks,
+    int stem_block_size, int stem_stride, float lambda_mag, int max_num_stem_blocks,
+    int max_k_down_len, int ldK, int ldV, int ldKS, int ldKS1, int ldKS2, void *v_norm_down_ptr,
+    cudaStream_t stream);
+
+}  // namespace stem
+}  // namespace hpc
+
+#endif  // SRC_STEM_STEM_OAM_PREP_PAGED_KV_DIM128_H_

--- a/src/stem/stem_oam_prep_varlen_q_dim128.cu
+++ b/src/stem/stem_oam_prep_varlen_q_dim128.cu
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Tencent.
+
+#include <cuda.h>
+
+#include "src/stem/stem_kernels.cuh"
+#include "src/stem/stem_oam_prep_varlen_q_dim128.h"
+#include "src/utils/utils.cuh"
+
+namespace hpc {
+namespace stem {
+
+template <int kStemBlockSize, int kStride, int kDimQK, bool kIsPerTensorQscale>
+void launch_stem_oam_prep_varlen_q_dim128(void *qflat_ptr, const void *q_fp8_ptr,
+                                          const void *qscale_ptr, const void *q_seq_lens_ptr,
+                                          const void *cu_seqlens_q_ptr, int num_batch,
+                                          int num_head_q, int ldQ, int max_num_q_blocks,
+                                          cudaStream_t stream) {
+  constexpr int kSamplePerBlock = kStemBlockSize / kStride;
+  dim3 grid(max_num_q_blocks, num_batch * num_head_q);
+  dim3 block(kSamplePerBlock * 32);
+
+  kernels::stem_prep_varlen_q_kernel<kStemBlockSize, kStride, kDimQK, kIsPerTensorQscale>
+      <<<grid, block, 0, stream>>>(reinterpret_cast<const __nv_fp8_e4m3 *>(q_fp8_ptr),
+                                   reinterpret_cast<const float *>(qscale_ptr),
+                                   reinterpret_cast<const int *>(q_seq_lens_ptr),
+                                   reinterpret_cast<const int *>(cu_seqlens_q_ptr),
+                                   reinterpret_cast<__nv_bfloat16 *>(qflat_ptr), num_head_q, ldQ,
+                                   max_num_q_blocks);
+}
+
+void stem_oam_prep_varlen_q_dim128_async(void *qflat_ptr, const void *q_fp8_ptr,
+                                         const void *qscale_ptr, const void *q_seq_lens_ptr,
+                                         const void *cu_seqlens_q_ptr, int num_batch,
+                                         int num_head_q, int ldQ, int stem_block_size,
+                                         int stem_stride, int max_num_q_blocks,
+                                         cudaStream_t stream) {
+  // dim128 model uses per-token qscale [B, Hq, seq].
+  launch_stem_oam_prep_varlen_q_dim128<128, 16, 128, false>(
+      qflat_ptr, q_fp8_ptr, qscale_ptr, q_seq_lens_ptr, cu_seqlens_q_ptr, num_batch, num_head_q,
+      ldQ, max_num_q_blocks, stream);
+}
+
+}  // namespace stem
+}  // namespace hpc

--- a/src/stem/stem_oam_prep_varlen_q_dim128.h
+++ b/src/stem/stem_oam_prep_varlen_q_dim128.h
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Tencent.
+
+#ifndef SRC_STEM_STEM_OAM_PREP_VARLEN_Q_DIM128_H_
+#define SRC_STEM_STEM_OAM_PREP_VARLEN_Q_DIM128_H_
+
+#include <cuda_runtime_api.h>
+#include <stdint.h>
+
+namespace hpc {
+namespace stem {
+
+void stem_oam_prep_varlen_q_dim128_async(void *qflat_ptr, const void *q_fp8_ptr,
+                                         const void *qscale_ptr, const void *q_seq_lens_ptr,
+                                         const void *cu_seqlens_q_ptr, int num_batch,
+                                         int num_head_q, int ldQ, int stem_block_size,
+                                         int stem_stride, int max_num_q_blocks,
+                                         cudaStream_t stream);
+
+}  // namespace stem
+}  // namespace hpc
+
+#endif  // SRC_STEM_STEM_OAM_PREP_VARLEN_Q_DIM128_H_

--- a/src/stem/stem_tpd.cu
+++ b/src/stem/stem_tpd.cu
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 Tencent.
+
+#include <cuda.h>
+
+#include "src/stem/stem_kernels.cuh"
+#include "src/stem/stem_tpd.h"
+
+namespace hpc {
+namespace stem {
+
+// kEPT: Elements per thread
+// kWPR: Warps per row
+// kWPC: Warps per CTA
+//
+//   max_Kb    kEPT   kWPR   kWPC  Threads  kRowsPerCTA  Coverage
+//   ≤ 1024      32     1     8      256         8         1024
+//   ≤ 2048      32     2     2       64         1         2048
+//   ≤ 4096      32     4     4      128         1         4096
+//   ≤ 8192      32     8     8      256         1         8192
+//   > 8192     128     8     8      256         1        32768
+//
+//   kWPR = 1  →  kWPC = 8     (8 independent rows/CTA, warp-shuffle only, no sync)
+//   kWPR > 1  →  kWPC = kWPR  (1 cooperative row/CTA, cross-warp via __syncthreads)
+template <int kEPT, int kWPR, int kWPC>
+void launch_stem_tpd(void *mask_ptr, const void *block_logits_ptr, const void *q_seq_lens_ptr,
+                     const void *kv_seq_lens_ptr, const void *num_prompt_tokens_ptr, int num_batch,
+                     int num_heads, int max_Qb, int max_Kb, int block_size, float alpha,
+                     int initial_blocks, int window_size, float k_block_num_rate_medium,
+                     int k_block_num_bias_medium, float k_block_num_rate_large,
+                     int k_block_num_bias_large, cudaStream_t stream) {
+  constexpr int kRowsPerCTA = kWPC / kWPR;
+
+  dim3 grid((max_Qb + kRowsPerCTA - 1) / kRowsPerCTA, num_heads, num_batch);
+  dim3 block(kWPC * 32);
+
+  kernels::stem_tpd_kernel<kEPT, kWPR, kWPC><<<grid, block, 0, stream>>>(
+      reinterpret_cast<const __nv_bfloat16 *>(block_logits_ptr),
+      reinterpret_cast<uint8_t *>(mask_ptr), reinterpret_cast<const int *>(q_seq_lens_ptr),
+      reinterpret_cast<const int *>(kv_seq_lens_ptr),
+      reinterpret_cast<const int *>(num_prompt_tokens_ptr), alpha, block_size, initial_blocks,
+      window_size, k_block_num_rate_medium, k_block_num_bias_medium, k_block_num_rate_large,
+      k_block_num_bias_large, num_heads, max_Qb, max_Kb);
+}
+
+void stem_tpd_async(void *mask_ptr, const void *block_logits_ptr, const void *q_seq_lens_ptr,
+                    const void *kv_seq_lens_ptr, const void *num_prompt_tokens_ptr, int num_batch,
+                    int num_heads, int max_Qb, int max_Kb, int block_size, float alpha,
+                    int initial_blocks, int window_size, float k_block_num_rate_medium,
+                    int k_block_num_bias_medium, float k_block_num_rate_large,
+                    int k_block_num_bias_large, cudaStream_t stream) {
+  if (max_Kb <= 1024) {
+    launch_stem_tpd<32, 1, 8>(mask_ptr, block_logits_ptr, q_seq_lens_ptr, kv_seq_lens_ptr,
+                              num_prompt_tokens_ptr, num_batch, num_heads, max_Qb, max_Kb,
+                              block_size, alpha, initial_blocks, window_size,
+                              k_block_num_rate_medium, k_block_num_bias_medium,
+                              k_block_num_rate_large, k_block_num_bias_large, stream);
+  } else if (max_Kb <= 2048) {
+    launch_stem_tpd<32, 2, 2>(mask_ptr, block_logits_ptr, q_seq_lens_ptr, kv_seq_lens_ptr,
+                              num_prompt_tokens_ptr, num_batch, num_heads, max_Qb, max_Kb,
+                              block_size, alpha, initial_blocks, window_size,
+                              k_block_num_rate_medium, k_block_num_bias_medium,
+                              k_block_num_rate_large, k_block_num_bias_large, stream);
+  } else if (max_Kb <= 4096) {
+    launch_stem_tpd<32, 4, 4>(mask_ptr, block_logits_ptr, q_seq_lens_ptr, kv_seq_lens_ptr,
+                              num_prompt_tokens_ptr, num_batch, num_heads, max_Qb, max_Kb,
+                              block_size, alpha, initial_blocks, window_size,
+                              k_block_num_rate_medium, k_block_num_bias_medium,
+                              k_block_num_rate_large, k_block_num_bias_large, stream);
+  } else if (max_Kb <= 8192) {
+    launch_stem_tpd<32, 8, 8>(mask_ptr, block_logits_ptr, q_seq_lens_ptr, kv_seq_lens_ptr,
+                              num_prompt_tokens_ptr, num_batch, num_heads, max_Qb, max_Kb,
+                              block_size, alpha, initial_blocks, window_size,
+                              k_block_num_rate_medium, k_block_num_bias_medium,
+                              k_block_num_rate_large, k_block_num_bias_large, stream);
+  } else {
+    launch_stem_tpd<128, 8, 8>(mask_ptr, block_logits_ptr, q_seq_lens_ptr, kv_seq_lens_ptr,
+                               num_prompt_tokens_ptr, num_batch, num_heads, max_Qb, max_Kb,
+                               block_size, alpha, initial_blocks, window_size,
+                               k_block_num_rate_medium, k_block_num_bias_medium,
+                               k_block_num_rate_large, k_block_num_bias_large, stream);
+  }
+}
+
+}  // namespace stem
+}  // namespace hpc

--- a/src/stem/stem_tpd.h
+++ b/src/stem/stem_tpd.h
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Tencent.
+
+#ifndef SRC_STEM_STEM_TPD_H_
+#define SRC_STEM_STEM_TPD_H_
+
+#include <cuda_runtime_api.h>
+
+namespace hpc {
+namespace stem {
+
+void stem_tpd_async(void *mask_ptr, const void *block_logits_ptr, const void *q_seq_lens_ptr,
+                    const void *kv_seq_lens_ptr, const void *num_prompt_tokens_ptr, int num_batch,
+                    int num_heads, int max_Qb, int max_Kb, int block_size, float alpha,
+                    int initial_blocks, int window_size, float k_block_num_rate_medium,
+                    int k_block_num_bias_medium, float k_block_num_rate_large,
+                    int k_block_num_bias_large, cudaStream_t stream);
+
+}  // namespace stem
+}  // namespace hpc
+
+#endif  // SRC_STEM_STEM_TPD_H_

--- a/src/utils/utils.cuh
+++ b/src/utils/utils.cuh
@@ -123,6 +123,26 @@ __device__ __forceinline__ constexpr auto to(const vec_t<T, N> &v) {
       o[i] = __nv_fp8x4_e4m3(*reinterpret_cast<const float4 *>(&v[4 * i]));
     }
     return o;
+  } else if constexpr (std::is_same_v<T, __nv_fp8x4_e4m3> && std::is_same_v<U, float>) {
+    using V = vec_t<float, N * 4>;
+    V o;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      auto y = static_cast<float4>(v[i]);
+      o[i * 4 + 0] = y.x;
+      o[i * 4 + 1] = y.y;
+      o[i * 4 + 2] = y.z;
+      o[i * 4 + 3] = y.w;
+    }
+    return o;
+  } else if constexpr (std::is_same_v<T, __nv_fp8_e4m3> && std::is_same_v<U, float>) {
+    using V = vec_t<float, N>;
+    V o;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      o[i] = static_cast<float>(v[i]);
+    }
+    return o;
   } else if constexpr (std::is_same_v<T, __nv_bfloat162> && std::is_same_v<U, __nv_fp8x4_e4m3>) {
     static_assert(N % 2 == 0, "N % 2 must be 0");
     using V = vec_t<__nv_fp8x4_e4m3, N / 2>;

--- a/tests/test_stem_qkpertoken_perhead_vperhead.py
+++ b/tests/test_stem_qkpertoken_perhead_vperhead.py
@@ -1,0 +1,476 @@
+"""CI correctness tests for dim128 Stem with Q/K per-token and V per-head scales.
+
+Exercises `QuantType.QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD`:
+  - kscale: 4D [num_blocks, kScaleBlockSize, num_kv_heads, num_dim_scale]
+            * fp32 dtype OR fp8 view of the same fp32 storage (both supported)
+            * semantically per-KV-token (one fp32 scale per token in page)
+  - vscale: per-head fp32 vector [num_kv_heads]
+
+Tests:
+  1. test_qkpertoken_perhead_vperhead_prep_paged_kv  -- kflat / vbias correctness
+  2. test_qkpertoken_perhead_vperhead_fp8_view       -- fp8 view matches fp32
+  3. test_qkpertoken_perhead_vperhead_e2e            -- end-to-end stem_paged_kv
+"""
+
+import math
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.realpath(list(Path(__file__).parent.glob("../build/lib.*/"))[0]))
+
+import hpc
+import torch
+
+# ====================================================================
+# Shared constants
+# ====================================================================
+
+STEM_BLOCK_SIZE = 128
+STEM_STRIDE = 16
+LAMBDA_MAG = 0.3
+ALPHA = 1.0
+INITIAL_BLOCKS = 4
+WINDOW_SIZE = 4
+K_BLOCK_NUM_RATE_MEDIUM = 0.2
+K_BLOCK_NUM_BIAS_MEDIUM = 30
+K_BLOCK_NUM_RATE_LARGE = 0.1
+K_BLOCK_NUM_BIAS_LARGE = 30
+
+
+def _setup_paged_fp8_data(
+    num_batch,
+    seq_len,
+    num_head_q,
+    num_head_kv,
+    dim_qk=128,
+    dim_v=128,
+    kv_block_size=64,
+):
+    """Create random paged FP8 data with new-path K-scale (4D fp32) + V-scale (per-head)."""
+    T_fp8 = torch.float8_e4m3fn
+    device = "cuda"
+    total_tokens = num_batch * seq_len
+
+    q_fp8 = (
+        torch.randn(total_tokens, num_head_q, dim_qk, dtype=torch.bfloat16, device=device)
+        / math.sqrt(dim_qk)
+    ).to(T_fp8)
+
+    num_blocks_per_req = (seq_len + kv_block_size - 1) // kv_block_size
+    total_blocks = num_batch * num_blocks_per_req
+
+    kcache_fp8 = (
+        torch.randn(
+            total_blocks,
+            kv_block_size,
+            num_head_kv,
+            dim_qk,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / math.sqrt(dim_qk)
+    ).to(T_fp8)
+    vcache_fp8 = torch.randn(
+        total_blocks,
+        kv_block_size,
+        num_head_kv,
+        dim_v,
+        dtype=torch.bfloat16,
+        device=device,
+    ).to(T_fp8)
+
+    kv_indices = torch.arange(total_blocks, device=device, dtype=torch.int32).reshape(
+        num_batch, num_blocks_per_req
+    )
+
+    max_seqlen_pad128 = ((seq_len + 127) // 128) * 128
+    qscale = torch.ones(
+        num_batch, num_head_q, max_seqlen_pad128, dtype=torch.float32, device=device
+    )
+
+    # 4D per-token K-scale: kscale_fp32[block, row_in_page // 32, head_kv, row_in_page % 32].
+    num_dim_scale = dim_v // 4
+    assert (
+        kv_block_size % num_dim_scale == 0
+    ), f"kv_block_size={kv_block_size} must be a multiple of num_dim_scale={num_dim_scale}"
+    scale_block_size = kv_block_size // num_dim_scale
+    kscale_fp32 = (
+        torch.abs(
+            torch.randn(
+                total_blocks,
+                scale_block_size,
+                num_head_kv,
+                num_dim_scale,
+                dtype=torch.float32,
+                device=device,
+            )
+        )
+        / 10
+    )
+
+    vscale = torch.abs(torch.ones(num_head_kv, dtype=torch.float32, device=device))
+
+    seqlens = torch.full((num_batch,), seq_len, dtype=torch.int32, device=device)
+    cu_q_seqlens = torch.zeros(num_batch + 1, dtype=torch.int32, device=device)
+    cu_q_seqlens[1:] = torch.cumsum(seqlens, dim=0)
+    kv_seqlens = seqlens.clone()
+
+    return dict(
+        q_fp8=q_fp8,
+        kcache_fp8=kcache_fp8,
+        vcache_fp8=vcache_fp8,
+        qscale=qscale,
+        kscale_fp32=kscale_fp32,
+        vscale=vscale,
+        kv_indices=kv_indices,
+        cu_q_seqlens=cu_q_seqlens,
+        kv_seqlens=kv_seqlens,
+        kv_block_size=kv_block_size,
+        scale_block_size=scale_block_size,
+        num_dim_scale=num_dim_scale,
+    )
+
+
+# ====================================================================
+# PyTorch reference for the new quant_type=0 KV prep
+# ====================================================================
+
+
+def _gather_per_token_kscale(kscale_fp32, kv_indices, kv_seqlens, kv_block_size):
+    """Materialize a per-token K-scale tensor [num_batch, num_head_kv, max_kv_pad].
+
+    For each request and each KV token position t < kv_seqlens[b]:
+      page_idx       = t // kv_block_size
+      row_in_page    = t %  kv_block_size
+      phys_block     = kv_indices[b, page_idx]
+      kscale_per_tok = kscale_fp32[phys_block, row_in_page // 32, head_kv, row_in_page % 32]
+    """
+    num_batch = kv_seqlens.shape[0]
+    num_head_kv = kscale_fp32.shape[2]
+    max_kv_padded = (
+        (int(kv_seqlens.max().item()) + STEM_BLOCK_SIZE - 1) // STEM_BLOCK_SIZE
+    ) * STEM_BLOCK_SIZE
+    device = kscale_fp32.device
+    dtype = kscale_fp32.dtype
+    out = torch.zeros(num_batch, num_head_kv, max_kv_padded, dtype=dtype, device=device)
+    for b in range(num_batch):
+        seqlen_b = int(kv_seqlens[b].item())
+        for t in range(seqlen_b):
+            page_idx = t // kv_block_size
+            row_in_page = t % kv_block_size
+            phys_block = int(kv_indices[b, page_idx].item())
+            row_chunk = row_in_page // 32
+            row_offset = row_in_page % 32
+            for h in range(num_head_kv):
+                out[b, h, t] = kscale_fp32[phys_block, row_chunk, h, row_offset]
+    return out
+
+
+def _kv_prep_reference(
+    kcache_fp8,
+    vcache_fp8,
+    kscale_fp32,
+    vscale,
+    kv_indices,
+    kv_seqlens,
+    kv_block_size,
+    lambda_mag=LAMBDA_MAG,
+    stem_block_size=STEM_BLOCK_SIZE,
+    stem_stride=STEM_STRIDE,
+):
+    """Pure PyTorch reference matching the new qkpertoken_perhead_vperhead kernel.
+
+    K processing: per-KV-token scale folded into the FP32 group sum.
+    V processing: per-head vscale folded into element-wise scaling before L2 norm.
+    Vbias path is shared with legacy (log normalize is invariant to global per-head scale).
+    """
+    num_batch = kv_seqlens.shape[0]
+    num_head_kv = kcache_fp8.shape[2]
+    dim_qk = kcache_fp8.shape[3]
+    dim_v = vcache_fp8.shape[3]
+
+    sample_per_block = stem_block_size // stem_stride  # = 8
+
+    max_kv = int(kv_seqlens.max().item())
+    max_kv_padded = ((max_kv + stem_block_size - 1) // stem_block_size) * stem_block_size
+    max_num_stem_blocks = max_kv_padded // stem_block_size
+    max_k_down_len = max_kv_padded // stem_stride
+
+    device = kcache_fp8.device
+
+    # Materialize per-token K-scale (B, Hkv, max_kv_pad).
+    kscale_per_token = _gather_per_token_kscale(kscale_fp32, kv_indices, kv_seqlens, kv_block_size)
+
+    # Materialize gathered K/V per (batch, head_kv, token, dim).
+    K_dense = torch.zeros(
+        num_batch, num_head_kv, max_kv_padded, dim_qk, dtype=torch.float32, device=device
+    )
+    V_dense = torch.zeros(
+        num_batch, num_head_kv, max_kv_padded, dim_v, dtype=torch.float32, device=device
+    )
+    for b in range(num_batch):
+        seqlen_b = int(kv_seqlens[b].item())
+        for t in range(seqlen_b):
+            page_idx = t // kv_block_size
+            row_in_page = t % kv_block_size
+            phys_block = int(kv_indices[b, page_idx].item())
+            K_dense[b, :, t, :] = kcache_fp8[phys_block, row_in_page, :, :].float()
+            V_dense[b, :, t, :] = vcache_fp8[phys_block, row_in_page, :, :].float()
+
+    # Apply per-token K-scale to K (broadcast on dim).
+    K_scaled = K_dense * kscale_per_token.unsqueeze(-1)
+
+    # K group-sum -> kflat (BF16 with reversed group order).
+    kflat = torch.zeros(
+        num_batch,
+        num_head_kv,
+        max_num_stem_blocks,
+        stem_stride * dim_qk,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    for b in range(num_batch):
+        seqlen_b = int(kv_seqlens[b].item())
+        nblock = (seqlen_b + stem_block_size - 1) // stem_block_size
+        for sb in range(nblock):
+            row_base = sb * stem_block_size
+            for g in range(stem_stride):
+                acc = torch.zeros(num_head_kv, dim_qk, dtype=torch.float32, device=device)
+                for r in range(sample_per_block):
+                    row = row_base + g + r * stem_stride
+                    if row < seqlen_b:
+                        acc += K_scaled[b, :, row, :]
+                seg = stem_stride - 1 - g  # reversed group order
+                kflat[b, :, sb, seg * dim_qk : (seg + 1) * dim_qk] = acc.to(torch.bfloat16)
+
+    # V L2 norm with per-head vscale -> v_norm_down (FP32).
+    v_norm_down = torch.zeros(
+        num_batch, num_head_kv, max_k_down_len, dtype=torch.float32, device=device
+    )
+    for b in range(num_batch):
+        seqlen_b = int(kv_seqlens[b].item())
+        k_padded = ((seqlen_b + stem_block_size - 1) // stem_block_size) * stem_block_size
+        nblock = k_padded // stem_block_size
+        for sb in range(nblock):
+            row_base = sb * stem_block_size
+            for g in range(sample_per_block):
+                # Warp g handles rows [g*stride .. g*stride+stride-1] within the block.
+                max_norm = torch.zeros(num_head_kv, dtype=torch.float32, device=device)
+                for s in range(stem_stride):
+                    row = row_base + g * stem_stride + s
+                    if row < seqlen_b:
+                        v_scaled = V_dense[b, :, row, :] * vscale.unsqueeze(-1)
+                        norm = torch.sqrt((v_scaled * v_scaled).sum(dim=-1))
+                        max_norm = torch.maximum(max_norm, norm)
+                down_idx = sb * sample_per_block + g
+                if down_idx < max_k_down_len:
+                    v_norm_down[b, :, down_idx] = max_norm
+
+    # vbias_reduce: log normalize -> ReLU -> block average (per (batch, head_kv)).
+    vbias = torch.zeros(
+        num_batch, num_head_kv, max_num_stem_blocks, dtype=torch.float32, device=device
+    )
+    for b in range(num_batch):
+        seqlen_b = int(kv_seqlens[b].item())
+        k_padded = ((seqlen_b + stem_block_size - 1) // stem_block_size) * stem_block_size
+        k_down = k_padded // stem_stride
+        nblock = k_padded // stem_block_size
+        if k_down == 0:
+            continue
+        for h in range(num_head_kv):
+            slice_h = v_norm_down[b, h, :k_down]
+            log_vals = torch.log(slice_h + 1e-6)
+            mean = log_vals.mean()
+            std = log_vals.std(unbiased=True) if k_down > 1 else torch.tensor(0.0, device=device)
+            inv_std = 1.0 / (std + 1e-6)
+            for sb in range(nblock):
+                acc = torch.tensor(0.0, dtype=torch.float32, device=device)
+                for r in range(sample_per_block):
+                    idx = sb * sample_per_block + r
+                    if idx < k_down:
+                        log_val = torch.log(v_norm_down[b, h, idx] + 1e-6)
+                        normalized = (log_val - mean) * inv_std
+                        acc = acc + lambda_mag * torch.clamp(normalized, min=0.0)
+                vbias[b, h, sb] = acc / sample_per_block
+
+    return kflat, vbias
+
+
+# ====================================================================
+# Test 1: stem_oam_prep_paged_kv with quant_type=0 (QK per-token, V per-head)
+# ====================================================================
+
+
+@pytest.mark.parametrize("num_batch", [1])
+@pytest.mark.parametrize("seq_len", [256])
+@pytest.mark.parametrize("num_head_q,num_head_kv", [(4, 1)])
+@pytest.mark.parametrize("kv_block_size", [32, 64])
+def test_qkpertoken_perhead_vperhead_prep_paged_kv(
+    num_batch, seq_len, num_head_q, num_head_kv, kv_block_size
+):
+    torch.manual_seed(20260423)
+    torch.cuda.manual_seed(20260423)
+    d = _setup_paged_fp8_data(
+        num_batch, seq_len, num_head_q, num_head_kv, kv_block_size=kv_block_size
+    )
+
+    # Reference (FP32).
+    ref_kflat, ref_vbias = _kv_prep_reference(
+        d["kcache_fp8"],
+        d["vcache_fp8"],
+        d["kscale_fp32"],
+        d["vscale"],
+        d["kv_indices"],
+        d["kv_seqlens"],
+        d["kv_block_size"],
+        lambda_mag=LAMBDA_MAG,
+        stem_block_size=STEM_BLOCK_SIZE,
+        stem_stride=STEM_STRIDE,
+    )
+
+    # CUDA kernel via new quant_type=0 path (kscale fp32 dtype).
+    cuda_kflat, cuda_vbias = hpc.stem_oam_prep_paged_kv(
+        d["kcache_fp8"],
+        d["vcache_fp8"],
+        d["kscale_fp32"],
+        d["vscale"],
+        d["kv_indices"],
+        d["kv_seqlens"],
+        lambda_mag=LAMBDA_MAG,
+        stem_block_size=STEM_BLOCK_SIZE,
+        stem_stride=STEM_STRIDE,
+        quant_type=hpc.QuantType.QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD,
+    )
+
+    # Shape sanity.
+    assert cuda_kflat.shape == ref_kflat.shape
+    assert cuda_vbias.shape == ref_vbias.shape
+    assert cuda_kflat.dtype == torch.bfloat16
+    assert cuda_vbias.dtype == torch.float32
+
+    # Compare valid blocks per request.
+    for b in range(num_batch):
+        seqlen_b = int(d["kv_seqlens"][b].item())
+        valid_kb = (seqlen_b + STEM_BLOCK_SIZE - 1) // STEM_BLOCK_SIZE
+        ref_k = ref_kflat[b, :, :valid_kb].float()
+        cuda_k = cuda_kflat[b, :, :valid_kb].float()
+        assert torch.allclose(ref_k, cuda_k, atol=5e-2, rtol=5e-2), (
+            f"Kflat mismatch (batch={b}): "
+            f"max_abs={(ref_k - cuda_k).abs().max():.4e} "
+            f"mean_abs={(ref_k - cuda_k).abs().mean():.4e}"
+        )
+        ref_vb = ref_vbias[b, :, :valid_kb]
+        cuda_vb = cuda_vbias[b, :, :valid_kb]
+        assert torch.allclose(ref_vb, cuda_vb, atol=5e-3, rtol=5e-3), (
+            f"Vbias mismatch (batch={b}): " f"max_abs={(ref_vb - cuda_vb).abs().max():.4e}"
+        )
+
+
+# ====================================================================
+# Test 2: kscale passed as fp8 view (mirrors attention-side calling pattern)
+# ====================================================================
+
+
+@pytest.mark.parametrize("num_batch", [1])
+@pytest.mark.parametrize("seq_len", [512])
+@pytest.mark.parametrize("num_head_q,num_head_kv", [(4, 1)])
+@pytest.mark.parametrize("kv_block_size", [64])
+def test_qkpertoken_perhead_vperhead_fp8_view(
+    num_batch, seq_len, num_head_q, num_head_kv, kv_block_size
+):
+    """fp8 view of an fp32-backed kscale tensor must produce identical output.
+
+    The entry layer folds fp8 strides back to fp32 element units so the kernel
+    sees the same indexing in both cases.
+    """
+    torch.manual_seed(20260424)
+    torch.cuda.manual_seed(20260424)
+    d = _setup_paged_fp8_data(
+        num_batch, seq_len, num_head_q, num_head_kv, kv_block_size=kv_block_size
+    )
+    kscale_fp32 = d["kscale_fp32"]
+    # fp8 view: reinterpret the same memory as fp8; last dim grows by 4x in the byte view.
+    kscale_fp8_view = kscale_fp32.view(torch.float8_e4m3fn)
+    assert kscale_fp8_view.shape[3] == kscale_fp32.shape[3] * 4
+
+    out_fp32 = hpc.stem_oam_prep_paged_kv(
+        d["kcache_fp8"],
+        d["vcache_fp8"],
+        kscale_fp32,
+        d["vscale"],
+        d["kv_indices"],
+        d["kv_seqlens"],
+        lambda_mag=LAMBDA_MAG,
+        stem_block_size=STEM_BLOCK_SIZE,
+        stem_stride=STEM_STRIDE,
+        quant_type=hpc.QuantType.QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD,
+    )
+    out_fp8 = hpc.stem_oam_prep_paged_kv(
+        d["kcache_fp8"],
+        d["vcache_fp8"],
+        kscale_fp8_view,
+        d["vscale"],
+        d["kv_indices"],
+        d["kv_seqlens"],
+        lambda_mag=LAMBDA_MAG,
+        stem_block_size=STEM_BLOCK_SIZE,
+        stem_stride=STEM_STRIDE,
+        quant_type=hpc.QuantType.QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD,
+    )
+    # Bit-for-bit equal (both paths use identical kernel + identical underlying data).
+    assert torch.equal(out_fp32[0], out_fp8[0]), "Kflat differs between fp32 and fp8-view inputs"
+    assert torch.equal(out_fp32[1], out_fp8[1]), "Vbias differs between fp32 and fp8-view inputs"
+
+
+# ====================================================================
+# Test 3: end-to-end stem_paged_kv with quant_type=0
+# ====================================================================
+
+
+@pytest.mark.parametrize("num_batch", [1])
+@pytest.mark.parametrize("seq_len", [2048])
+@pytest.mark.parametrize("num_head_q,num_head_kv", [(4, 1)])
+def test_qkpertoken_perhead_vperhead_e2e(num_batch, seq_len, num_head_q, num_head_kv):
+    torch.manual_seed(20260425)
+    torch.cuda.manual_seed(20260425)
+    d = _setup_paged_fp8_data(num_batch, seq_len, num_head_q, num_head_kv)
+
+    mask = hpc.stem_paged_kv(
+        d["q_fp8"],
+        d["kcache_fp8"],
+        d["vcache_fp8"],
+        d["qscale"],
+        d["kscale_fp32"],
+        d["vscale"],
+        d["kv_indices"],
+        d["cu_q_seqlens"],
+        d["kv_seqlens"],
+        d["kv_seqlens"],  # num_prompt_tokens (normal prefill: equals kv_seqlens)
+        lambda_mag=LAMBDA_MAG,
+        alpha=ALPHA,
+        stem_block_size=STEM_BLOCK_SIZE,
+        stem_stride=STEM_STRIDE,
+        causal=True,
+        initial_blocks=INITIAL_BLOCKS,
+        window_size=WINDOW_SIZE,
+        k_block_num_rate_medium=K_BLOCK_NUM_RATE_MEDIUM,
+        k_block_num_bias_medium=K_BLOCK_NUM_BIAS_MEDIUM,
+        k_block_num_rate_large=K_BLOCK_NUM_RATE_LARGE,
+        k_block_num_bias_large=K_BLOCK_NUM_BIAS_LARGE,
+        quant_type=hpc.QuantType.QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD,
+    )
+
+    max_qb = (seq_len + STEM_BLOCK_SIZE - 1) // STEM_BLOCK_SIZE
+    assert mask.dim() == 4
+    assert mask.shape[0] == num_batch
+    assert mask.shape[1] == num_head_q
+    assert mask.dtype == torch.uint8
+    density = mask.float().mean().item()
+    assert 0.0 < density < 1.0, f"Mask density {density:.4f} looks degenerate"
+    # Diagonal must always be selected (TPD post-fix retention).
+    min_dim = min(mask.shape[2], mask.shape[3])
+    diag = mask[:, :, range(min_dim), range(min_dim)]
+    assert (diag == 1).all(), "Diagonal blocks must be selected"

--- a/tests/test_stem_qpertoken_perhead_kvpertensor.py
+++ b/tests/test_stem_qpertoken_perhead_kvpertensor.py
@@ -1,0 +1,334 @@
+"""CI correctness tests for dim128 Stem with Q per-token and KV per-tensor scales.
+
+Lightweight smoke tests covering:
+  1. stem_oam_prep_paged_kv  — KV prep (paged, dim=128): shape & dtype check
+  2. stem_oam_prep_varlen_q  — Q prep (dim=128): shape & dtype check
+  3. stem_oam_gemm           — OAM block-logits GEMM: shape & finite check
+  4. stem_tpd                — TPD mask generation: shape, dtype & mask sanity
+  5. stem_paged_kv           — End-to-end pipeline (dim=128): mask shape & sanity
+"""
+
+import sys
+import os
+import pytest
+from pathlib import Path
+
+sys.path.insert(0, os.path.realpath(list(Path(__file__).parent.glob("../build/lib.*/"))[0]))
+
+import hpc
+import torch
+import math
+
+
+# ====================================================================
+# Shared helpers
+# ====================================================================
+
+STEM_BLOCK_SIZE = 128
+STEM_STRIDE = 16
+LAMBDA_MAG = 0.3
+ALPHA = 1.0
+INITIAL_BLOCKS = 4
+WINDOW_SIZE = 4
+K_BLOCK_NUM_RATE_MEDIUM = 0.2
+K_BLOCK_NUM_BIAS_MEDIUM = 30
+K_BLOCK_NUM_RATE_LARGE = 0.1
+K_BLOCK_NUM_BIAS_LARGE = 30
+
+
+def _setup_paged_fp8_data(
+    num_batch, seq_len, num_head_q, num_head_kv, dim_qk=128, dim_v=128, kv_block_size=64
+):
+    """Create random paged FP8 data for dim_qk=128 Stem pipeline."""
+    T_fp8 = torch.float8_e4m3fn
+    device = "cuda"
+    total_tokens = num_batch * seq_len
+
+    q_fp8 = (
+        torch.randn(total_tokens, num_head_q, dim_qk, dtype=torch.bfloat16, device=device)
+        / math.sqrt(dim_qk)
+    ).to(T_fp8)
+
+    num_blocks_per_req = (seq_len + kv_block_size - 1) // kv_block_size
+    total_blocks = num_batch * num_blocks_per_req
+
+    kcache_fp8 = (
+        torch.randn(
+            total_blocks, kv_block_size, num_head_kv, dim_qk, dtype=torch.bfloat16, device=device
+        )
+        / math.sqrt(dim_qk)
+    ).to(T_fp8)
+    vcache_fp8 = torch.randn(
+        total_blocks,
+        kv_block_size,
+        num_head_kv,
+        dim_v,
+        dtype=torch.bfloat16,
+        device=device,
+    ).to(T_fp8)
+
+    kv_indices = torch.arange(total_blocks, device=device, dtype=torch.int32).reshape(
+        num_batch, num_blocks_per_req
+    )
+
+    max_seqlen_pad128 = ((seq_len + 127) // 128) * 128
+    qscale = torch.ones(
+        num_batch, num_head_q, max_seqlen_pad128, dtype=torch.float32, device=device
+    )
+    kscale = torch.ones(1, dtype=torch.float32, device=device)
+    vscale = torch.tensor(1.0, dtype=torch.float32, device=device)
+
+    seqlens = torch.full((num_batch,), seq_len, dtype=torch.int32, device=device)
+    cu_q_seqlens = torch.zeros(num_batch + 1, dtype=torch.int32, device=device)
+    cu_q_seqlens[1:] = torch.cumsum(seqlens, dim=0)
+    kv_seqlens = seqlens.clone()
+
+    return dict(
+        q_fp8=q_fp8,
+        kcache_fp8=kcache_fp8,
+        vcache_fp8=vcache_fp8,
+        qscale=qscale,
+        kscale=kscale,
+        vscale=vscale,
+        kv_indices=kv_indices,
+        cu_q_seqlens=cu_q_seqlens,
+        kv_seqlens=kv_seqlens,
+    )
+
+
+# ====================================================================
+# Test 1: stem_oam_prep_paged_kv
+# ====================================================================
+
+
+@pytest.mark.parametrize("num_batch", [1])
+@pytest.mark.parametrize("seq_len", [1024])
+@pytest.mark.parametrize("num_head_q,num_head_kv", [(4, 1)])
+def test_stem_oam_prep_paged_kv(num_batch, seq_len, num_head_q, num_head_kv):
+    torch.manual_seed(10086)
+    torch.cuda.manual_seed(10086)
+    d = _setup_paged_fp8_data(num_batch, seq_len, num_head_q, num_head_kv)
+    vscale_t = d["vscale"].unsqueeze(0)
+
+    kflat, vbias = hpc.stem_oam_prep_paged_kv(
+        d["kcache_fp8"],
+        d["vcache_fp8"],
+        d["kscale"],
+        vscale_t,
+        d["kv_indices"],
+        d["kv_seqlens"],
+        lambda_mag=LAMBDA_MAG,
+        stem_block_size=STEM_BLOCK_SIZE,
+        stem_stride=STEM_STRIDE,
+        quant_type=hpc.QuantType.QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR,
+    )
+
+    max_kv_padded = ((seq_len + STEM_BLOCK_SIZE - 1) // STEM_BLOCK_SIZE) * STEM_BLOCK_SIZE
+    max_kb = max_kv_padded // STEM_BLOCK_SIZE
+
+    assert kflat.dim() == 4
+    assert kflat.shape[0] == num_batch
+    assert kflat.shape[1] == num_head_kv
+    assert kflat.shape[2] == max_kb
+    assert kflat.dtype == torch.bfloat16
+
+    assert vbias.dim() == 3
+    assert vbias.shape[0] == num_batch
+    assert vbias.shape[1] == num_head_kv
+    assert vbias.shape[2] == max_kb
+    assert vbias.dtype == torch.float32
+
+
+# ====================================================================
+# Test 2: stem_oam_prep_varlen_q
+# ====================================================================
+
+
+@pytest.mark.parametrize("num_batch", [1])
+@pytest.mark.parametrize("seq_len", [1024])
+@pytest.mark.parametrize("num_head_q,num_head_kv", [(4, 1)])
+def test_stem_oam_prep_varlen_q(num_batch, seq_len, num_head_q, num_head_kv):
+    torch.manual_seed(10086)
+    torch.cuda.manual_seed(10086)
+    d = _setup_paged_fp8_data(num_batch, seq_len, num_head_q, num_head_kv)
+    q_seqlens = (d["cu_q_seqlens"][1:] - d["cu_q_seqlens"][:-1]).to(torch.int32)
+
+    qflat = hpc.stem_oam_prep_varlen_q(
+        d["q_fp8"],
+        d["qscale"],
+        q_seqlens,
+        d["cu_q_seqlens"],
+        stem_block_size=STEM_BLOCK_SIZE,
+        stem_stride=STEM_STRIDE,
+    )
+
+    max_q_padded = ((seq_len + STEM_BLOCK_SIZE - 1) // STEM_BLOCK_SIZE) * STEM_BLOCK_SIZE
+    max_qb = max_q_padded // STEM_BLOCK_SIZE
+
+    assert qflat.dim() == 4
+    assert qflat.shape[0] == num_batch
+    assert qflat.shape[1] == num_head_q
+    assert qflat.shape[2] == max_qb
+    assert qflat.dtype == torch.bfloat16
+
+
+# ====================================================================
+# Test 3: stem_oam_gemm
+# ====================================================================
+
+
+@pytest.mark.parametrize("num_batch", [1])
+@pytest.mark.parametrize("seq_len", [1024])
+@pytest.mark.parametrize("num_head_q,num_head_kv", [(4, 1)])
+def test_stem_oam_gemm(num_batch, seq_len, num_head_q, num_head_kv):
+    torch.manual_seed(10086)
+    torch.cuda.manual_seed(10086)
+    d = _setup_paged_fp8_data(num_batch, seq_len, num_head_q, num_head_kv)
+    q_seqlens = (d["cu_q_seqlens"][1:] - d["cu_q_seqlens"][:-1]).to(torch.int32)
+    vscale_t = d["vscale"].unsqueeze(0)
+
+    kflat, vbias = hpc.stem_oam_prep_paged_kv(
+        d["kcache_fp8"],
+        d["vcache_fp8"],
+        d["kscale"],
+        vscale_t,
+        d["kv_indices"],
+        d["kv_seqlens"],
+        lambda_mag=LAMBDA_MAG,
+        stem_block_size=STEM_BLOCK_SIZE,
+        stem_stride=STEM_STRIDE,
+        quant_type=hpc.QuantType.QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR,
+    )
+    qflat = hpc.stem_oam_prep_varlen_q(
+        d["q_fp8"],
+        d["qscale"],
+        q_seqlens,
+        d["cu_q_seqlens"],
+        stem_block_size=STEM_BLOCK_SIZE,
+        stem_stride=STEM_STRIDE,
+    )
+    block_logits = hpc.stem_oam_gemm(
+        qflat,
+        kflat,
+        vbias,
+        q_seqlens,
+        d["kv_seqlens"],
+        stem_block_size=STEM_BLOCK_SIZE,
+        stem_stride=STEM_STRIDE,
+        causal=True,
+    )
+
+    assert block_logits.dim() == 4
+    assert block_logits.shape[0] == num_batch
+    assert block_logits.shape[1] == num_head_q
+    # Logits should be mostly finite (causal masked positions are -inf)
+    finite_ratio = torch.isfinite(block_logits).float().mean().item()
+    assert finite_ratio > 0.1, f"Too few finite logits: {finite_ratio:.2%}"
+
+
+# ====================================================================
+# Test 4: stem_tpd
+# ====================================================================
+
+
+@pytest.mark.parametrize("num_batch", [1])
+@pytest.mark.parametrize("seq_len", [1024])
+@pytest.mark.parametrize("num_head_q", [4])
+def test_stem_tpd(num_batch, seq_len, num_head_q):
+    torch.manual_seed(10086)
+    torch.cuda.manual_seed(10086)
+    device = "cuda"
+    stem_block_size = STEM_BLOCK_SIZE
+    max_qb = (seq_len + stem_block_size - 1) // stem_block_size
+    max_kb = max_qb
+
+    # Simulate block_logits (bf16, causal-masked)
+    block_logits = torch.randn(
+        num_batch, num_head_q, max_qb, max_kb, dtype=torch.bfloat16, device=device
+    )
+    # Apply causal mask
+    qr = torch.arange(max_qb, device=device).unsqueeze(1)
+    kr = torch.arange(max_kb, device=device).unsqueeze(0)
+    causal_mask = kr > qr
+    block_logits.masked_fill_(causal_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+    q_seq_lens = torch.full((num_batch,), seq_len, dtype=torch.int32, device=device)
+    kv_seq_lens = q_seq_lens.clone()
+
+    mask = hpc.stem_tpd(
+        block_logits,
+        q_seq_lens,
+        kv_seq_lens,
+        kv_seq_lens,  # num_prompt_tokens (normal prefill: equals kv_seq_lens)
+        block_size=stem_block_size,
+        alpha=ALPHA,
+        initial_blocks=INITIAL_BLOCKS,
+        window_size=WINDOW_SIZE,
+        k_block_num_rate_medium=K_BLOCK_NUM_RATE_MEDIUM,
+        k_block_num_bias_medium=K_BLOCK_NUM_BIAS_MEDIUM,
+        k_block_num_rate_large=K_BLOCK_NUM_RATE_LARGE,
+        k_block_num_bias_large=K_BLOCK_NUM_BIAS_LARGE,
+    )
+
+    assert mask.shape == (num_batch, num_head_q, max_qb, max_kb)
+    assert mask.dtype == torch.uint8
+    # Diagonal should always be selected
+    diag = mask[:, :, range(min(max_qb, max_kb)), range(min(max_qb, max_kb))]
+    assert (diag == 1).all(), "Diagonal blocks must be selected"
+    # initial_blocks should be selected for all Q blocks
+    if max_kb >= INITIAL_BLOCKS:
+        init = mask[:, :, :, :INITIAL_BLOCKS]
+        assert (init == 1).all(), "Initial blocks must be selected"
+
+
+# ====================================================================
+# Test 5: stem_paged_kv (end-to-end pipeline)
+# ====================================================================
+
+
+@pytest.mark.parametrize("num_batch", [1])
+@pytest.mark.parametrize("seq_len", [2048])
+@pytest.mark.parametrize("num_head_q,num_head_kv", [(4, 1)])
+def test_stem_paged_kv_e2e(num_batch, seq_len, num_head_q, num_head_kv):
+    torch.manual_seed(10086)
+    torch.cuda.manual_seed(10086)
+    d = _setup_paged_fp8_data(num_batch, seq_len, num_head_q, num_head_kv)
+    vscale_t = d["vscale"].unsqueeze(0)
+
+    mask = hpc.stem_paged_kv(
+        d["q_fp8"],
+        d["kcache_fp8"],
+        d["vcache_fp8"],
+        d["qscale"],
+        d["kscale"],
+        vscale_t,
+        d["kv_indices"],
+        d["cu_q_seqlens"],
+        d["kv_seqlens"],
+        d["kv_seqlens"],  # num_prompt_tokens (normal prefill: equals kv_seqlens)
+        lambda_mag=LAMBDA_MAG,
+        alpha=ALPHA,
+        stem_block_size=STEM_BLOCK_SIZE,
+        stem_stride=STEM_STRIDE,
+        causal=True,
+        initial_blocks=INITIAL_BLOCKS,
+        window_size=WINDOW_SIZE,
+        k_block_num_rate_medium=K_BLOCK_NUM_RATE_MEDIUM,
+        k_block_num_bias_medium=K_BLOCK_NUM_BIAS_MEDIUM,
+        k_block_num_rate_large=K_BLOCK_NUM_RATE_LARGE,
+        k_block_num_bias_large=K_BLOCK_NUM_BIAS_LARGE,
+        quant_type=hpc.QuantType.QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR,
+    )
+
+    max_qb = (seq_len + STEM_BLOCK_SIZE - 1) // STEM_BLOCK_SIZE
+    assert mask.dim() == 4
+    assert mask.shape[0] == num_batch
+    assert mask.shape[1] == num_head_q
+    assert mask.dtype == torch.uint8
+    # Mask should be non-trivial (not all zeros, not all ones for seq_len >= 2048)
+    density = mask.float().mean().item()
+    assert 0.0 < density < 1.0, f"Mask density {density:.4f} looks degenerate"
+    # Diagonal should always be selected
+    min_dim = min(mask.shape[2], mask.shape[3])
+    diag = mask[:, :, range(min_dim), range(min_dim)]
+    assert (diag == 1).all(), "Diagonal blocks must be selected"


### PR DESCRIPTION
  ## Summary
  - Stem for block-sparse-attention, accepted by **ICML 2026**: https://arxiv.org/abs/2603.06274
  - Adds Stem scoring kernels: prep (paged KV / varlen Q), OAM block-logits GEMM, and TPD mask generation
  - Two quant schemes: `QPERTOKEN_PERHEAD_KPERTENSOR_VPERTENSOR` and `QPERTOKEN_PERHEAD_KPERTOKEN_PERHEAD_VPERHEAD`
  - 4 new ops: `stem_oam_prep_paged_kv`,  `stem_oam_prep_varlen_q`,  `stem_oam_gemm`, `stem_tpd`
  - Adds two missing `to<__nv_fp8x4_e4m3 → float>` / `to<__nv_fp8_e4m3 → float>` branches in `src/utils/utils.cuh`

  ## Stacked on top of
  - #<!45>  (block-sparse fp8 prefill attention)

  ## Test results
  - [x] `pytest tests/` — all passed
  - [x] strict diff against internal source: byte-identical

  ## Benchmark

<img width="2636" height="1435" alt="fig_stem_accuracy" src="https://github.com/user-attachments/assets/88f35eaf-4630-476e-b3fb-273f8dbc5696" />

<img width="3536" height="1586" alt="fig_stem_speedup" src="https://github.com/user-attachments/assets/7b37b173-0478-4183-a292-e6bd79ed35c8" />
