### PR TITLE
add fused sampler ops (topk/topp/temperature + rejection sampling)

### DIFF
--- a/benchmark/sampler/README.md
+++ b/benchmark/sampler/README.md
@@ -1,0 +1,46 @@
+# Sampler Benchmark
+
+This directory contains the benchmark entry used to reproduce the sampler latency results for the open-source figures.
+
+## Figure Mapping
+- Operator: HPC-Ops Sampler
+- Providers:
+  - `HPC-Ops`
+  - `vLLM/PyTorch`
+  - `FlashInfer`
+- Timing unit: microseconds per sampler call
+- Timing modes:
+  - `--timing nsys`: release-style timing using `nsys`, NVTX `step`, eager sampler calls, and median latency. This keeps the profiler/post-processing style aligned with FusedMoE while avoiding CUDA Graph capture paths that are not safe for sampler APIs in this environment.
+  - `--timing event`: quick CUDA event timing with eager sampler calls by default. `--graph` is available only for experiments because some sampler paths are not CUDA-graph-capture safe.
+- Default config: vocab size `120832`, BF16 logits, batch sizes `1,8,16,32,64,128,256,512`.
+
+## Scenario Names
+
+- `temperature`: `Temperature Sampling`, temperature-only fast path.
+- `full`: `Full Sampling`, repetition penalty + temperature + topk/topp + sampling.
+
+## Reproduction Commands
+
+Full sweep with the FusedMoE-aligned `nsys` timing path:
+
+```bash
+python3 benchmark_sampler.py \
+  --timing nsys \
+  --output-dir sampler_nsys \
+  --csv sampler_latency.csv \
+  --jsonl sampler_latency.jsonl
+```
+
+Fast smoke test with CUDA event timing:
+
+```bash
+python3 benchmark_sampler.py \
+  --timing event \
+  --scenes temperature full \
+  --batches 1 8 \
+  --providers hpc torch \
+  --warmup 1 \
+  --iters 3
+```
+
+If FlashInfer is unavailable or its API is incompatible with the local environment, the benchmark records the provider error and continues with the remaining providers.

--- a/benchmark/sampler/README.md
+++ b/benchmark/sampler/README.md
@@ -1,6 +1,6 @@
 # Sampler Benchmark
 
-This directory contains the benchmark entry used to reproduce the sampler latency results for the open-source figures.
+This directory contains the benchmark entry used to reproduce the sampler latency results.
 
 ## Figure Mapping
 - Operator: HPC-Ops Sampler

--- a/benchmark/sampler/README.md
+++ b/benchmark/sampler/README.md
@@ -1,8 +1,9 @@
 # Sampler Benchmark
 
-This directory contains the benchmark entry used to reproduce the sampler latency results.
+Benchmark HPC-Ops sampler kernels against PyTorch/vLLM-style and FlashInfer paths.
 
-## Figure Mapping
+## Overview
+
 - Operator: HPC-Ops Sampler
 - Providers:
   - `HPC-Ops`
@@ -10,18 +11,18 @@ This directory contains the benchmark entry used to reproduce the sampler latenc
   - `FlashInfer`
 - Timing unit: microseconds per sampler call
 - Timing modes:
-  - `--timing nsys`: release-style timing using `nsys`, NVTX `step`, eager sampler calls, and median latency. This keeps the profiler/post-processing style aligned with FusedMoE while avoiding CUDA Graph capture paths that are not safe for sampler APIs in this environment.
-  - `--timing event`: quick CUDA event timing with eager sampler calls by default. `--graph` is available only for experiments because some sampler paths are not CUDA-graph-capture safe.
+  - `--timing nsys`: release-style timing using `nsys`, NVTX ranges, eager sampler calls, and median latency from NVTX GPU projected duration. The worker does not synchronize inside each timed step.
+  - `--timing event`: quick CUDA event timing with eager sampler calls.
 - Default config: vocab size `120832`, BF16 logits, batch sizes `1,8,16,32,64,128,256,512`.
 
-## Scenario Names
+## Scenarios
 
 - `temperature`: `Temperature Sampling`, temperature-only fast path.
 - `full`: `Full Sampling`, repetition penalty + temperature + topk/topp + sampling.
 
-## Reproduction Commands
+## Usage
 
-Full sweep with the FusedMoE-aligned `nsys` timing path:
+Full sweep:
 
 ```bash
 python3 benchmark_sampler.py \
@@ -31,7 +32,7 @@ python3 benchmark_sampler.py \
   --jsonl sampler_latency.jsonl
 ```
 
-Fast smoke test with CUDA event timing:
+Smoke test:
 
 ```bash
 python3 benchmark_sampler.py \
@@ -42,5 +43,7 @@ python3 benchmark_sampler.py \
   --warmup 1 \
   --iters 3
 ```
+
+## Notes
 
 If FlashInfer is unavailable or its API is incompatible with the local environment, the benchmark records the provider error and continues with the remaining providers.

--- a/benchmark/sampler/benchmark_sampler.py
+++ b/benchmark/sampler/benchmark_sampler.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Tencent.
+
+"""Sampler benchmark.
+
+Scenarios:
+    - temperature: temperature-only sampling fast path.
+    - full: repetition penalty + temperature + topk/topp + sampling.
+
+operator: nsys profile, NVTX ``step`` ranges, and median latency. Sampler kernels
+are measured in eager mode because the temperature fast path and baseline
+sampling APIs are not CUDA-graph-capture safe in this environment.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from statistics import mean, median
+
+import torch
+
+
+sys.path.insert(0, os.path.realpath(list(Path(__file__).parent.glob("../../build/lib.*/"))[0]))
+
+import hpc  # noqa: E402
+from hpc.sampler import SoftmaxPolicy  # noqa: E402
+
+
+VOCAB_SIZE = 120832
+BATCHES = [1, 8, 16, 32, 64, 128, 256, 512]
+SCENES = ["temperature", "full"]
+PROVIDERS = ["hpc", "torch", "flashinfer"]
+DISPLAY = {
+    "hpc": "HPC-Ops",
+    "torch": "vLLM/PyTorch",
+    "flashinfer": "FlashInfer",
+}
+
+
+def make_gumbel(shape, device="cuda") -> torch.Tensor:
+    u = torch.rand(shape, dtype=torch.float32, device=device).clamp_min_(1e-20)
+    return -(-u.log()).log()
+
+
+def build_inputs(batch: int, dtype: torch.dtype, seed: int):
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    logits = torch.randn(batch, VOCAB_SIZE, dtype=dtype, device="cuda")
+    gumbel = make_gumbel((batch, VOCAB_SIZE))
+    temperature = torch.full((batch,), 0.7, dtype=torch.float32, device="cuda")
+    topk = torch.full((batch,), 20, dtype=torch.int32, device="cuda")
+    topp = torch.full((batch,), 0.9, dtype=torch.float32, device="cuda")
+    row_bytes = (VOCAB_SIZE + 7) // 8
+    penalty_mask = torch.zeros((batch, row_bytes), dtype=torch.uint8, device="cuda")
+    slot_id = torch.arange(batch, dtype=torch.int32, device="cuda")
+    return {
+        "logits": logits,
+        "gumbel": gumbel,
+        "temperature": temperature,
+        "topk": topk,
+        "topp": topp,
+        "penalty_mask": penalty_mask,
+        "slot_id": slot_id,
+    }
+
+
+def setup_call(provider: str, scene: str, batch: int, dtype: torch.dtype, seed: int):
+    data = build_inputs(batch, dtype, seed)
+    logits = data["logits"]
+    gumbel = data["gumbel"]
+    temperature = data["temperature"]
+
+    if provider == "hpc":
+        if scene == "temperature":
+            return lambda: hpc.fused_sampler(logits, temperature=temperature, gumbel_noise=gumbel)
+        if scene == "full":
+            return lambda: hpc.fused_sampler(
+                logits,
+                penalty_mask=data["penalty_mask"],
+                slot_id=data["slot_id"],
+                repetition_penalty=1.05,
+                temperature=temperature,
+                softmax_policy=SoftmaxPolicy.AFTER_TOPK,
+                topk=data["topk"],
+                topp=data["topp"],
+                max_topk=32,
+                gumbel_noise=gumbel,
+            )
+        raise ValueError(scene)
+
+    if provider == "torch":
+        if scene == "temperature":
+            return lambda: (logits.float() / temperature[:, None] + gumbel).argmax(dim=-1)
+        if scene == "full":
+            def run_torch_full():
+                work = logits.float() / temperature[:, None]
+                vals, idx = torch.topk(work, k=20, dim=-1)
+                probs = torch.softmax(vals, dim=-1)
+                keep = probs.cumsum(dim=-1) <= 0.9
+                keep[:, 0] = True
+                scores = torch.where(keep, probs.log(), torch.full_like(probs, -float("inf")))
+                scores = scores + torch.gather(gumbel, 1, idx)
+                return idx.gather(1, scores.argmax(dim=-1, keepdim=True))
+            return run_torch_full
+        raise ValueError(scene)
+
+    if provider == "flashinfer":
+        import flashinfer.sampling as sampling
+
+        if scene == "temperature":
+            return lambda: sampling.sampling_from_logits(
+                logits.float() / temperature[:, None],
+                deterministic=True,
+                seed=seed,
+            )
+        if scene == "full":
+            return lambda: sampling.top_k_top_p_sampling_from_logits(
+                logits.float() / temperature[:, None],
+                top_k=20,
+                top_p=0.9,
+                filter_apply_order="top_k_first",
+                deterministic=True,
+                seed=seed,
+            )
+        raise ValueError(scene)
+
+    raise ValueError(provider)
+
+
+def run_nsys_steps(call_fn, *, warmup: int, n_timed: int) -> None:
+    for _ in range(warmup):
+        call_fn()
+    torch.cuda.synchronize()
+
+    torch.cuda.cudart().cudaProfilerStart()
+    for _ in range(n_timed):
+        torch.cuda.nvtx.range_push("step")
+        call_fn()
+        torch.cuda.synchronize()
+        torch.cuda.nvtx.range_pop()
+    torch.cuda.cudart().cudaProfilerStop()
+
+
+def bench_event(call_fn, warmup: int, iters: int, use_graph: bool) -> tuple[float, float, int]:
+    for _ in range(warmup):
+        call_fn()
+    torch.cuda.synchronize()
+
+    if use_graph:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            call_fn()
+        for _ in range(warmup):
+            graph.replay()
+        torch.cuda.synchronize()
+        call_fn = graph.replay
+
+    events = [(torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)) for _ in range(iters)]
+    for start, end in events:
+        start.record()
+        call_fn()
+        end.record()
+    torch.cuda.synchronize()
+    vals = sorted(start.elapsed_time(end) * 1000.0 for start, end in events)
+    return float(median(vals)), float(mean(vals)), len(vals)
+
+
+def extract_nvtx_us(report_prefix: Path) -> list[float]:
+    cmd = [
+        "nsys",
+        "stats",
+        "--report",
+        "nvtx_gpu_proj_trace",
+        "--force-export=true",
+        "-q",
+        "-f",
+        "json",
+        str(report_prefix) + ".nsys-rep",
+    ]
+    try:
+        out = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
+        raw = json.loads(out.decode())
+        data = raw[0]["data"] if isinstance(raw, list) and raw and "data" in raw[0] else raw
+        samples = []
+        for entry in data:
+            name = entry.get("Name", "").strip().strip('"')
+            if name in ("step", ":step"):
+                samples.append(float(entry["Projected Duration (ns)"]) / 1000.0)
+        return samples[2:]
+    except Exception:
+        return []
+
+
+def run_nsys_profile(args, scene: str, batch: int, provider: str, out_dir: Path) -> tuple[float | None, float | None, int, str | None]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    report_prefix = out_dir / f"{scene}_bs{batch}_{provider}"
+    report_file = str(report_prefix) + ".nsys-rep"
+    if os.path.exists(report_file):
+        os.remove(report_file)
+
+    cmd = [
+        "nsys",
+        "profile",
+        "-f",
+        "true",
+        "-o",
+        str(report_prefix),
+        "--capture-range=cudaProfilerApi",
+        "--capture-range-end=stop-shutdown",
+        "--cuda-graph-trace=node",
+        "-t",
+        "cuda,nvtx",
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--worker",
+        "--scene",
+        scene,
+        "--batch",
+        str(batch),
+        "--provider",
+        provider,
+        "--dtype",
+        args.dtype,
+        "--warmup",
+        str(args.warmup),
+        "--iters",
+        str(args.iters),
+        "--seed",
+        str(args.seed),
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            timeout=args.nsys_timeout,
+            env=os.environ.copy(),
+        )
+    except subprocess.TimeoutExpired:
+        return None, None, 0, "nsys profile timeout"
+
+    if not os.path.exists(report_file) and proc.returncode != 0:
+        err = proc.stderr.decode(errors="replace").strip().splitlines()
+        return None, None, 0, err[-1] if err else "nsys profile failed"
+
+    vals = extract_nvtx_us(report_prefix)
+    if not vals:
+        return None, None, 0, "no NVTX step samples"
+    return float(median(vals)), float(mean(vals)), len(vals), None
+
+
+def dtype_from_name(name: str) -> torch.dtype:
+    return {"float32": torch.float32, "bfloat16": torch.bfloat16}[name]
+
+
+def run_worker(args) -> None:
+    call_fn = setup_call(args.provider, args.scene, args.batch, dtype_from_name(args.dtype), args.seed)
+    run_nsys_steps(call_fn, warmup=args.warmup, n_timed=args.iters + 2)
+
+
+def print_table(rows: list[dict]) -> None:
+    scenes = {"temperature": "Temperature Sampling", "full": "Full Sampling"}
+    print("")
+    print("=" * 110)
+    print("Sampler latency | us per call (lower is better)")
+    print("-" * 110)
+    print(f"{'scene':>22} | {'batch':>5} | {'provider':>12} | {'median_us':>10} | {'mean_us':>10} | {'samples':>7} | {'error':>18}")
+    print("-" * 110)
+    for r in rows:
+        med = f"{r['median_us']:.2f}" if isinstance(r.get("median_us"), (int, float)) else "ERR"
+        avg = f"{r['mean_us']:.2f}" if isinstance(r.get("mean_us"), (int, float)) else "ERR"
+        err = r.get("error") or ""
+        print(f"{scenes[r['scene']]:>22} | {r['batch']:5d} | {DISPLAY[r['provider']]:>12} | {med:>10} | {avg:>10} | {r['samples']:7d} | {err[:18]:>18}")
+    print("=" * 110)
+
+
+def write_csv(path: str, rows: list[dict]) -> None:
+    if not path or not rows:
+        return
+    with Path(path).open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_jsonl(path: str, rows: list[dict]) -> None:
+    if not path:
+        return
+    with Path(path).open("w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Benchmark HPC-Ops Sampler for figure 11.")
+    p.add_argument("--scenes", nargs="+", default=SCENES, choices=SCENES)
+    p.add_argument("--batches", type=int, nargs="+", default=BATCHES)
+    p.add_argument("--providers", nargs="+", default=PROVIDERS, choices=PROVIDERS)
+    p.add_argument("--timing", choices=["nsys", "event"], default="nsys")
+    p.add_argument(
+        "--graph",
+        dest="graph",
+        action="store_true",
+        help="try CUDA Graph replay for --timing event; sampler paths are measured eager by default.",
+    )
+    p.add_argument("--no-graph", dest="graph", action="store_false", help=argparse.SUPPRESS)
+    p.add_argument("--dtype", choices=["float32", "bfloat16"], default="bfloat16")
+    p.add_argument("--warmup", type=int, default=3)
+    p.add_argument("--iters", type=int, default=52)
+    p.add_argument("--seed", type=int, default=10086)
+    p.add_argument("--output-dir", default="")
+    p.add_argument("--tag", default="")
+    p.add_argument("--nsys-timeout", type=int, default=300)
+    p.add_argument("--csv", default="")
+    p.add_argument("--jsonl", default="")
+    p.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    p.add_argument("--scene", choices=SCENES, default="temperature", help=argparse.SUPPRESS)
+    p.add_argument("--batch", type=int, default=1, help=argparse.SUPPRESS)
+    p.add_argument("--provider", choices=PROVIDERS, default="hpc", help=argparse.SUPPRESS)
+    p.set_defaults(graph=False)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.worker:
+        run_worker(args)
+        return
+
+    rows = []
+    tag = args.tag or f"sampler_{int(time.time())}"
+    out_dir = Path(args.output_dir) / tag if args.output_dir else Path(__file__).resolve().parent / "log" / tag
+    for scene in args.scenes:
+        for batch in args.batches:
+            for provider in args.providers:
+                if args.timing == "nsys":
+                    median_us, mean_us, n, err = run_nsys_profile(args, scene, batch, provider, out_dir)
+                else:
+                    try:
+                        call_fn = setup_call(provider, scene, batch, dtype_from_name(args.dtype), args.seed)
+                        median_us, mean_us, n = bench_event(call_fn, args.warmup, args.iters, args.graph)
+                        err = None
+                    except Exception as exc:
+                        median_us, mean_us, n, err = None, None, 0, repr(exc)
+                rows.append(
+                    {
+                        "scene": scene,
+                        "batch": batch,
+                        "provider": provider,
+                        "median_us": median_us,
+                        "mean_us": mean_us,
+                        "samples": n,
+                        "timing": "nsys_eager_nvtx_median" if args.timing == "nsys" else ("event_graph_median" if args.graph else "event_eager_median"),
+                        "dtype": args.dtype,
+                        "vocab_size": VOCAB_SIZE,
+                        "error": err,
+                    }
+                )
+    print_table(rows)
+    write_csv(args.csv, rows)
+    write_jsonl(args.jsonl, rows)
+    if args.timing == "nsys":
+        print(f"nsys reports: {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/sampler/benchmark_sampler.py
+++ b/benchmark/sampler/benchmark_sampler.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (C) 2026 Tencent.
 
 """Sampler benchmark.
@@ -298,7 +297,7 @@ def write_jsonl(path: str, rows: list[dict]) -> None:
 
 
 def parse_args():
-    p = argparse.ArgumentParser(description="Benchmark HPC-Ops Sampler for figure 11.")
+    p = argparse.ArgumentParser(description="Benchmark HPC-Ops Sampler")
     p.add_argument("--scenes", nargs="+", default=SCENES, choices=SCENES)
     p.add_argument("--batches", type=int, nargs="+", default=BATCHES)
     p.add_argument("--providers", nargs="+", default=PROVIDERS, choices=PROVIDERS)

--- a/benchmark/sampler/benchmark_sampler.py
+++ b/benchmark/sampler/benchmark_sampler.py
@@ -1,14 +1,15 @@
+#!/usr/bin/env python3
 # Copyright (C) 2026 Tencent.
 
 """Sampler benchmark.
 
 Scenarios:
     - temperature: temperature-only sampling fast path.
-    - full: repetition penalty + temperature + topk/topp + sampling.
+    - full: repetition penalty + temperature + top-k/top-p + sampling.
 
-operator: nsys profile, NVTX ``step`` ranges, and median latency. Sampler kernels
-are measured in eager mode because the temperature fast path and baseline
-sampling APIs are not CUDA-graph-capture safe in this environment.
+The nsys mode records eager sampler calls under NVTX ranges and reports median
+latency from Nsight Systems' GPU projected duration. Timed loops do not
+synchronize per iteration.
 """
 from __future__ import annotations
 
@@ -27,138 +28,195 @@ import torch
 
 sys.path.insert(0, os.path.realpath(list(Path(__file__).parent.glob("../../build/lib.*/"))[0]))
 
-import hpc  # noqa: E402
-from hpc.sampler import SoftmaxPolicy  # noqa: E402
+from hpc.sampler import SoftmaxPolicy, fused_sampler  # noqa: E402
 
+
+SCRIPT_DIR = Path(__file__).resolve().parent
 
 VOCAB_SIZE = 120832
-BATCHES = [1, 8, 16, 32, 64, 128, 256, 512]
+MAX_CONTEXT_LEN = 32768
+REPETITION_PENALTY = 1.1
+TEMPERATURE = 1.05
+TOPK = 20
+TOPP = 0.9
+SAMPLER_SEED = 1
+
 SCENES = ["temperature", "full"]
 PROVIDERS = ["hpc", "torch", "flashinfer"]
+DEFAULT_BATCHES = [1, 8, 16, 32, 64, 128, 256, 512]
+
+SCENE_LABELS = {
+    "temperature": "Temperature Sampling",
+    "full": "Full Sampling",
+}
 DISPLAY = {
     "hpc": "HPC-Ops",
     "torch": "vLLM/PyTorch",
     "flashinfer": "FlashInfer",
 }
+PATH_BY_CELL = {
+    ("temperature", "torch"): "stable-torch",
+    ("temperature", "flashinfer"): "stable-fi",
+    ("temperature", "hpc"): "stable-hpc",
+    ("full", "torch"): "full-vllm",
+    ("full", "flashinfer"): "full-fi",
+    ("full", "hpc"): "full-hpc",
+}
 
 
-def make_gumbel(shape, device="cuda") -> torch.Tensor:
-    u = torch.rand(shape, dtype=torch.float32, device=device).clamp_min_(1e-20)
-    return -(-u.log()).log()
+def build_inputs(batch: int, device: str = "cuda") -> dict:
+    generator = torch.Generator(device="cpu").manual_seed(batch)
+    logits = torch.randn(batch, VOCAB_SIZE, generator=generator).to(
+        device=device, dtype=torch.bfloat16,
+    ).contiguous()
+    repetition = torch.full((batch,), REPETITION_PENALTY, dtype=torch.float32, device=device)
 
+    prompt_cpu = torch.randint(
+        0, VOCAB_SIZE, (batch, MAX_CONTEXT_LEN), dtype=torch.int64, generator=generator,
+    )
+    output_cpu = torch.randint(
+        0, VOCAB_SIZE, (batch, MAX_CONTEXT_LEN), dtype=torch.int64, generator=generator,
+    )
+    try:
+        prompt_cpu = prompt_cpu.pin_memory()
+        output_cpu = output_cpu.pin_memory()
+    except Exception:
+        pass
 
-def build_inputs(batch: int, dtype: torch.dtype, seed: int):
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed(seed)
-    logits = torch.randn(batch, VOCAB_SIZE, dtype=dtype, device="cuda")
-    gumbel = make_gumbel((batch, VOCAB_SIZE))
-    temperature = torch.full((batch,), 0.7, dtype=torch.float32, device="cuda")
-    topk = torch.full((batch,), 20, dtype=torch.int32, device="cuda")
-    topp = torch.full((batch,), 0.9, dtype=torch.float32, device="cuda")
     row_bytes = (VOCAB_SIZE + 7) // 8
-    penalty_mask = torch.zeros((batch, row_bytes), dtype=torch.uint8, device="cuda")
-    slot_id = torch.arange(batch, dtype=torch.int32, device="cuda")
+    max_rows = max(batch, 64)
+    bitmask = torch.zeros(max_rows, row_bytes, dtype=torch.uint8, device=device)
+    token_ids = torch.cat([prompt_cpu.to(device), output_cpu.to(device)], dim=1).clamp(0, VOCAB_SIZE - 1)
+    token_mask = torch.zeros(batch, VOCAB_SIZE, dtype=torch.bool, device=device)
+    token_mask.scatter_(1, token_ids, torch.ones_like(token_ids, dtype=torch.bool))
+
+    padded_vocab = row_bytes * 8
+    if padded_vocab != VOCAB_SIZE:
+        pad = torch.zeros(batch, padded_vocab - VOCAB_SIZE, dtype=torch.bool, device=device)
+        token_mask = torch.cat([token_mask, pad], dim=1)
+    bits = token_mask.view(batch, row_bytes, 8).to(torch.uint8)
+    weights = torch.tensor([1, 2, 4, 8, 16, 32, 64, 128], dtype=torch.uint8, device=device)
+    bitmask[:batch] = (bits * weights).sum(dim=-1, dtype=torch.uint8)
+
     return {
         "logits": logits,
-        "gumbel": gumbel,
-        "temperature": temperature,
-        "topk": topk,
-        "topp": topp,
-        "penalty_mask": penalty_mask,
-        "slot_id": slot_id,
+        "repetition": repetition,
+        "prompt_cpu": prompt_cpu,
+        "output_cpu": output_cpu,
+        "bitmask": bitmask,
+        "slot_id": torch.arange(batch, dtype=torch.int32, device=device),
     }
 
 
-def setup_call(provider: str, scene: str, batch: int, dtype: torch.dtype, seed: int):
-    data = build_inputs(batch, dtype, seed)
-    logits = data["logits"]
-    gumbel = data["gumbel"]
-    temperature = data["temperature"]
+def setup_call(scene: str, provider: str, batch: int):
+    inputs = build_inputs(batch)
+    logits = inputs["logits"]
 
-    if provider == "hpc":
-        if scene == "temperature":
-            return lambda: hpc.fused_sampler(logits, temperature=temperature, gumbel_noise=gumbel)
-        if scene == "full":
-            return lambda: hpc.fused_sampler(
-                logits,
-                penalty_mask=data["penalty_mask"],
-                slot_id=data["slot_id"],
-                repetition_penalty=1.05,
-                temperature=temperature,
-                softmax_policy=SoftmaxPolicy.AFTER_TOPK,
-                topk=data["topk"],
-                topp=data["topp"],
-                max_topk=32,
-                gumbel_noise=gumbel,
-            )
-        raise ValueError(scene)
+    if scene == "temperature" and provider == "torch":
+        def run_temperature_torch():
+            probs = logits.to(torch.float32).div_(TEMPERATURE).softmax(dim=-1)
+            noise = torch.empty_like(probs).exponential_(1.0)
+            return probs.div_(noise).argmax(dim=-1).view(-1, 1).to(torch.int32)
+        return run_temperature_torch
 
-    if provider == "torch":
-        if scene == "temperature":
-            return lambda: (logits.float() / temperature[:, None] + gumbel).argmax(dim=-1)
-        if scene == "full":
-            def run_torch_full():
-                work = logits.float() / temperature[:, None]
-                vals, idx = torch.topk(work, k=20, dim=-1)
-                probs = torch.softmax(vals, dim=-1)
-                keep = probs.cumsum(dim=-1) <= 0.9
-                keep[:, 0] = True
-                scores = torch.where(keep, probs.log(), torch.full_like(probs, -float("inf")))
-                scores = scores + torch.gather(gumbel, 1, idx)
-                return idx.gather(1, scores.argmax(dim=-1, keepdim=True))
-            return run_torch_full
-        raise ValueError(scene)
-
-    if provider == "flashinfer":
+    if scene == "temperature" and provider == "flashinfer":
         import flashinfer.sampling as sampling
 
-        if scene == "temperature":
-            return lambda: sampling.sampling_from_logits(
-                logits.float() / temperature[:, None],
-                deterministic=True,
-                seed=seed,
-            )
-        if scene == "full":
-            return lambda: sampling.top_k_top_p_sampling_from_logits(
-                logits.float() / temperature[:, None],
-                top_k=20,
-                top_p=0.9,
+        def run_temperature_flashinfer():
+            probs = sampling.softmax(logits, temperature=TEMPERATURE)
+            tokens = sampling.sampling_from_probs(probs, deterministic=True)
+            return tokens.view(-1, 1).to(torch.int32)
+        return run_temperature_flashinfer
+
+    if scene == "temperature" and provider == "hpc":
+        return lambda: fused_sampler(logits, temperature=TEMPERATURE, seed=SAMPLER_SEED)
+
+    def penalty_temperature():
+        from vllm._custom_ops import apply_repetition_penalties
+
+        batch_size = logits.shape[0]
+        work = logits.to(torch.float32)
+        prompt_dev = inputs["prompt_cpu"].to("cuda", non_blocking=True)
+        output_dev = inputs["output_cpu"].to("cuda", non_blocking=True)
+        prompt_buf = torch.zeros(batch_size, VOCAB_SIZE + 1, dtype=torch.bool, device="cuda")
+        output_buf = torch.zeros(batch_size, VOCAB_SIZE + 1, dtype=torch.bool, device="cuda")
+        ones = torch.ones(1, dtype=torch.bool, device="cuda")
+        prompt_buf.scatter_(1, prompt_dev.clamp(max=VOCAB_SIZE), ones.expand_as(prompt_dev))
+        output_buf.scatter_(1, output_dev.clamp(max=VOCAB_SIZE), ones.expand_as(output_dev))
+        apply_repetition_penalties(
+            work,
+            prompt_buf[:, :VOCAB_SIZE].contiguous(),
+            output_buf[:, :VOCAB_SIZE].contiguous(),
+            inputs["repetition"],
+        )
+        work.div_(TEMPERATURE)
+        return work
+
+    if scene == "full" and provider == "torch":
+        def run_full_torch():
+            work = penalty_temperature()
+            sorted_logits, sorted_idx = work.sort(dim=-1, descending=False)
+            cutoff = sorted_logits[..., VOCAB_SIZE - TOPK].unsqueeze(-1)
+            sorted_logits = sorted_logits.masked_fill(sorted_logits < cutoff, float("-inf"))
+            sorted_probs = sorted_logits.softmax(dim=-1)
+            cumulative = sorted_probs.cumsum(dim=-1)
+            drop = cumulative <= (1 - TOPP)
+            drop[..., -1] = False
+            sorted_logits = sorted_logits.masked_fill(drop, float("-inf"))
+            filtered = torch.empty_like(work).scatter_(dim=-1, index=sorted_idx, src=sorted_logits)
+            probs = filtered.softmax(dim=-1)
+            noise = torch.empty_like(probs).exponential_(1.0)
+            return probs.div_(noise).argmax(dim=-1).view(-1, 1).to(torch.int32)
+        return run_full_torch
+
+    if scene == "full" and provider == "flashinfer":
+        import flashinfer.sampling as sampling
+
+        def run_full_flashinfer():
+            return sampling.top_k_top_p_sampling_from_logits(
+                penalty_temperature(),
+                TOPK,
+                TOPP,
                 filter_apply_order="top_k_first",
                 deterministic=True,
-                seed=seed,
-            )
-        raise ValueError(scene)
+            ).view(-1, 1).to(torch.int32)
+        return run_full_flashinfer
 
-    raise ValueError(provider)
+    if scene == "full" and provider == "hpc":
+        return lambda: fused_sampler(
+            logits,
+            penalty_mask=inputs["bitmask"],
+            slot_id=inputs["slot_id"],
+            repetition_penalty=inputs["repetition"],
+            temperature=TEMPERATURE,
+            softmax_policy=SoftmaxPolicy.AFTER_TOPK,
+            topk=TOPK,
+            topp=TOPP,
+            max_topk=32,
+            seed=SAMPLER_SEED,
+        )
+
+    raise ValueError(f"unsupported scene/provider: {scene}/{provider}")
 
 
-def run_nsys_steps(call_fn, *, warmup: int, n_timed: int) -> None:
+def run_nsys_steps(call_fn, *, warmup: int, iters: int, range_name: str = "step") -> None:
     for _ in range(warmup):
         call_fn()
     torch.cuda.synchronize()
 
-    torch.cuda.cudart().cudaProfilerStart()
-    for _ in range(n_timed):
-        torch.cuda.nvtx.range_push("step")
-        call_fn()
-        torch.cuda.synchronize()
-        torch.cuda.nvtx.range_pop()
-    torch.cuda.cudart().cudaProfilerStop()
-
-
-def bench_event(call_fn, warmup: int, iters: int, use_graph: bool) -> tuple[float, float, int]:
-    for _ in range(warmup):
-        call_fn()
-    torch.cuda.synchronize()
-
-    if use_graph:
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph):
+    for _ in range(iters):
+        torch.cuda.nvtx.range_push(range_name)
+        try:
             call_fn()
-        for _ in range(warmup):
-            graph.replay()
-        torch.cuda.synchronize()
-        call_fn = graph.replay
+        finally:
+            torch.cuda.nvtx.range_pop()
+    torch.cuda.synchronize()
+
+
+def bench_event(call_fn, *, warmup: int, iters: int) -> tuple[float, float, int]:
+    for _ in range(warmup):
+        call_fn()
+    torch.cuda.synchronize()
 
     events = [(torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)) for _ in range(iters)]
     for start, end in events:
@@ -166,40 +224,42 @@ def bench_event(call_fn, warmup: int, iters: int, use_graph: bool) -> tuple[floa
         call_fn()
         end.record()
     torch.cuda.synchronize()
-    vals = sorted(start.elapsed_time(end) * 1000.0 for start, end in events)
-    return float(median(vals)), float(mean(vals)), len(vals)
+    values = [start.elapsed_time(end) * 1000.0 for start, end in events]
+    return float(median(values)), float(mean(values)), len(values)
 
 
-def extract_nvtx_us(report_prefix: Path) -> list[float]:
-    cmd = [
-        "nsys",
-        "stats",
-        "--report",
-        "nvtx_gpu_proj_trace",
-        "--force-export=true",
-        "-q",
-        "-f",
-        "json",
-        str(report_prefix) + ".nsys-rep",
-    ]
-    try:
-        out = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
-        raw = json.loads(out.decode())
-        data = raw[0]["data"] if isinstance(raw, list) and raw and "data" in raw[0] else raw
-        samples = []
-        for entry in data:
-            name = entry.get("Name", "").strip().strip('"')
-            if name in ("step", ":step"):
-                samples.append(float(entry["Projected Duration (ns)"]) / 1000.0)
-        return samples[2:]
-    except Exception:
-        return []
+def run_worker(args) -> None:
+    torch.cuda.set_device(0)
+    cells = json.loads(args.worker_cells)
+    torch.cuda.cudart().cudaProfilerStart()
+    for cell in cells:
+        scene = cell["scene"]
+        provider = cell["provider"]
+        batch = int(cell["batch"])
+        range_name = PATH_BY_CELL[(scene, provider)] + f"|B{batch}"
+        try:
+            call_fn = setup_call(scene, provider, batch)
+            run_nsys_steps(call_fn, warmup=args.warmup, iters=args.iters, range_name=range_name)
+            print(f"[worker] done {scene} batch={batch} provider={provider}", file=sys.stderr, flush=True)
+        except Exception as exc:
+            print(
+                f"[worker] failed {scene} batch={batch} provider={provider}: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+        torch.cuda.empty_cache()
+    torch.cuda.cudart().cudaProfilerStop()
 
 
-def run_nsys_profile(args, scene: str, batch: int, provider: str, out_dir: Path) -> tuple[float | None, float | None, int, str | None]:
-    out_dir.mkdir(parents=True, exist_ok=True)
-    report_prefix = out_dir / f"{scene}_bs{batch}_{provider}"
-    report_file = str(report_prefix) + ".nsys-rep"
+def report_prefix(output_dir: Path, tag: str) -> Path:
+    return output_dir / f"sampler_{tag}"
+
+
+def run_nsys_profile(args, cells: list[dict], output_dir: Path, tag: str) -> tuple[Path, str | None]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    prefix = report_prefix(output_dir, tag)
+    report_file = str(prefix) + ".nsys-rep"
     if os.path.exists(report_file):
         os.remove(report_file)
 
@@ -209,74 +269,155 @@ def run_nsys_profile(args, scene: str, batch: int, provider: str, out_dir: Path)
         "-f",
         "true",
         "-o",
-        str(report_prefix),
+        str(prefix),
+        "--sample=none",
+        "--cpuctxsw=none",
         "--capture-range=cudaProfilerApi",
         "--capture-range-end=stop-shutdown",
-        "--cuda-graph-trace=node",
         "-t",
         "cuda,nvtx",
         sys.executable,
         str(Path(__file__).resolve()),
         "--worker",
-        "--scene",
-        scene,
-        "--batch",
-        str(batch),
-        "--provider",
-        provider,
-        "--dtype",
-        args.dtype,
+        "--worker-cells",
+        json.dumps(cells),
         "--warmup",
         str(args.warmup),
         "--iters",
         str(args.iters),
-        "--seed",
-        str(args.seed),
     ]
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
     try:
         proc = subprocess.run(
             cmd,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
             timeout=args.nsys_timeout,
-            env=os.environ.copy(),
+            env=env,
         )
     except subprocess.TimeoutExpired:
-        return None, None, 0, "nsys profile timeout"
+        return Path(report_file), "nsys profile timeout"
 
-    if not os.path.exists(report_file) and proc.returncode != 0:
-        err = proc.stderr.decode(errors="replace").strip().splitlines()
-        return None, None, 0, err[-1] if err else "nsys profile failed"
-
-    vals = extract_nvtx_us(report_prefix)
-    if not vals:
-        return None, None, 0, "no NVTX step samples"
-    return float(median(vals)), float(mean(vals)), len(vals), None
+    if not os.path.exists(report_file):
+        stderr = proc.stderr.decode(errors="replace").strip().splitlines()
+        return Path(report_file), stderr[-1] if stderr else "nsys profile failed"
+    return Path(report_file), None
 
 
-def dtype_from_name(name: str) -> torch.dtype:
-    return {"float32": torch.float32, "bfloat16": torch.bfloat16}[name]
+def export_nvtx_csv(report_file: Path, output_dir: Path, tag: str) -> Path:
+    output_prefix = output_dir / f"proj_{tag}"
+    cmd = [
+        "nsys",
+        "stats",
+        "-r",
+        "nvtx_gpu_proj_trace",
+        "--format",
+        "csv",
+        "--force-export=true",
+        "-o",
+        str(output_prefix),
+        str(report_file),
+    ]
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL)
+    return Path(str(output_prefix) + "_nvtx_gpu_proj_trace.csv")
 
 
-def run_worker(args) -> None:
-    call_fn = setup_call(args.provider, args.scene, args.batch, dtype_from_name(args.dtype), args.seed)
-    run_nsys_steps(call_fn, warmup=args.warmup, n_timed=args.iters + 2)
+def parse_nvtx_csv(path: Path) -> dict[str, list[float]]:
+    samples: dict[str, list[float]] = {}
+    with path.open(newline="") as f:
+        for row in csv.DictReader(f):
+            name = row.get("Name", "").strip().strip('"').lstrip(":")
+            if "|B" not in name:
+                continue
+            samples.setdefault(name, []).append(float(row["Projected Duration (ns)"]) / 1000.0)
+    return samples
+
+
+def build_cells(args) -> list[dict]:
+    return [
+        {"scene": scene, "batch": batch, "provider": provider}
+        for scene in args.scenes
+        for batch in args.batches
+        for provider in args.providers
+    ]
+
+
+def make_row(scene: str, batch: int, provider: str, values: list[float], timing: str, error: str | None = None) -> dict:
+    return {
+        "scene": scene,
+        "batch": batch,
+        "provider": provider,
+        "path": PATH_BY_CELL[(scene, provider)],
+        "n": len(values),
+        "median_us": float(median(values)) if values else None,
+        "mean_us": float(mean(values)) if values else None,
+        "timing": timing,
+        "vocab_size": VOCAB_SIZE,
+        "error": error,
+    }
+
+
+def rows_from_nsys(args, cells: list[dict], output_dir: Path, tag: str) -> tuple[list[dict], Path | None]:
+    report_file, profile_error = run_nsys_profile(args, cells, output_dir, tag)
+    if profile_error:
+        return [
+            make_row(c["scene"], c["batch"], c["provider"], [], "nsys_eager_nvtx_median", profile_error)
+            for c in cells
+        ], None
+
+    nvtx_csv = export_nvtx_csv(report_file, output_dir, tag)
+    samples = parse_nvtx_csv(nvtx_csv)
+    rows = []
+    for cell in cells:
+        path = PATH_BY_CELL[(cell["scene"], cell["provider"])]
+        key = f"{path}|B{cell['batch']}"
+        values = samples.get(key, [])
+        error = None if values else "no NVTX samples"
+        rows.append(make_row(cell["scene"], cell["batch"], cell["provider"], values, "nsys_eager_nvtx_median", error))
+    return rows, report_file
+
+
+def rows_from_events(args, cells: list[dict]) -> list[dict]:
+    rows = []
+    for cell in cells:
+        try:
+            call_fn = setup_call(cell["scene"], cell["provider"], cell["batch"])
+            median_us, mean_us, n = bench_event(call_fn, warmup=args.warmup, iters=args.iters)
+            values = [median_us]
+            row = make_row(cell["scene"], cell["batch"], cell["provider"], values, "event_eager_median")
+            row["median_us"] = median_us
+            row["mean_us"] = mean_us
+            row["n"] = n
+        except Exception as exc:
+            row = make_row(
+                cell["scene"], cell["batch"], cell["provider"], [],
+                "event_eager_median", f"{type(exc).__name__}: {exc}",
+            )
+        rows.append(row)
+    return rows
 
 
 def print_table(rows: list[dict]) -> None:
-    scenes = {"temperature": "Temperature Sampling", "full": "Full Sampling"}
     print("")
-    print("=" * 110)
+    print("=" * 118)
     print("Sampler latency | us per call (lower is better)")
-    print("-" * 110)
-    print(f"{'scene':>22} | {'batch':>5} | {'provider':>12} | {'median_us':>10} | {'mean_us':>10} | {'samples':>7} | {'error':>18}")
-    print("-" * 110)
-    for r in rows:
-        med = f"{r['median_us']:.2f}" if isinstance(r.get("median_us"), (int, float)) else "ERR"
-        avg = f"{r['mean_us']:.2f}" if isinstance(r.get("mean_us"), (int, float)) else "ERR"
-        err = r.get("error") or ""
-        print(f"{scenes[r['scene']]:>22} | {r['batch']:5d} | {DISPLAY[r['provider']]:>12} | {med:>10} | {avg:>10} | {r['samples']:7d} | {err[:18]:>18}")
-    print("=" * 110)
+    print("-" * 118)
+    print(
+        f"{'scene':>22} | {'batch':>5} | {'provider':>12} | "
+        f"{'median_us':>10} | {'mean_us':>10} | {'samples':>7} | {'error':>20}"
+    )
+    print("-" * 118)
+    for row in rows:
+        med = f"{row['median_us']:.2f}" if isinstance(row.get("median_us"), (int, float)) else "ERR"
+        avg = f"{row['mean_us']:.2f}" if isinstance(row.get("mean_us"), (int, float)) else "ERR"
+        err = row.get("error") or ""
+        print(
+            f"{SCENE_LABELS[row['scene']]:>22} | {row['batch']:5d} | "
+            f"{DISPLAY[row['provider']]:>12} | {med:>10} | {avg:>10} | "
+            f"{row['n']:7d} | {err[:20]:>20}"
+        )
+    print("=" * 118)
 
 
 def write_csv(path: str, rows: list[dict]) -> None:
@@ -297,76 +438,54 @@ def write_jsonl(path: str, rows: list[dict]) -> None:
 
 
 def parse_args():
-    p = argparse.ArgumentParser(description="Benchmark HPC-Ops Sampler")
-    p.add_argument("--scenes", nargs="+", default=SCENES, choices=SCENES)
-    p.add_argument("--batches", type=int, nargs="+", default=BATCHES)
-    p.add_argument("--providers", nargs="+", default=PROVIDERS, choices=PROVIDERS)
-    p.add_argument("--timing", choices=["nsys", "event"], default="nsys")
-    p.add_argument(
-        "--graph",
-        dest="graph",
-        action="store_true",
-        help="try CUDA Graph replay for --timing event; sampler paths are measured eager by default.",
-    )
-    p.add_argument("--no-graph", dest="graph", action="store_false", help=argparse.SUPPRESS)
-    p.add_argument("--dtype", choices=["float32", "bfloat16"], default="bfloat16")
-    p.add_argument("--warmup", type=int, default=3)
-    p.add_argument("--iters", type=int, default=52)
-    p.add_argument("--seed", type=int, default=10086)
-    p.add_argument("--output-dir", default="")
-    p.add_argument("--tag", default="")
-    p.add_argument("--nsys-timeout", type=int, default=300)
-    p.add_argument("--csv", default="")
-    p.add_argument("--jsonl", default="")
-    p.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
-    p.add_argument("--scene", choices=SCENES, default="temperature", help=argparse.SUPPRESS)
-    p.add_argument("--batch", type=int, default=1, help=argparse.SUPPRESS)
-    p.add_argument("--provider", choices=PROVIDERS, default="hpc", help=argparse.SUPPRESS)
-    p.set_defaults(graph=False)
-    return p.parse_args()
+    parser = argparse.ArgumentParser(description="Benchmark HPC-Ops sampler kernels.")
+    parser.add_argument("--scenes", nargs="+", default=SCENES, choices=SCENES)
+    parser.add_argument("--batches", type=int, nargs="+", default=DEFAULT_BATCHES)
+    parser.add_argument("--providers", nargs="+", default=PROVIDERS, choices=PROVIDERS)
+    parser.add_argument("--timing", choices=["nsys", "event"], default="nsys")
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--gpu", type=int, default=0)
+    parser.add_argument("--output-dir", default="")
+    parser.add_argument("--tag", default="")
+    parser.add_argument("--nsys-timeout", type=int, default=600)
+    parser.add_argument("--csv", default="")
+    parser.add_argument("--jsonl", default="")
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--worker-cells", default="[]", help=argparse.SUPPRESS)
+    return parser.parse_args()
 
 
-def main() -> None:
+def main() -> int:
     args = parse_args()
     if args.worker:
         run_worker(args)
-        return
+        return 0
 
-    rows = []
+    if args.iters < 1 or args.warmup < 0:
+        raise SystemExit("--iters must be >= 1 and --warmup must be >= 0")
+
+    cells = build_cells(args)
     tag = args.tag or f"sampler_{int(time.time())}"
-    out_dir = Path(args.output_dir) / tag if args.output_dir else Path(__file__).resolve().parent / "log" / tag
-    for scene in args.scenes:
-        for batch in args.batches:
-            for provider in args.providers:
-                if args.timing == "nsys":
-                    median_us, mean_us, n, err = run_nsys_profile(args, scene, batch, provider, out_dir)
-                else:
-                    try:
-                        call_fn = setup_call(provider, scene, batch, dtype_from_name(args.dtype), args.seed)
-                        median_us, mean_us, n = bench_event(call_fn, args.warmup, args.iters, args.graph)
-                        err = None
-                    except Exception as exc:
-                        median_us, mean_us, n, err = None, None, 0, repr(exc)
-                rows.append(
-                    {
-                        "scene": scene,
-                        "batch": batch,
-                        "provider": provider,
-                        "median_us": median_us,
-                        "mean_us": mean_us,
-                        "samples": n,
-                        "timing": "nsys_eager_nvtx_median" if args.timing == "nsys" else ("event_graph_median" if args.graph else "event_eager_median"),
-                        "dtype": args.dtype,
-                        "vocab_size": VOCAB_SIZE,
-                        "error": err,
-                    }
-                )
+    output_dir = Path(args.output_dir) if args.output_dir else SCRIPT_DIR / "log"
+
+    if args.timing == "nsys":
+        rows, report_file = rows_from_nsys(args, cells, output_dir, tag)
+    else:
+        rows = rows_from_events(args, cells)
+        report_file = None
+
     print_table(rows)
     write_csv(args.csv, rows)
     write_jsonl(args.jsonl, rows)
-    if args.timing == "nsys":
-        print(f"nsys reports: {out_dir}")
+    if report_file:
+        print(f"nsys report: {report_file}")
+    if args.csv:
+        print(f"CSV: {args.csv}")
+    if args.jsonl:
+        print(f"JSONL: {args.jsonl}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/hpc/sampler.py
+++ b/hpc/sampler.py
@@ -1,0 +1,182 @@
+from enum import IntEnum
+from typing import Optional, Tuple, Union
+
+import torch
+from torch import Tensor
+
+
+class SoftmaxPolicy(IntEnum):
+    """Where (if anywhere) the kernel should run softmax.
+
+    The fused sampler supports softmax exactly ``0`` or ``1`` times per step:
+
+    * ``NONE``        — no softmax; topk / Gumbel-max operate directly on logits.
+    * ``BEFORE_TOPK`` — "joint topk-topp": softmax1 over the full vocab (after
+      rep-penalty / temperature), topk operates on probabilities, topp
+      is computed directly from the softmax1 output.
+    * ``AFTER_TOPK``  — "topk-first": topk operates on logits, then a small
+      softmax2 is applied over the surviving top-K; topp operates on softmax2.
+
+    Enabling topp requires ``softmax_policy != NONE`` (probabilities must exist
+    somewhere for cumulative-sum truncation to be meaningful). The Python
+    wrapper enforces this with a ``TORCH_CHECK`` inside the C++ entry.
+    """
+
+    NONE = 0
+    BEFORE_TOPK = 1
+    AFTER_TOPK = 2
+
+
+def _to_tensor_scalar_tuple(x) -> Tuple[Optional[Tensor], Union[int, float]]:
+    if isinstance(x, torch.Tensor):
+        if x.dtype == torch.float:
+            return (x, 0.0)
+        elif x.dtype == torch.int32 or x.dtype == torch.int64:
+            return (x, 0)
+        else:
+            raise ValueError(f"Unsupported dtype {x.dtype}")
+    else:
+        return (None, x)
+
+
+def fused_sampler(
+    logits: Tensor,
+    *,
+    penalty_mask: Optional[Tensor] = None,
+    slot_id: Optional[Tensor] = None,
+    repetition_penalty: Union[Tensor, float] = 0.0,
+    temperature: Union[Tensor, float] = 0.0,
+    softmax_policy: SoftmaxPolicy = SoftmaxPolicy.NONE,
+    topk: Union[Tensor, int] = 0,
+    topp: Union[Tensor, float] = 0.0,
+    max_topk: int = 32,
+    gumbel_noise: Optional[Tensor] = None,
+    draft_token_ids: Optional[Tensor] = None,
+    seed: int = 0,
+) -> Tensor:
+    """2-kernel fused sampler.
+
+    Pipeline inside the kernel::
+
+        repetition_penalty -> temperature -> [softmax1] ->
+        topk -> [softmax2] -> topp -> Gumbel-max sampling -> penalty writeback
+
+    Every feature except the final Gumbel-max is optional. At minimum, pass
+    just ``logits`` to get a per-batch random sample restricted to the
+    ``max_topk`` (32/64) highest-logit candidates (the kernel internally draws
+    Gumbel(0) noise via curand). Note this is NOT a full-vocabulary argmax /
+    softmax sample: tokens outside the top-``max_topk`` can never be drawn.
+
+    Args:
+        logits: Compact ``[B, V]`` tensor, ``float32`` or ``bfloat16``. The
+            first dim ``B`` is the effective batch count — rows are not
+            gathered via ``slot_id``; only ``penalty_mask`` is.
+        penalty_mask: Optional ``[MAX_BS, ceil(V/8)]`` ``uint8`` bit-mask
+            (each bit = one vocab token). ``MAX_BS >= slot_id.size(0)``; only
+            the rows named by ``slot_id`` are touched. After sampling, the
+            kernel sets the bit for the sampled token (``atomicOr``) in
+            ``penalty_mask[slot_id[b], token_id[b]]``.
+        slot_id: Optional ``[B]`` ``int32`` row index into ``penalty_mask``.
+            ``penalty_mask`` and ``slot_id`` must be provided together or not
+            at all.
+        repetition_penalty: Scalar float or ``[B]`` float32 tensor. ``0`` (or
+            no tensor) disables. When enabled, requires ``penalty_mask`` /
+            ``slot_id`` to be provided.
+        temperature: Scalar float or ``[B]`` float32 tensor. Scalar ``0``
+            disables. When a tensor is given, every element must be strictly
+            ``> 0`` (the temperature fast-path kernel has no in-kernel ``t<=0``
+            guard; a zero/negative entry would produce inf/NaN scores).
+        softmax_policy: ``SoftmaxPolicy`` enum. See the enum docstring.
+        topk: Scalar int or ``[B]`` int32/int64 tensor. Must be ``<= max_topk``
+            per batch. ``0`` (or unset) does NOT widen sampling to the full
+            vocab: it just means "do not tighten below ``max_topk``", so
+            sampling still happens within the top-``max_topk`` (32/64)
+            candidates. Tokens outside that set can never be sampled.
+        topp: Scalar float or ``[B]`` float32 tensor. Requires topk to be
+            enabled and ``softmax_policy != NONE``. ``0`` disables topp.
+        max_topk: Compile-time topk upper bound. Must be ``32`` or ``64``.
+        gumbel_noise: Optional ``[B, V]`` ``float32`` Gumbel(0) noise
+            (e.g. ``u = torch.rand_like(logits.float()).clamp_min_(1e-20);
+            gumbel = -(-u.log()).log()``). Same convention as
+            ``fused_sampler_temperature``. The kernel adds it directly to the
+            score (``score = value + gumbel_noise``). If provided, sampling is
+            bit-reproducible against a PyTorch reference implementation. If
+            ``None``, the kernel samples internally via curand
+            (non-deterministic).
+        draft_token_ids: Optional ``[B]`` ``int64`` tensor (one entry per
+            logits row). For each row ``b``: if ``draft_token_ids[b] != -1``,
+            the post-temperature logit at ``logits[b, draft_token_ids[b]]`` is
+            treated as ``-inf`` for scoring (the original tensor is NOT
+            modified). Entries with ``-1`` leave the row unmasked. Currently
+            supported only on the temperature-only fast path; if the call
+            would otherwise dispatch to the heavy ``fused_sampler`` kernel, a
+            ``ValueError`` is raised.
+
+    Returns:
+        ``token_ids: Tensor[B, 1] int32``. The sampled token for each row.
+
+    Note:
+        The temperature-only fast path (and ``fused_sampler_temperature``) uses
+        a per-device shared workspace. Do NOT invoke this sampler concurrently
+        on multiple streams of the same device — use one stream per device or
+        serialize the calls.
+    """
+    if isinstance(softmax_policy, int) and not isinstance(softmax_policy, SoftmaxPolicy):
+        softmax_policy = SoftmaxPolicy(softmax_policy)
+
+    if max_topk not in (32, 64):
+        raise ValueError(f"fused_sampler: max_topk must be 32 or 64, got {max_topk}.")
+
+    # Fast-path: temperature-only → lighter fused_sampler_temperature_sample
+    # kernel (skips the cluster-cooperative topk machinery). Detected when every
+    # other feature is disabled (mirrors the C++ entry's disabled-flag rules):
+    # no penalty_mask/slot_id, rep_penalty/topp/topk scalar 0, softmax_policy
+    # NONE, and temperature is a tensor or a positive scalar. gumbel_noise and
+    # draft_token_ids are forwarded only on this fast path.
+    def _is_scalar_zero(x):
+        return (not isinstance(x, Tensor)) and float(x) == 0.0
+
+    _temp_is_tensor = isinstance(temperature, Tensor)
+    _temp_is_positive_scalar = (not _temp_is_tensor) and float(temperature) > 0.0
+    _fast_path = (
+        penalty_mask is None
+        and slot_id is None
+        and _is_scalar_zero(repetition_penalty)
+        and _is_scalar_zero(topp)
+        and (not isinstance(topk, Tensor))
+        and int(topk) == 0
+        and softmax_policy == SoftmaxPolicy.NONE
+        and (_temp_is_tensor or _temp_is_positive_scalar)
+    )
+    if _fast_path:
+        temp_tensor, temp_scalar = _to_tensor_scalar_tuple(temperature)
+        return torch.ops.hpc.fused_sampler_temperature_sample(
+            logits,
+            temp_tensor,
+            float(temp_scalar),
+            gumbel_noise,
+            draft_token_ids,
+            seed,
+        )
+
+    if draft_token_ids is not None:
+        raise ValueError(
+            "draft_token_ids currently requires the temperature-only fast path. "
+            "Disable the other sampler features "
+            "(penalty_mask/slot_id/repetition_penalty/topk/topp/softmax_policy) "
+            "to use draft-mask sampling."
+        )
+
+    return torch.ops.hpc.fused_sampler(
+        logits,
+        penalty_mask,
+        slot_id,
+        *_to_tensor_scalar_tuple(repetition_penalty),
+        *_to_tensor_scalar_tuple(temperature),
+        int(softmax_policy),
+        *_to_tensor_scalar_tuple(topk),
+        *_to_tensor_scalar_tuple(topp),
+        max_topk,
+        gumbel_noise,
+        seed,
+    )

--- a/src/sampler/entry.cc
+++ b/src/sampler/entry.cc
@@ -1,0 +1,307 @@
+// Copyright (C) 2026 Tencent.
+
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime_api.h>
+#include <time.h>
+#include <torch/all.h>
+#include <torch/library.h>
+
+#include "src/sampler/sampler.h"
+
+namespace hpc {
+namespace sampler {
+// fused_sampler: 2-kernel fused sampling op. Kernel in fused_sampler.cu,
+// wrapper in hpc/sampler.py.
+torch::Tensor fused_sampler_entry(
+    const torch::Tensor& logits, std::optional<torch::Tensor> penalty_mask,
+    std::optional<torch::Tensor> slot_id, std::optional<torch::Tensor> repetition_penalty,
+    double repetition_penalty_val, std::optional<torch::Tensor> temperature, double temperature_val,
+    int64_t softmax_policy, std::optional<torch::Tensor> topk, int64_t topk_val,
+    std::optional<torch::Tensor> topp, double topp_val, int64_t max_topk,
+    std::optional<torch::Tensor> gumbel_noise, int64_t seed) {
+  TORCH_CHECK(logits.dim() == 2, "logits tensor must be dim == 2");
+  TORCH_CHECK(logits.scalar_type() == torch::kFloat32 || logits.scalar_type() == torch::kBFloat16,
+              "logits dtype must be float32 or bfloat16");
+  const int batch_size = logits.size(0);
+  const int vocab_size = logits.size(1);
+  const int64_t logits_row_stride = logits.stride(0);
+  TORCH_CHECK(logits.stride(1) == 1,
+              "fused_sampler: logits must have contiguous inner dim (stride(1)=1), "
+              "got stride(1)=",
+              logits.stride(1));
+  TORCH_CHECK(logits_row_stride >= vocab_size,
+              "fused_sampler: logits stride(0)=", logits_row_stride,
+              " must be >= vocab_size=", vocab_size);
+  // Row may be strided; require only row-major + inner stride 1 (not is_contiguous).
+
+  TORCH_CHECK(softmax_policy >= 0 && softmax_policy <= 2,
+              "softmax_policy must be one of 0(NONE)/1(BEFORE_TOPK)/2(AFTER_TOPK)");
+
+  const bool has_penalty_mask = penalty_mask.has_value();
+  const bool has_slot_id = slot_id.has_value();
+  TORCH_CHECK(has_penalty_mask == has_slot_id,
+              "penalty_mask and slot_id must both be provided or both be omitted");
+
+  uint8_t* penalty_mask_ptr = nullptr;
+  const int32_t* slot_id_ptr = nullptr;
+  if (has_penalty_mask) {
+    TORCH_CHECK(penalty_mask->is_contiguous(), "penalty_mask tensor must be contiguous");
+    TORCH_CHECK(penalty_mask->scalar_type() == torch::kUInt8, "penalty_mask dtype must be uint8");
+    TORCH_CHECK(penalty_mask->dim() == 2, "penalty_mask must be 2D [MAX_BS, ceil(V/8)]");
+    TORCH_CHECK(penalty_mask->size(1) >= (vocab_size + 7) / 8,
+                "penalty_mask dim 1 must be >= ", (vocab_size + 7) / 8, ", got ",
+                penalty_mask->size(1));
+
+    TORCH_CHECK(slot_id->is_contiguous(), "slot_id tensor must be contiguous");
+    TORCH_CHECK(slot_id->scalar_type() == torch::kInt32, "slot_id dtype must be int32");
+    TORCH_CHECK(slot_id->dim() == 1, "slot_id must be 1D");
+    TORCH_CHECK(slot_id->size(0) == batch_size,
+                "slot_id.size(0) must equal batch_size=", batch_size, ", got ", slot_id->size(0));
+    TORCH_CHECK(penalty_mask->size(0) >= batch_size,
+                "penalty_mask.size(0)(MAX_BS) must be >= batch_size=", batch_size);
+
+    penalty_mask_ptr = penalty_mask->data_ptr<uint8_t>();
+    slot_id_ptr = slot_id->data_ptr<int32_t>();
+  }
+
+  auto check_1d_float = [&](const std::optional<torch::Tensor>& t, const char* name) {
+    if (!t.has_value()) {
+      return;
+    }
+    TORCH_CHECK(t->is_contiguous(), name, " tensor must be contiguous");
+    TORCH_CHECK(t->scalar_type() == torch::kFloat32, name, " dtype must be float32");
+    TORCH_CHECK(t->dim() == 1, name, " tensor must be 1D");
+    TORCH_CHECK(t->size(0) == batch_size, name, " size must be [batch_size=", batch_size,
+                "], got [", t->size(0), "]");
+  };
+  check_1d_float(repetition_penalty, "repetition_penalty");
+  check_1d_float(temperature, "temperature");
+  check_1d_float(topp, "topp");
+
+  const float* rp_arr =
+      repetition_penalty.has_value() ? repetition_penalty->data_ptr<float>() : nullptr;
+  const float* temp_arr = temperature.has_value() ? temperature->data_ptr<float>() : nullptr;
+  const float* topp_arr = topp.has_value() ? topp->data_ptr<float>() : nullptr;
+
+  const void* topk_ptr = nullptr;
+  int topk_int_bytes = 0;
+  if (topk.has_value()) {
+    TORCH_CHECK(topk->is_contiguous(), "topk tensor must be contiguous");
+    TORCH_CHECK(topk->dim() == 1, "topk tensor must be 1D");
+    TORCH_CHECK(topk->size(0) == batch_size, "topk size must be [batch_size=", batch_size,
+                "], got [", topk->size(0), "]");
+    if (topk->scalar_type() == torch::kInt32) {
+      topk_int_bytes = 4;
+    } else if (topk->scalar_type() == torch::kInt64) {
+      topk_int_bytes = 8;
+    } else {
+      TORCH_CHECK(false, "topk dtype must be int32 or int64");
+    }
+    topk_ptr = topk->data_ptr();
+  }
+
+  // Enable flags (for constraint checks).
+  const bool has_rp = (rp_arr != nullptr) || (repetition_penalty_val > 0.f);
+  const bool has_topk = (topk_ptr != nullptr) || (topk_val > 0);
+  const bool has_topp = (topp_arr != nullptr) || (topp_val > 0.f);
+
+  // Repetition penalty gating.
+  TORCH_CHECK(!has_rp || has_penalty_mask,
+              "repetition_penalty is enabled but penalty_mask/slot_id are missing");
+
+  // topp requires topk + softmax.
+  TORCH_CHECK(!has_topp || has_topk,
+              "topp requires topk to be enabled (kernel does not support bare topp)");
+  TORCH_CHECK(!has_topp || softmax_policy != 0,
+              "topp requires softmax_policy != NONE (BEFORE_TOPK or AFTER_TOPK)");
+  // softmax requires topp: without topp, softmax is order-preserving and would
+  // be silent overhead. Reject the conflict.
+  TORCH_CHECK(softmax_policy == 0 || has_topp,
+              "softmax_policy != NONE requires topp to be enabled "
+              "(softmax has no effect on sampling without topp)");
+
+  TORCH_CHECK(max_topk == 32 || max_topk == 64, "max_topk must be 32 or 64, got ", max_topk);
+
+  const float* gumbel_noise_ptr = nullptr;
+  if (gumbel_noise.has_value()) {
+    TORCH_CHECK(gumbel_noise->is_contiguous(), "gumbel_noise tensor must be contiguous");
+    TORCH_CHECK(gumbel_noise->scalar_type() == torch::kFloat32,
+                "gumbel_noise dtype must be float32");
+    TORCH_CHECK(gumbel_noise->dim() == 2, "gumbel_noise must be 2D");
+    TORCH_CHECK(gumbel_noise->size(0) == batch_size && gumbel_noise->size(1) == vocab_size,
+                "gumbel_noise shape must be [", batch_size, ", ", vocab_size, "]");
+    gumbel_noise_ptr = gumbel_noise->data_ptr<float>();
+  }
+
+  torch::Tensor token_ids =
+      torch::empty({batch_size, 1}, torch::dtype(torch::kInt32).device(logits.device()));
+
+  int logits_dtype = (logits.scalar_type() == torch::kFloat32) ? 0 : 1;
+  auto stream = at::cuda::getCurrentCUDAStream(logits.get_device());
+
+  const int nmax = hpc::sampler::fused_sampler_nmax(static_cast<int>(max_topk));
+  TORCH_CHECK(nmax > 0, "fused_sampler: invalid max_topk=", max_topk);
+  const auto f32_opts = torch::dtype(torch::kFloat32).device(logits.device());
+  const auto i32_opts = torch::dtype(torch::kInt32).device(logits.device());
+
+  torch::Tensor mid_logits =
+      torch::empty({batch_size, nmax * static_cast<int>(max_topk)}, f32_opts);
+  torch::Tensor mid_tokens =
+      torch::empty({batch_size, nmax * static_cast<int>(max_topk)}, i32_opts);
+
+  // partial_max/sum only needed for BEFORE_TOPK; otherwise pass nullptr.
+  torch::Tensor partial_max;
+  torch::Tensor partial_sum;
+  float* partial_max_ptr = nullptr;
+  float* partial_sum_ptr = nullptr;
+  if (softmax_policy == 1 /* BEFORE_TOPK */) {
+    partial_max = torch::empty({batch_size, nmax}, f32_opts);
+    partial_sum = torch::empty({batch_size, nmax}, f32_opts);
+    partial_max_ptr = partial_max.mutable_data_ptr<float>();
+    partial_sum_ptr = partial_sum.mutable_data_ptr<float>();
+  }
+
+  // RNG seed required (> 0) only when no external gumbel_noise is supplied.
+  uint64_t rng_seed = 0;
+  if (gumbel_noise_ptr == nullptr) {
+    TORCH_CHECK(
+        seed > 0,
+        "fused_sampler: seed must be > 0 when gumbel_noise is not provided, got seed=", seed);
+    rng_seed = static_cast<uint64_t>(seed);
+  }
+
+  fused_sampler_async(
+      token_ids.mutable_data_ptr<int32_t>(), logits.data_ptr(), logits_dtype, penalty_mask_ptr,
+      slot_id_ptr, rp_arr, static_cast<float>(repetition_penalty_val), temp_arr,
+      static_cast<float>(temperature_val), static_cast<int>(softmax_policy), topk_ptr,
+      topk_int_bytes, static_cast<int>(topk_val), topp_arr, static_cast<float>(topp_val),
+      gumbel_noise_ptr, partial_max_ptr, partial_sum_ptr, mid_logits.mutable_data_ptr<float>(),
+      mid_tokens.mutable_data_ptr<int32_t>(), batch_size, vocab_size,
+      static_cast<int>(logits_row_stride), static_cast<int>(max_topk), rng_seed, stream);
+
+  return token_ids;
+}
+// fused_sampler_temperature_sample: temperature-only fast-path. Kernel in
+// src/sampler/fused_sampler_temperature.cu.
+torch::Tensor fused_sampler_temperature_sample_entry(const torch::Tensor& logits,
+                                                     std::optional<torch::Tensor> temperature,
+                                                     double temperature_val,
+                                                     std::optional<torch::Tensor> gumbel_noise,
+                                                     std::optional<torch::Tensor> draft_token_ids,
+                                                     int64_t seed) {
+  TORCH_CHECK(logits.dim() == 2, "logits tensor must be dim == 2");
+  TORCH_CHECK(logits.scalar_type() == torch::kFloat32 || logits.scalar_type() == torch::kBFloat16,
+              "logits dtype must be float32 or bfloat16");
+  const int batch_size = logits.size(0);
+  const int vocab_size = logits.size(1);
+  const int64_t logits_row_stride = logits.stride(0);
+  TORCH_CHECK(logits.stride(1) == 1,
+              "fused_sampler_temperature_sample: logits must have contiguous inner dim "
+              "(stride(1)=1), got stride(1)=",
+              logits.stride(1));
+  TORCH_CHECK(logits_row_stride >= vocab_size,
+              "fused_sampler_temperature_sample: logits stride(0)=", logits_row_stride,
+              " must be >= vocab_size=", vocab_size);
+
+  const float* temperature_ptr = nullptr;
+  if (temperature.has_value()) {
+    TORCH_CHECK(temperature->is_contiguous(), "temperature tensor must be contiguous");
+    TORCH_CHECK(temperature->scalar_type() == torch::kFloat32, "temperature dtype must be float32");
+    TORCH_CHECK(temperature->dim() == 1, "temperature tensor must be 1D");
+    TORCH_CHECK(temperature->size(0) == batch_size,
+                "temperature size must be [batch_size=", batch_size, "], got [",
+                temperature->size(0), "]");
+    // The temperature kernel divides logits by each per-batch temperature with
+    // no in-kernel t<=0 guard (unlike the main fused_sampler kernel). A zero or
+    // negative entry would yield +-inf / NaN scores, so require every element
+    // strictly > 0 here.
+    TORCH_CHECK(temperature->numel() == 0 || temperature->min().item<float>() > 0.f,
+                "fused_sampler_temperature_sample: every temperature tensor element must be > 0, "
+                "got min=",
+                (temperature->numel() == 0 ? 0.f : temperature->min().item<float>()));
+    temperature_ptr = temperature->data_ptr<float>();
+  } else {
+    TORCH_CHECK(temperature_val > 0.f,
+                "fused_sampler_temperature_sample: scalar temperature must be > 0, got ",
+                temperature_val);
+  }
+
+  const float* gumbel_noise_ptr = nullptr;
+  if (gumbel_noise.has_value()) {
+    TORCH_CHECK(gumbel_noise->is_contiguous(), "gumbel_noise tensor must be contiguous");
+    TORCH_CHECK(gumbel_noise->scalar_type() == torch::kFloat32,
+                "gumbel_noise dtype must be float32");
+    TORCH_CHECK(gumbel_noise->dim() == 2, "gumbel_noise must be 2D");
+    TORCH_CHECK(gumbel_noise->size(0) == batch_size && gumbel_noise->size(1) == vocab_size,
+                "gumbel_noise shape must be [", batch_size, ", ", vocab_size, "]");
+    gumbel_noise_ptr = gumbel_noise->data_ptr<float>();
+  }
+
+  // ---- Optional draft mask [batch_size] int64: -1 = unmasked, else that
+  //   token's logit is treated as -inf. Out-of-range values ignored by kernel.
+  const int64_t* draft_token_ids_ptr = nullptr;
+  if (draft_token_ids.has_value()) {
+    TORCH_CHECK(draft_token_ids->is_contiguous(), "draft_token_ids tensor must be contiguous");
+    TORCH_CHECK(draft_token_ids->scalar_type() == torch::kInt64,
+                "draft_token_ids dtype must be int64");
+    TORCH_CHECK(draft_token_ids->dim() == 1, "draft_token_ids must be 1D");
+    TORCH_CHECK(draft_token_ids->size(0) == batch_size,
+                "draft_token_ids size must be [batch_size=", batch_size, "], got [",
+                draft_token_ids->size(0), "]");
+    draft_token_ids_ptr = draft_token_ids->data_ptr<int64_t>();
+  }
+
+  torch::Tensor token_ids =
+      torch::empty({batch_size, 1}, torch::dtype(torch::kInt32).device(logits.device()));
+
+  uint64_t rng_seed = 0;
+  if (gumbel_noise_ptr == nullptr) {
+    TORCH_CHECK(seed > 0,
+                "fused_sampler_temperature_sample: seed must be > 0 when gumbel_noise "
+                "is not provided, got seed=",
+                seed);
+    rng_seed = static_cast<uint64_t>(seed);
+  }
+
+  const int logits_dtype = (logits.scalar_type() == torch::kFloat32) ? 0 : 1;
+  auto stream = at::cuda::getCurrentCUDAStream(logits.get_device());
+
+  const int n_max_per_row = hpc::sampler::fused_sampler_temperature_n_max_per_row();
+  const auto f32_opts = torch::dtype(torch::kFloat32).device(logits.device());
+  const auto i32_opts = torch::dtype(torch::kInt32).device(logits.device());
+  torch::Tensor scratch_score = torch::empty({batch_size, n_max_per_row}, f32_opts);
+  torch::Tensor scratch_tok = torch::empty({batch_size, n_max_per_row}, i32_opts);
+  torch::Tensor counter = torch::zeros({batch_size}, i32_opts);
+
+  fused_sampler_temperature_async(
+      token_ids.mutable_data_ptr<int32_t>(), logits.data_ptr(), logits_dtype,
+      static_cast<int>(logits_row_stride), temperature_ptr, static_cast<float>(temperature_val),
+      gumbel_noise_ptr, draft_token_ids_ptr, scratch_score.mutable_data_ptr<float>(),
+      scratch_tok.mutable_data_ptr<int32_t>(), counter.mutable_data_ptr<int32_t>(), batch_size,
+      vocab_size, rng_seed, stream);
+  return token_ids;
+}
+
+}  // namespace sampler
+}  // namespace hpc
+
+TORCH_LIBRARY_FRAGMENT(hpc, m) {
+  m.def(
+      "fused_sampler(Tensor logits, Tensor? penalty_mask, Tensor? slot_id, "
+      "Tensor? repetition_penalty, float repetition_penalty_val, "
+      "Tensor? temperature, float temperature_val, "
+      "int softmax_policy, "
+      "Tensor? topk, int topk_val, "
+      "Tensor? topp, float topp_val, "
+      "int max_topk, "
+      "Tensor? gumbel_noise=None, int seed=0) -> Tensor");
+  m.impl("fused_sampler", torch::kCUDA, &hpc::sampler::fused_sampler_entry);
+  m.def(
+      "fused_sampler_temperature_sample(Tensor logits, Tensor? temperature, "
+      "float temperature_val, Tensor? gumbel_noise=None, "
+      "Tensor? draft_token_ids=None, "
+      "int seed=0) -> Tensor");
+  m.impl("fused_sampler_temperature_sample", torch::kCUDA,
+         &hpc::sampler::fused_sampler_temperature_sample_entry);
+}

--- a/src/sampler/entry.cc
+++ b/src/sampler/entry.cc
@@ -140,28 +140,6 @@ torch::Tensor fused_sampler_entry(
   int logits_dtype = (logits.scalar_type() == torch::kFloat32) ? 0 : 1;
   auto stream = at::cuda::getCurrentCUDAStream(logits.get_device());
 
-  const int nmax = hpc::sampler::fused_sampler_nmax(static_cast<int>(max_topk));
-  TORCH_CHECK(nmax > 0, "fused_sampler: invalid max_topk=", max_topk);
-  const auto f32_opts = torch::dtype(torch::kFloat32).device(logits.device());
-  const auto i32_opts = torch::dtype(torch::kInt32).device(logits.device());
-
-  torch::Tensor mid_logits =
-      torch::empty({batch_size, nmax * static_cast<int>(max_topk)}, f32_opts);
-  torch::Tensor mid_tokens =
-      torch::empty({batch_size, nmax * static_cast<int>(max_topk)}, i32_opts);
-
-  // partial_max/sum only needed for BEFORE_TOPK; otherwise pass nullptr.
-  torch::Tensor partial_max;
-  torch::Tensor partial_sum;
-  float* partial_max_ptr = nullptr;
-  float* partial_sum_ptr = nullptr;
-  if (softmax_policy == 1 /* BEFORE_TOPK */) {
-    partial_max = torch::empty({batch_size, nmax}, f32_opts);
-    partial_sum = torch::empty({batch_size, nmax}, f32_opts);
-    partial_max_ptr = partial_max.mutable_data_ptr<float>();
-    partial_sum_ptr = partial_sum.mutable_data_ptr<float>();
-  }
-
   // RNG seed required (> 0) only when no external gumbel_noise is supplied.
   uint64_t rng_seed = 0;
   if (gumbel_noise_ptr == nullptr) {
@@ -176,9 +154,8 @@ torch::Tensor fused_sampler_entry(
       slot_id_ptr, rp_arr, static_cast<float>(repetition_penalty_val), temp_arr,
       static_cast<float>(temperature_val), static_cast<int>(softmax_policy), topk_ptr,
       topk_int_bytes, static_cast<int>(topk_val), topp_arr, static_cast<float>(topp_val),
-      gumbel_noise_ptr, partial_max_ptr, partial_sum_ptr, mid_logits.mutable_data_ptr<float>(),
-      mid_tokens.mutable_data_ptr<int32_t>(), batch_size, vocab_size,
-      static_cast<int>(logits_row_stride), static_cast<int>(max_topk), rng_seed, stream);
+      gumbel_noise_ptr, batch_size, vocab_size, static_cast<int>(logits_row_stride),
+      static_cast<int>(max_topk), rng_seed, stream);
 
   return token_ids;
 }
@@ -267,19 +244,10 @@ torch::Tensor fused_sampler_temperature_sample_entry(const torch::Tensor& logits
   const int logits_dtype = (logits.scalar_type() == torch::kFloat32) ? 0 : 1;
   auto stream = at::cuda::getCurrentCUDAStream(logits.get_device());
 
-  const int n_max_per_row = hpc::sampler::fused_sampler_temperature_n_max_per_row();
-  const auto f32_opts = torch::dtype(torch::kFloat32).device(logits.device());
-  const auto i32_opts = torch::dtype(torch::kInt32).device(logits.device());
-  torch::Tensor scratch_score = torch::empty({batch_size, n_max_per_row}, f32_opts);
-  torch::Tensor scratch_tok = torch::empty({batch_size, n_max_per_row}, i32_opts);
-  torch::Tensor counter = torch::zeros({batch_size}, i32_opts);
-
   fused_sampler_temperature_async(
       token_ids.mutable_data_ptr<int32_t>(), logits.data_ptr(), logits_dtype,
       static_cast<int>(logits_row_stride), temperature_ptr, static_cast<float>(temperature_val),
-      gumbel_noise_ptr, draft_token_ids_ptr, scratch_score.mutable_data_ptr<float>(),
-      scratch_tok.mutable_data_ptr<int32_t>(), counter.mutable_data_ptr<int32_t>(), batch_size,
-      vocab_size, rng_seed, stream);
+      gumbel_noise_ptr, draft_token_ids_ptr, batch_size, vocab_size, rng_seed, stream);
   return token_ids;
 }
 

--- a/src/sampler/fused_sampler.cu
+++ b/src/sampler/fused_sampler.cu
@@ -1,0 +1,761 @@
+// Copyright (C) 2026 Tencent.
+//
+// Fused sampler — 2-kernel pipeline. Pipeline:
+//   rp -> temp -> [softmax1] -> topk -> [softmax2] -> topp -> Gumbel-max -> penalty writeback
+//
+//   K1 fused_scan_topk_kernel  grid=(N,B) block=1024: single vocab pass →
+//      rp+temp → online max(+sum) → BlockRadixSort top-K per block.
+//   K2 stage2_kernel           grid=(B,) block=Nmax*K: merge N blocks' top-K,
+//      softmax/topp/Gumbel-max sample, write token + penalty bit.
+//
+//   N = blocks-per-batch (runtime), Nmax = min(1024/K, 32) compile-time cap.
+//   Template axes: DType, kVocabSize, kMaxTopK{32,64}, kSoftmaxPolicy, kHasTopP.
+//   Optional features disabled by null/zero: rp, temperature, topk, gumbel_noise.
+
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <curand_kernel.h>
+
+#include <algorithm>
+#include <cub/cub.cuh>  // NOLINT
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+#include "src/sampler/sampler.h"
+#include "src/sampler/sampler_rng.cuh"
+#include "src/utils/utils.cuh"
+
+namespace hpc {
+namespace sampler {
+namespace fused_sampler_kernels {
+
+constexpr int kThreadsPerBlock = 1024;
+constexpr int kItemsPerThread = 4;
+constexpr int kSoftmaxNone = 0;
+constexpr int kSoftmaxBeforeTopk = 1;
+constexpr int kSoftmaxAfterTopk = 2;
+constexpr float kNegInfF = -std::numeric_limits<float>::infinity();
+
+// Nmax: compile-time blocks-per-batch cap = min(1024/K, 32). 1024/K bounds K2's
+// block (Nmax*K ≤ 1024); 32 bounds K2's warp-0 partial reduce (one lane/block).
+template <int kMaxTopK>
+constexpr int kMaxBlocksPerBatch =
+    (kThreadsPerBlock / kMaxTopK) < 32 ? (kThreadsPerBlock / kMaxTopK) : 32;
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+template <typename DType>
+__device__ __forceinline__ void load_4_as_float(const DType* gmem, float* out) {
+  if constexpr (std::is_same_v<DType, float>) {
+    vec_t<float, kItemsPerThread> v = load<float, kItemsPerThread>(gmem);
+#pragma unroll
+    for (int i = 0; i < kItemsPerThread; i++) {
+      out[i] = v[i];
+    }
+  } else {
+    vec_t<__nv_bfloat16, kItemsPerThread> v = load<__nv_bfloat16, kItemsPerThread>(gmem);
+#pragma unroll
+    for (int i = 0; i < kItemsPerThread; i++) {
+      out[i] = __bfloat162float(v[i]);
+    }
+  }
+}
+
+template <typename DType, int kVocabSize>
+__device__ __forceinline__ void load_logits_safe(const DType* logits_batch, int col_base,
+                                                 float* vals) {
+  if (col_base + kItemsPerThread <= kVocabSize) {
+    load_4_as_float<DType>(logits_batch + col_base, vals);
+  } else {
+#pragma unroll
+    for (int i = 0; i < kItemsPerThread; i++) {
+      int col = col_base + i;
+      if (col < kVocabSize) {
+        if constexpr (std::is_same_v<DType, float>) {
+          vals[i] = logits_batch[col];
+        } else {
+          vals[i] = __bfloat162float(logits_batch[col]);
+        }
+      } else {
+        vals[i] = kNegInfF;
+      }
+    }
+  }
+}
+
+__device__ __forceinline__ void apply_rp_temp(float* vals, int col_base, bool rp_active, float rp,
+                                              float inv_rp, const uint8_t* penalty_row,
+                                              bool temp_active, float inv_t, int vocab_size) {
+  if (rp_active) {
+#pragma unroll
+    for (int i = 0; i < kItemsPerThread; i++) {
+      int col = col_base + i;
+      if (col < vocab_size) {
+        int byte_idx = col >> 3;
+        int bit_idx = col & 0x7;
+        if ((penalty_row[byte_idx] >> bit_idx) & 1u) {
+          vals[i] *= (vals[i] > 0.f) ? inv_rp : rp;
+        }
+      }
+    }
+  }
+  if (temp_active) {
+#pragma unroll
+    for (int i = 0; i < kItemsPerThread; i++) {
+      vals[i] *= inv_t;
+    }
+  }
+}
+
+__device__ __forceinline__ float block_reduce_max_smem(float v, float* warp_scratch) {
+  constexpr int kWarpSize = 32;
+  constexpr int kNumWarps = kThreadsPerBlock / kWarpSize;
+  int iwarp = threadIdx.x / kWarpSize;
+  int ilane = threadIdx.x % kWarpSize;
+  v = warp_reduce_max_xor(v);
+  if (ilane == 0) {
+    warp_scratch[iwarp] = v;
+  }
+  __syncthreads();
+  if (iwarp == 0) {
+    float u = (ilane < kNumWarps) ? warp_scratch[ilane] : kNegInfF;
+    u = warp_reduce_max_xor(u);
+    if (ilane == 0) {
+      warp_scratch[0] = u;
+    }
+  }
+  __syncthreads();
+  return warp_scratch[0];
+}
+
+__device__ __forceinline__ float block_reduce_sum_smem(float v, float* warp_scratch) {
+  constexpr int kWarpSize = 32;
+  constexpr int kNumWarps = kThreadsPerBlock / kWarpSize;
+  int iwarp = threadIdx.x / kWarpSize;
+  int ilane = threadIdx.x % kWarpSize;
+  v = warp_reduce_sum_xor(v);
+  if (ilane == 0) {
+    warp_scratch[iwarp] = v;
+  }
+  __syncthreads();
+  if (iwarp == 0) {
+    float u = (ilane < kNumWarps) ? warp_scratch[ilane] : 0.f;
+    u = warp_reduce_sum_xor(u);
+    if (ilane == 0) {
+      warp_scratch[0] = u;
+    }
+  }
+  __syncthreads();
+  return warp_scratch[0];
+}
+
+// ---------------------------------------------------------------------------
+// K1: single vocab pass → rp+temp → online max(+sum, BEFORE_TOPK only) →
+// per-block BlockRadixSort top-K. grid=(N,B); loop count derives from runtime N.
+// ---------------------------------------------------------------------------
+template <typename DType, int kVocabSize, int kMaxTopK, int kSoftmaxPolicy>
+__global__ __launch_bounds__(kThreadsPerBlock) void fused_scan_topk_kernel(
+    float* mid_logits,    // [B, Nmax, kMaxTopK]
+    int* mid_tokens,      // [B, Nmax, kMaxTopK]
+    float* partial_max,   // [B, Nmax]
+    float* partial_sum,   // [B, Nmax]
+    const DType* logits,  // [B, V] with stride
+    int logits_row_stride, const uint8_t* penalty_mask, const int32_t* slot_id, const float* rp_arr,
+    float rp_val, const float* temp_arr, float temp_val, int penalty_row_bytes,
+    int n_blocks_per_row,  // dynamic N (∈ [kNMin, Nmax])
+    int scratch_stride) {  // output row stride = Nmax (compile-time cap)
+  const int ibatch = blockIdx.y;
+  const int bid = blockIdx.x;
+  const int tid = threadIdx.x;
+
+  // --- Thread role ---
+  constexpr int kKeeperThreads = kMaxTopK / kItemsPerThread;
+  constexpr int kLoaderThreads = kThreadsPerBlock - kKeeperThreads;
+  const bool is_keeper = (tid < kKeeperThreads);
+  const int loader_id = tid - kKeeperThreads;  // valid only for loaders
+
+  // --- Per-batch parameters ---
+  const DType* logits_batch = logits + static_cast<int64_t>(ibatch) * logits_row_stride;
+
+  const float rp = rp_arr ? rp_arr[ibatch] : rp_val;
+  const bool rp_active = (rp > 0.f) && (penalty_mask != nullptr) && (slot_id != nullptr);
+  const float inv_rp = rp_active ? rcpf_ftz(rp) : 0.f;
+  const uint8_t* penalty_row =
+      rp_active ? (penalty_mask + slot_id[ibatch] * penalty_row_bytes) : nullptr;
+
+  const float t = temp_arr ? temp_arr[ibatch] : temp_val;
+  const bool temp_active = (t > 0.f);
+  const float inv_t = temp_active ? rcpf_ftz(t) : 0.f;
+
+  // --- Sort types ---
+  using BlockRadixSortT = cub::BlockRadixSort<float, kThreadsPerBlock, kItemsPerThread, int>;
+
+  __shared__ union {
+    typename BlockRadixSortT::TempStorage sort_temp;
+    float warp_scratch[kThreadsPerBlock / 32];
+  } shared;
+
+  // --- Initialize per-thread state ---
+  float thread_logits[kItemsPerThread];
+  int thread_tokens[kItemsPerThread];
+
+  // Keepers hold the rolling top-K; initialize to -inf before the load loop.
+  if (is_keeper) {
+#pragma unroll
+    for (int i = 0; i < kItemsPerThread; i++) {
+      thread_logits[i] = kNegInfF;
+      thread_tokens[i] = -1;
+    }
+  }
+
+  // Online max+sum accumulators — only used by BEFORE_TOPK loaders.
+  // NONE keeps raw logits; AFTER_TOPK normalizes over the surviving top-K in K2.
+  [[maybe_unused]] float thread_max = kNegInfF;
+  [[maybe_unused]] float thread_sum = 0.f;
+
+  // Load loop: runtime-bounded; `#pragma unroll 1` keeps register pressure flat.
+  const int elements_per_load_loop = n_blocks_per_row * kLoaderThreads * kItemsPerThread;
+  const int num_load_loops = (kVocabSize + elements_per_load_loop - 1) / elements_per_load_loop;
+
+#pragma unroll 1
+  for (int iloop = 0; iloop < num_load_loops; iloop++) {
+    if (!is_keeper) {
+      int col_base = iloop * elements_per_load_loop + bid * kLoaderThreads * kItemsPerThread +
+                     loader_id * kItemsPerThread;
+
+      float vals[kItemsPerThread];
+      load_logits_safe<DType, kVocabSize>(logits_batch, col_base, vals);
+      apply_rp_temp(vals, col_base, rp_active, rp, inv_rp, penalty_row, temp_active, inv_t,
+                    kVocabSize);
+
+      // Populate thread data for sort
+#pragma unroll
+      for (int i = 0; i < kItemsPerThread; i++) {
+        int col = col_base + i;
+        if (col < kVocabSize) {
+          thread_logits[i] = vals[i];
+          thread_tokens[i] = col;
+
+          // Online max (+sum) — only BEFORE_TOPK needs these.
+          if constexpr (kSoftmaxPolicy == kSoftmaxBeforeTopk) {
+            float x = vals[i];
+            if (x > thread_max) {
+              thread_sum *= expf(thread_max - x);
+              thread_max = x;
+            }
+            thread_sum += expf(x - thread_max);
+          }
+        } else {
+          thread_logits[i] = kNegInfF;
+          thread_tokens[i] = -1;
+        }
+      }
+    }
+
+    __syncthreads();
+    BlockRadixSortT(shared.sort_temp).SortDescending(thread_logits, thread_tokens);
+    __syncthreads();
+  }
+
+  // --- Post-loop: block reduce max+sum (BEFORE_TOPK only) ---
+  if constexpr (kSoftmaxPolicy == kSoftmaxBeforeTopk) {
+    float reduce_max = is_keeper ? kNegInfF : thread_max;
+    float block_max = block_reduce_max_smem(reduce_max, shared.warp_scratch);
+
+    float reduce_sum = is_keeper ? 0.f : thread_sum;
+    // Empty tail block (block_max == -inf): contribute 0, else expf(NaN) poisons K2's sum.
+    float corrected = (block_max == kNegInfF) ? 0.f : reduce_sum * expf(reduce_max - block_max);
+    float block_sum = block_reduce_sum_smem(corrected, shared.warp_scratch);
+    if (tid == 0) {
+      partial_max[ibatch * scratch_stride + bid] = block_max;
+      partial_sum[ibatch * scratch_stride + bid] = block_sum;
+    }
+  }
+
+  // --- Write top-K outputs ---
+  if (is_keeper) {
+    int dst_base = ibatch * scratch_stride * kMaxTopK + bid * kMaxTopK + tid * kItemsPerThread;
+#pragma unroll
+    for (int i = 0; i < kItemsPerThread; i++) {
+      mid_logits[dst_base + i] = thread_logits[i];
+      mid_tokens[dst_base + i] = thread_tokens[i];
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// K2: merge N blocks' top-K candidates → softmax/topp/Gumbel-max sample.
+// Block size = Nmax*K (static, cub::BlockRadixSort); slots from blocks ≥ N
+// masked to -inf.
+// ---------------------------------------------------------------------------
+template <int kMaxTopK, int kSoftmaxPolicy, bool kHasTopP>
+__global__ void stage2_kernel(int32_t* token_ids_out,    // [B]
+                              const float* mid_logits,   // [B, Nmax, kMaxTopK]
+                              const int* mid_tokens,     // [B, Nmax, kMaxTopK]
+                              const float* partial_max,  // [B, Nmax]
+                              const float* partial_sum,  // [B, Nmax]
+                              const void* topk_ptr, int topk_int_bytes, int topk_val,
+                              const float* topp_ptr, float topp_val, const float* gumbel_noise_ptr,
+                              int vocab_size, uint8_t* penalty_mask, const int32_t* slot_id,
+                              const float* rp_arr, float rp_val, int penalty_row_bytes,
+                              uint64_t rng_seed, uint64_t rng_base_offset, int n_blocks_per_row) {
+  constexpr int kNmax = kMaxBlocksPerBatch<kMaxTopK>;
+  constexpr int kThreadsPerBlock2 = kNmax * kMaxTopK;
+  const int ibatch = blockIdx.x;
+  const int tid = threadIdx.x;
+  const int ilane = tid % 32;
+
+  // --- Resolve effective top-K for this batch ---
+  int effK = kMaxTopK;
+  if (topk_ptr != nullptr) {
+    int user_k;
+    if (topk_int_bytes == 4) {
+      user_k = reinterpret_cast<const int32_t*>(topk_ptr)[ibatch];
+    } else {
+      user_k = static_cast<int>(reinterpret_cast<const int64_t*>(topk_ptr)[ibatch]);
+    }
+    if (user_k > 0) {
+      effK = min(user_k, kMaxTopK);
+    }
+  } else if (topk_val > 0) {
+    effK = min(topk_val, kMaxTopK);
+  }
+
+  // --- Phase 0: reduce partial_max/sum → global_max, inv_sum [BEFORE_TOPK only] ---
+  // Warp 0 reduces; lanes ≥ N use identity (only first N slots written by K1).
+  [[maybe_unused]] float global_max = 0.f;
+  [[maybe_unused]] float inv_sum = 0.f;
+  if constexpr (kSoftmaxPolicy == kSoftmaxBeforeTopk) {
+    __shared__ float smem_global_max;
+    __shared__ float smem_inv_sum;
+
+    if (tid < 32) {
+      float pm = (ilane < n_blocks_per_row) ? partial_max[ibatch * kNmax + ilane] : kNegInfF;
+      float gmax = warp_reduce_max_xor(pm);
+      float ps = (ilane < n_blocks_per_row) ? partial_sum[ibatch * kNmax + ilane] : 0.f;
+      float corrected = ps * expf(pm - gmax);  // rebase each block's sum to global_max
+      float global_sum = warp_reduce_sum_xor(corrected);
+      if (ilane == 0) {
+        smem_global_max = gmax;
+        smem_inv_sum = (global_sum > 0.f) ? rcpf_ftz(global_sum) : 0.f;
+      }
+    }
+    __syncthreads();
+
+    global_max = smem_global_max;
+    inv_sum = smem_inv_sum;
+  }
+
+  // --- Phase 1: load candidates (mask blocks ≥ N) + probability conversion ---
+  using BlockRadixSortT = cub::BlockRadixSort<float, kThreadsPerBlock2, 1, int>;
+
+  __shared__ union {
+    typename BlockRadixSortT::TempStorage sort_temp;
+    struct {
+      float final_logits[kThreadsPerBlock2];
+      int final_tokens[kThreadsPerBlock2];
+    } data;
+  } shared2;
+
+  const int cand_bid = tid / kMaxTopK;
+  float key[1];
+  int val[1];
+  if (cand_bid < n_blocks_per_row) {
+    int idx_in = ibatch * kNmax * kMaxTopK + tid;
+    key[0] = mid_logits[idx_in];
+    val[0] = mid_tokens[idx_in];
+  } else {
+    key[0] = kNegInfF;
+    val[0] = -1;
+  }
+
+  // Convert based on softmax policy
+  if constexpr (kSoftmaxPolicy == kSoftmaxBeforeTopk) {
+    // Full-vocab normalized probability
+    if (val[0] >= 0) {
+      key[0] = expf(key[0] - global_max) * inv_sum;
+    } else {
+      key[0] = 0.f;
+    }
+  }
+  // NONE / AFTER_TOPK: keep raw logits for sorting.
+
+  // --- Phase 2: BlockRadixSort merge ---
+  __syncthreads();
+  BlockRadixSortT(shared2.sort_temp).SortDescending(key, val);
+  __syncthreads();
+
+  // Store sorted results to shared memory
+  shared2.data.final_logits[tid] = key[0];
+  shared2.data.final_tokens[tid] = val[0];
+  __syncthreads();
+
+  // === Warp 0 only: phases 2.5-5 ===
+  if (tid >= 32) {
+    return;
+  }
+
+  constexpr int kItemsPerLane = kMaxTopK / 32;
+  float w_logit[kItemsPerLane];
+  int w_tok[kItemsPerLane];
+  float w_prob[kItemsPerLane];
+
+  // Load from shared (top-effK)
+#pragma unroll
+  for (int i = 0; i < kItemsPerLane; i++) {
+    int idx = ilane * kItemsPerLane + i;
+    w_logit[i] = shared2.data.final_logits[idx];
+    w_tok[i] = shared2.data.final_tokens[idx];
+    w_prob[i] = 0.f;
+  }
+
+  // --- Phase 2.5: AFTER_TOPK local softmax over top-K ---
+  if constexpr (kSoftmaxPolicy == kSoftmaxAfterTopk) {
+    float local_max = __shfl_sync(0xffffffff, w_logit[0], 0);  // sorted pos 0
+    float sum = 0.f;
+#pragma unroll
+    for (int i = 0; i < kItemsPerLane; i++) {
+      int idx = ilane * kItemsPerLane + i;
+      if (idx < effK && w_tok[i] >= 0) {
+        w_prob[i] = expf(w_logit[i] - local_max);
+        sum += w_prob[i];
+      }
+    }
+    sum = warp_reduce_sum_xor(sum);
+    float inv = (sum > 0.f) ? rcpf_ftz(sum) : 0.f;
+#pragma unroll
+    for (int i = 0; i < kItemsPerLane; i++) {
+      w_prob[i] *= inv;
+    }
+  } else if constexpr (kSoftmaxPolicy == kSoftmaxBeforeTopk) {
+    // Values are already full-vocab probabilities from Phase 1.
+#pragma unroll
+    for (int i = 0; i < kItemsPerLane; i++) {
+      int idx = ilane * kItemsPerLane + i;
+      w_prob[i] = (idx < effK && w_tok[i] >= 0) ? w_logit[i] : 0.f;
+    }
+  }
+  // NONE: w_prob stays 0 (sampling uses raw logits directly).
+
+  // --- Phase 3: Top-P truncation ---
+  float lane_run = 0.f;  // exclusive prefix sum at this lane's start
+  if constexpr (kHasTopP) {
+    float topp_b = topp_ptr ? topp_ptr[ibatch] : topp_val;
+    if (topp_b > 0.f) {
+      // Compute per-lane sum of probabilities
+      float lane_sum = 0.f;
+#pragma unroll
+      for (int i = 0; i < kItemsPerLane; i++) {
+        int idx = ilane * kItemsPerLane + i;
+        if (idx < effK) {
+          lane_sum += w_prob[i];
+        }
+      }
+      // Warp inclusive prefix scan
+      float prefix = lane_sum;
+      for (int offset = 1; offset < 32; offset <<= 1) {
+        float v = __shfl_up_sync(0xffffffff, prefix, offset);
+        if (ilane >= offset) {
+          prefix += v;
+        }
+      }
+      lane_run = prefix - lane_sum;  // exclusive prefix for this lane
+    }
+  }
+
+  // --- Phase 4: Gumbel-max sampling ---
+  float best_key = kNegInfF;
+  int best_tok = -1;
+
+  // Self-drawn RNG: Philox sequence = ibatch*32+ilane (same contract as
+  // fused_sampler_temperature.cu). External gumbel_noise_ptr is used directly.
+  static_assert(kItemsPerLane <= 4, "curand_uniform4 supplies at most 4 draws per lane");
+  curandStatePhilox4_32_10_t rng;
+  float u_vec[kItemsPerLane] = {};
+  if (gumbel_noise_ptr == nullptr) {
+    uint64_t sequence = static_cast<uint64_t>(ibatch) * 32 + ilane;
+    curand_init(rng_seed, sequence, rng_base_offset, &rng);
+    float4 r = curand_uniform4(&rng);
+    const float rr[4] = {r.x, r.y, r.z, r.w};
+#pragma unroll
+    for (int i = 0; i < kItemsPerLane; i++) {
+      u_vec[i] = rr[i];
+    }
+  }
+
+  float topp_threshold = 0.f;
+  if constexpr (kHasTopP) {
+    topp_threshold = topp_ptr ? topp_ptr[ibatch] : topp_val;
+  }
+
+  float running_cum = lane_run;
+#pragma unroll
+  for (int i = 0; i < kItemsPerLane; i++) {
+    int idx = ilane * kItemsPerLane + i;
+    int tok = w_tok[i];
+
+    bool keep = (idx < effK) && (tok >= 0);
+    if constexpr (kHasTopP) {
+      if (topp_threshold > 0.f) {
+        keep = keep && ((idx == 0) || (running_cum < topp_threshold));
+      }
+    }
+
+    if (keep) {
+      float value;
+      if constexpr (kSoftmaxPolicy == kSoftmaxNone) {
+        value = w_logit[i];
+      } else {
+        float p = w_prob[i];
+        value = (p > 0.f) ? logf_ftz(p) : kNegInfF;
+      }
+
+      // External buffer holds Gumbel(0) directly; self-drawn path applies the
+      // Gumbel transform from sampler_rng.cuh.
+      float g;
+      if (gumbel_noise_ptr != nullptr) {
+        g = gumbel_noise_ptr[ibatch * vocab_size + tok];
+      } else {
+        g = ::hpc::sampler::rng::gumbel_noise_from_uniform(u_vec[i]);
+      }
+
+      float k = value + g;
+      if (k > best_key || (k == best_key && (best_tok < 0 || tok < best_tok))) {
+        best_key = k;
+        best_tok = tok;
+      }
+    }
+
+    if constexpr (kHasTopP) {
+      running_cum += w_prob[i];
+    }
+  }
+
+  // --- Warp argmax with tiebreak ---
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    float other_key = __shfl_xor_sync(0xffffffff, best_key, offset);
+    int other_tok = __shfl_xor_sync(0xffffffff, best_tok, offset);
+
+    bool take;
+    if (other_key > best_key) {
+      take = true;
+    } else if (other_key < best_key) {
+      take = false;
+    } else {
+      // Tiebreak: prefer valid token, then smaller ID
+      take = (other_tok >= 0) && (best_tok < 0 || other_tok < best_tok);
+    }
+    if (take) {
+      best_key = other_key;
+      best_tok = other_tok;
+    }
+  }
+
+  // --- Phase 5: Output + penalty writeback ---
+  if (ilane == 0) {
+    int tok = (best_tok < 0) ? 0 : best_tok;
+    token_ids_out[ibatch] = tok;
+
+    // Penalty bit writeback
+    if (penalty_mask != nullptr && slot_id != nullptr && tok >= 0) {
+      float rp = rp_arr ? rp_arr[ibatch] : rp_val;
+      if (rp > 0.f) {
+        int slot = slot_id[ibatch];
+        uint8_t* row = penalty_mask + slot * penalty_row_bytes;
+        int byte_idx = tok >> 3;
+        int bit_in_byte = tok & 7;
+        uintptr_t byte_addr = reinterpret_cast<uintptr_t>(row + byte_idx);
+        uintptr_t word_addr = byte_addr & ~uintptr_t{3};
+        int byte_off = static_cast<int>(byte_addr - word_addr);
+        unsigned int bit_mask = (1u << bit_in_byte) << (byte_off * 8);
+        atomicOr(reinterpret_cast<unsigned int*>(word_addr), bit_mask);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic block-count: N = clamp(floor(SMs/B), kNMin, Nmax).
+//
+// K1 is limited to 1 block/SM, so floor(SMs/B) is the largest N keeping B*N ≤ SMs
+// (single wave; ceil would spill into a 2nd wave). kNMin floors N so per-block
+// work stays ≤ V/kNMin at large batch.
+// ---------------------------------------------------------------------------
+constexpr int kNMin = 8;
+
+inline int pick_n_blocks_per_row(int batch_size, int sm_count, int n_max) {
+  int n = sm_count / batch_size;  // floor(SMs / B)
+  if (n < kNMin) {
+    n = kNMin;
+  }
+  if (n > n_max) {
+    n = n_max;
+  }
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline launcher.
+// ---------------------------------------------------------------------------
+template <typename DType, int kVocabSize, int kMaxTopK, int kSoftmaxPolicy, bool kHasTopP>
+void launch_pipeline(int32_t* token_ids_out, const void* logits_ptr, uint8_t* penalty_mask_ptr,
+                     const int32_t* slot_id_ptr, const float* rp_arr, float rp_val,
+                     const float* temp_arr, float temp_val, int softmax_policy,
+                     const void* topk_ptr, int topk_int_bytes, int topk_val, const float* topp_ptr,
+                     float topp_val, const float* gumbel_noise_ptr, float* partial_max_ptr,
+                     float* partial_sum_ptr, float* mid_logits_ptr, int32_t* mid_tokens_ptr,
+                     int batch_size, int vocab_size, int logits_row_stride, int max_topk,
+                     uint64_t rng_seed, cudaStream_t stream) {
+  const int penalty_row_bytes = (vocab_size + 7) / 8;
+
+  // Nmax = compile-time cap; N = runtime value ≤ Nmax.
+  constexpr int kNmax = kMaxBlocksPerBatch<kMaxTopK>;
+  const int n_blocks_per_row = pick_n_blocks_per_row(batch_size, ::hpc::get_sm_count(), kNmax);
+
+  // Scratch is provided by the host (entry.cc, torch::empty), sized by Nmax
+  // (static strides); K1 writes first N slots, K2 masks the rest.
+  // partial_max/sum are non-null only for BEFORE_TOPK.
+
+  // --- Launch K1 ---
+  dim3 grid1(n_blocks_per_row, batch_size);
+  fused_scan_topk_kernel<DType, kVocabSize, kMaxTopK, kSoftmaxPolicy>
+      <<<grid1, kThreadsPerBlock, 0, stream>>>(
+          mid_logits_ptr, mid_tokens_ptr, partial_max_ptr, partial_sum_ptr,
+          reinterpret_cast<const DType*>(logits_ptr), logits_row_stride, penalty_mask_ptr,
+          slot_id_ptr, rp_arr, rp_val, temp_arr, temp_val, penalty_row_bytes, n_blocks_per_row,
+          kNmax);
+
+  // --- Launch K2 ---
+  constexpr int kThreadsPerBlock2 = kNmax * kMaxTopK;
+
+  // Per-launch Philox offset for fresh samples; external-gumbel path skips it.
+  uint64_t rng_base_offset = 0;
+  if (gumbel_noise_ptr == nullptr) {
+    rng_base_offset = ::hpc::sampler::rng::next_launch_offset();
+  }
+
+  stage2_kernel<kMaxTopK, kSoftmaxPolicy, kHasTopP><<<batch_size, kThreadsPerBlock2, 0, stream>>>(
+      token_ids_out, mid_logits_ptr, mid_tokens_ptr, partial_max_ptr, partial_sum_ptr, topk_ptr,
+      topk_int_bytes, topk_val, topp_ptr, topp_val, gumbel_noise_ptr, vocab_size, penalty_mask_ptr,
+      slot_id_ptr, rp_arr, rp_val, penalty_row_bytes, rng_seed, rng_base_offset, n_blocks_per_row);
+}
+
+// ---------------------------------------------------------------------------
+// Template dispatch chain.
+// ---------------------------------------------------------------------------
+
+template <typename T>
+struct type_tag {
+  using type = T;
+};
+
+}  // namespace fused_sampler_kernels
+
+// ---------------------------------------------------------------------------
+// Public entry point (called from entry.cc).
+// ---------------------------------------------------------------------------
+void fused_sampler_async(int32_t* token_ids_out, const void* logits_ptr, int logits_dtype,
+                         uint8_t* penalty_mask_ptr, const int32_t* slot_id_ptr,
+                         const float* repetition_penalty_ptr, float repetition_penalty_val,
+                         const float* temperature_ptr, float temperature_val, int softmax_policy,
+                         const void* topk_ptr, int topk_int_bytes, int topk_val,
+                         const float* topp_ptr, float topp_val, const float* gumbel_noise_ptr,
+                         float* partial_max_ptr, float* partial_sum_ptr, float* mid_logits_ptr,
+                         int32_t* mid_tokens_ptr, int batch_size, int vocab_size,
+                         int logits_row_stride, int max_topk, uint64_t rng_seed,
+                         cudaStream_t stream) {
+  using fused_sampler_kernels::launch_pipeline;
+  using fused_sampler_kernels::type_tag;
+  namespace kernels = fused_sampler_kernels;
+
+  const bool has_topp = (topp_ptr != nullptr) || (topp_val > 0.f);
+
+  // Tag-based dispatch: each lambda fixes one runtime axis to a compile-time
+  // constant, bottoming out in launch_pipeline.
+  auto launch = [&](auto dtype_tag, auto vocab_tag, auto topk_tag, auto policy_tag, auto topp_tag) {
+    using DType = typename decltype(dtype_tag)::type;
+    constexpr int kVocabSize = decltype(vocab_tag)::value;
+    constexpr int kMaxTopK = decltype(topk_tag)::value;
+    constexpr int kSoftmaxPolicy = decltype(policy_tag)::value;
+    constexpr bool kHasTopP = decltype(topp_tag)::value;
+    launch_pipeline<DType, kVocabSize, kMaxTopK, kSoftmaxPolicy, kHasTopP>(
+        token_ids_out, logits_ptr, penalty_mask_ptr, slot_id_ptr, repetition_penalty_ptr,
+        repetition_penalty_val, temperature_ptr, temperature_val, softmax_policy, topk_ptr,
+        topk_int_bytes, topk_val, topp_ptr, topp_val, gumbel_noise_ptr, partial_max_ptr,
+        partial_sum_ptr, mid_logits_ptr, mid_tokens_ptr, batch_size, vocab_size, logits_row_stride,
+        max_topk, rng_seed, stream);
+  };
+
+  auto dispatch_topp = [&](auto dtype_tag, auto vocab_tag, auto topk_tag, auto policy_tag) {
+    if (has_topp) {
+      launch(dtype_tag, vocab_tag, topk_tag, policy_tag, std::true_type{});
+    } else {
+      launch(dtype_tag, vocab_tag, topk_tag, policy_tag, std::false_type{});
+    }
+  };
+
+  auto dispatch_softmax = [&](auto dtype_tag, auto vocab_tag, auto topk_tag) {
+    switch (softmax_policy) {
+      case kernels::kSoftmaxNone:
+        dispatch_topp(dtype_tag, vocab_tag, topk_tag,
+                      std::integral_constant<int, kernels::kSoftmaxNone>{});
+        break;
+      case kernels::kSoftmaxBeforeTopk:
+        dispatch_topp(dtype_tag, vocab_tag, topk_tag,
+                      std::integral_constant<int, kernels::kSoftmaxBeforeTopk>{});
+        break;
+      case kernels::kSoftmaxAfterTopk:
+        dispatch_topp(dtype_tag, vocab_tag, topk_tag,
+                      std::integral_constant<int, kernels::kSoftmaxAfterTopk>{});
+        break;
+      default:
+        throw std::runtime_error("fused_sampler: unsupported softmax_policy " +
+                                 std::to_string(softmax_policy));
+    }
+  };
+
+  auto dispatch_max_topk = [&](auto dtype_tag, auto vocab_tag) {
+    if (max_topk == 32) {
+      dispatch_softmax(dtype_tag, vocab_tag, std::integral_constant<int, 32>{});
+    } else {
+      dispatch_softmax(dtype_tag, vocab_tag, std::integral_constant<int, 64>{});
+    }
+  };
+
+  auto dispatch_vocab = [&](auto dtype_tag) {
+    switch (vocab_size) {
+      case 120832:
+        dispatch_max_topk(dtype_tag, std::integral_constant<int, 120832>{});
+        break;
+      default:
+        throw std::runtime_error("fused_sampler: unsupported vocab_size " +
+                                 std::to_string(vocab_size));
+    }
+  };
+
+  if (logits_dtype == 0) {
+    dispatch_vocab(type_tag<float>{});
+  } else {
+    dispatch_vocab(type_tag<__nv_bfloat16>{});
+  }
+}
+
+// Host helper: Nmax for a given max_topk. Single source of truth for the
+// kernel's kMaxBlocksPerBatch so entry.cc can size scratch without duplicating
+// the constant. Returns 0 for unsupported max_topk.
+int fused_sampler_nmax(int max_topk) {
+  if (max_topk == 32) {
+    return fused_sampler_kernels::kMaxBlocksPerBatch<32>;
+  }
+  if (max_topk == 64) {
+    return fused_sampler_kernels::kMaxBlocksPerBatch<64>;
+  }
+  return 0;
+}
+
+}  // namespace sampler
+}  // namespace hpc

--- a/src/sampler/fused_sampler.cu
+++ b/src/sampler/fused_sampler.cu
@@ -579,6 +579,33 @@ __global__ void stage2_kernel(int32_t* token_ids_out,    // [B]
 }
 
 // ---------------------------------------------------------------------------
+// Scratch buffer RAII wrapper (cudaMallocAsync / cudaFreeAsync).
+// ---------------------------------------------------------------------------
+struct ScratchBuf {
+  void* ptr = nullptr;
+  cudaStream_t stream = nullptr;
+
+  ScratchBuf() = default;
+  ScratchBuf(size_t bytes, cudaStream_t s) : stream(s) {
+    if (bytes > 0) {
+      cudaMallocAsync(&ptr, bytes, stream);
+    }
+  }
+  ~ScratchBuf() {
+    if (ptr) {
+      cudaFreeAsync(ptr, stream);
+    }
+  }
+  ScratchBuf(const ScratchBuf&) = delete;
+  ScratchBuf& operator=(const ScratchBuf&) = delete;
+
+  template <typename T>
+  T* as() {
+    return reinterpret_cast<T*>(ptr);
+  }
+};
+
+// ---------------------------------------------------------------------------
 // Dynamic block-count: N = clamp(floor(SMs/B), kNMin, Nmax).
 //
 // K1 is limited to 1 block/SM, so floor(SMs/B) is the largest N keeping B*N ≤ SMs
@@ -606,28 +633,30 @@ void launch_pipeline(int32_t* token_ids_out, const void* logits_ptr, uint8_t* pe
                      const int32_t* slot_id_ptr, const float* rp_arr, float rp_val,
                      const float* temp_arr, float temp_val, int softmax_policy,
                      const void* topk_ptr, int topk_int_bytes, int topk_val, const float* topp_ptr,
-                     float topp_val, const float* gumbel_noise_ptr, float* partial_max_ptr,
-                     float* partial_sum_ptr, float* mid_logits_ptr, int32_t* mid_tokens_ptr,
-                     int batch_size, int vocab_size, int logits_row_stride, int max_topk,
-                     uint64_t rng_seed, cudaStream_t stream) {
+                     float topp_val, const float* gumbel_noise_ptr, int batch_size, int vocab_size,
+                     int logits_row_stride, int max_topk, uint64_t rng_seed, cudaStream_t stream) {
   const int penalty_row_bytes = (vocab_size + 7) / 8;
 
   // Nmax = compile-time cap; N = runtime value ≤ Nmax.
   constexpr int kNmax = kMaxBlocksPerBatch<kMaxTopK>;
   const int n_blocks_per_row = pick_n_blocks_per_row(batch_size, ::hpc::get_sm_count(), kNmax);
 
-  // Scratch is provided by the host (entry.cc, torch::empty), sized by Nmax
-  // (static strides); K1 writes first N slots, K2 masks the rest.
-  // partial_max/sum are non-null only for BEFORE_TOPK.
+  // Scratch sized by Nmax (static strides); K1 writes first N slots, K2 masks
+  // the rest. partial_max/sum only needed for BEFORE_TOPK.
+  constexpr bool kNeedPartial = (kSoftmaxPolicy == kSoftmaxBeforeTopk);
+  ScratchBuf partial_max_buf(kNeedPartial ? sizeof(float) * batch_size * kNmax : 0, stream);
+  ScratchBuf partial_sum_buf(kNeedPartial ? sizeof(float) * batch_size * kNmax : 0, stream);
+  ScratchBuf mid_logits_buf(sizeof(float) * batch_size * kNmax * kMaxTopK, stream);
+  ScratchBuf mid_tokens_buf(sizeof(int) * batch_size * kNmax * kMaxTopK, stream);
 
   // --- Launch K1 ---
   dim3 grid1(n_blocks_per_row, batch_size);
   fused_scan_topk_kernel<DType, kVocabSize, kMaxTopK, kSoftmaxPolicy>
       <<<grid1, kThreadsPerBlock, 0, stream>>>(
-          mid_logits_ptr, mid_tokens_ptr, partial_max_ptr, partial_sum_ptr,
-          reinterpret_cast<const DType*>(logits_ptr), logits_row_stride, penalty_mask_ptr,
-          slot_id_ptr, rp_arr, rp_val, temp_arr, temp_val, penalty_row_bytes, n_blocks_per_row,
-          kNmax);
+          mid_logits_buf.as<float>(), mid_tokens_buf.as<int>(), partial_max_buf.as<float>(),
+          partial_sum_buf.as<float>(), reinterpret_cast<const DType*>(logits_ptr),
+          logits_row_stride, penalty_mask_ptr, slot_id_ptr, rp_arr, rp_val, temp_arr, temp_val,
+          penalty_row_bytes, n_blocks_per_row, kNmax);
 
   // --- Launch K2 ---
   constexpr int kThreadsPerBlock2 = kNmax * kMaxTopK;
@@ -639,9 +668,10 @@ void launch_pipeline(int32_t* token_ids_out, const void* logits_ptr, uint8_t* pe
   }
 
   stage2_kernel<kMaxTopK, kSoftmaxPolicy, kHasTopP><<<batch_size, kThreadsPerBlock2, 0, stream>>>(
-      token_ids_out, mid_logits_ptr, mid_tokens_ptr, partial_max_ptr, partial_sum_ptr, topk_ptr,
-      topk_int_bytes, topk_val, topp_ptr, topp_val, gumbel_noise_ptr, vocab_size, penalty_mask_ptr,
-      slot_id_ptr, rp_arr, rp_val, penalty_row_bytes, rng_seed, rng_base_offset, n_blocks_per_row);
+      token_ids_out, mid_logits_buf.as<float>(), mid_tokens_buf.as<int>(),
+      partial_max_buf.as<float>(), partial_sum_buf.as<float>(), topk_ptr, topk_int_bytes, topk_val,
+      topp_ptr, topp_val, gumbel_noise_ptr, vocab_size, penalty_mask_ptr, slot_id_ptr, rp_arr,
+      rp_val, penalty_row_bytes, rng_seed, rng_base_offset, n_blocks_per_row);
 }
 
 // ---------------------------------------------------------------------------
@@ -664,10 +694,8 @@ void fused_sampler_async(int32_t* token_ids_out, const void* logits_ptr, int log
                          const float* temperature_ptr, float temperature_val, int softmax_policy,
                          const void* topk_ptr, int topk_int_bytes, int topk_val,
                          const float* topp_ptr, float topp_val, const float* gumbel_noise_ptr,
-                         float* partial_max_ptr, float* partial_sum_ptr, float* mid_logits_ptr,
-                         int32_t* mid_tokens_ptr, int batch_size, int vocab_size,
-                         int logits_row_stride, int max_topk, uint64_t rng_seed,
-                         cudaStream_t stream) {
+                         int batch_size, int vocab_size, int logits_row_stride, int max_topk,
+                         uint64_t rng_seed, cudaStream_t stream) {
   using fused_sampler_kernels::launch_pipeline;
   using fused_sampler_kernels::type_tag;
   namespace kernels = fused_sampler_kernels;
@@ -685,9 +713,8 @@ void fused_sampler_async(int32_t* token_ids_out, const void* logits_ptr, int log
     launch_pipeline<DType, kVocabSize, kMaxTopK, kSoftmaxPolicy, kHasTopP>(
         token_ids_out, logits_ptr, penalty_mask_ptr, slot_id_ptr, repetition_penalty_ptr,
         repetition_penalty_val, temperature_ptr, temperature_val, softmax_policy, topk_ptr,
-        topk_int_bytes, topk_val, topp_ptr, topp_val, gumbel_noise_ptr, partial_max_ptr,
-        partial_sum_ptr, mid_logits_ptr, mid_tokens_ptr, batch_size, vocab_size, logits_row_stride,
-        max_topk, rng_seed, stream);
+        topk_int_bytes, topk_val, topp_ptr, topp_val, gumbel_noise_ptr, batch_size, vocab_size,
+        logits_row_stride, max_topk, rng_seed, stream);
   };
 
   auto dispatch_topp = [&](auto dtype_tag, auto vocab_tag, auto topk_tag, auto policy_tag) {
@@ -742,19 +769,6 @@ void fused_sampler_async(int32_t* token_ids_out, const void* logits_ptr, int log
   } else {
     dispatch_vocab(type_tag<__nv_bfloat16>{});
   }
-}
-
-// Host helper: Nmax for a given max_topk. Single source of truth for the
-// kernel's kMaxBlocksPerBatch so entry.cc can size scratch without duplicating
-// the constant. Returns 0 for unsupported max_topk.
-int fused_sampler_nmax(int max_topk) {
-  if (max_topk == 32) {
-    return fused_sampler_kernels::kMaxBlocksPerBatch<32>;
-  }
-  if (max_topk == 64) {
-    return fused_sampler_kernels::kMaxBlocksPerBatch<64>;
-  }
-  return 0;
 }
 
 }  // namespace sampler

--- a/src/sampler/fused_sampler_temperature.cu
+++ b/src/sampler/fused_sampler_temperature.cu
@@ -1,0 +1,489 @@
+// Copyright (C) 2026 Tencent.
+//
+// Temperature-only fast-path sampler:
+//   token_id[b] = argmax_v ( logits[b, v] / temperature[b] + Gumbel(0)_{b,v} )
+//
+// Fast path of fused_sampler.cu for the "only temperature" case (skips the
+// topk/softmax/penalty machinery).
+//
+// Geometry: grid=(N, B), block=256. Each block scans a V/N vocab slice, reduces
+// to one (score, tok) partial in scratch[ibatch*stride+bid], then atomicAdds
+// counter[ibatch]; the last block (counter == N-1) reduces N partials → token.
+
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime_api.h>
+#include <curand_kernel.h>
+#include <stdint.h>
+
+#include <algorithm>
+#include <atomic>
+#include <limits>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+#include "src/sampler/sampler.h"
+#include "src/sampler/sampler_rng.cuh"
+#include "src/utils/utils.cuh"
+#include "src/utils/utils.h"
+
+namespace hpc {
+namespace sampler {
+namespace fused_sampler_temperature {
+namespace kernels {
+
+// Local analogue of `load_as_float` in fused_sampler.cu (own copy per TU).
+template <typename DType, int N>
+__device__ __forceinline__ void load_as_float_local(const DType* gmem, float* out) {
+  if constexpr (std::is_same_v<DType, float>) {
+    vec_t<float, N> v = load<float, N>(gmem);
+#pragma unroll
+    for (int i = 0; i < N; i++) {
+      out[i] = v[i];
+    }
+  } else {
+    vec_t<__nv_bfloat16, N> v = load<__nv_bfloat16, N>(gmem);
+#pragma unroll
+    for (int i = 0; i < N; i++) {
+      out[i] = __bfloat162float(v[i]);
+    }
+  }
+}
+
+// Tie-break: larger score wins; on a tie the smaller non-negative token id.
+// -1 is the empty-slot sentinel and never beats a real token.
+__device__ __forceinline__ bool take_other(float other_score, int other_tok, float my_score,
+                                           int my_tok) {
+  if (other_score > my_score) {
+    return true;
+  }
+  if (other_score < my_score) {
+    return false;
+  }
+  // Equal scores.
+  if (other_tok < 0) {
+    return false;
+  }
+  if (my_tok < 0) {
+    return true;
+  }
+  return other_tok < my_tok;
+}
+
+// ============================================================================
+// Kernel. Each block scans a V/N slice of one row → (best_score, best_tok) into
+// scratch[]; the last block to arrive (counter == N-1) reduces all N partials.
+// Draft mask: at most one masked token per row; draft_token_ids[b] == -1 means
+// unmasked, else that vocab id's post-temperature logit is treated as -inf.
+// ============================================================================
+
+template <typename DType, int kVocabSize, int kThreadsPerBlock, bool kHasExternalGumbel,
+          bool kHasDraftMask>
+__global__ __launch_bounds__(kThreadsPerBlock, 2) void fused_sampler_temperature_kernel(
+    int32_t* token_ids_out,          // [B, 1]
+    const DType* logits,             // base pointer, row stride = logits_row_stride
+    int logits_row_stride,           // >= kVocabSize
+    const float* temperature_arr,    // nullable [B]
+    float temperature_val,           //
+    const float* gumbel_noise,       // nullable [B, V]
+    const int64_t* draft_token_ids,  // nullable [B], -1 = no mask, else token id
+    float* scratch_score,            // [B * scratch_stride]
+    int32_t* scratch_tok,            // [B * scratch_stride]
+    int32_t* counter,                // [B], cache invariant: zero on entry
+    int n_blocks_per_row,            // dynamic N from launcher (∈ [kNMin, scratch_stride])
+    int scratch_stride,              // row stride for scratch (= max N supported = SM count)
+    uint64_t rng_seed,               //
+    uint64_t rng_base_offset) {      // per-launch base offset from host counter
+  constexpr int kWarpSize = 32;
+  constexpr int kWarpCount = kThreadsPerBlock / kWarpSize;
+  constexpr float kNegInf = -std::numeric_limits<float>::infinity();
+
+  const int bid = static_cast<int>(blockIdx.x);  // 0..N-1
+  const int ibatch = static_cast<int>(blockIdx.y);
+  const int tid = static_cast<int>(threadIdx.x);
+  const int iwarp = tid / kWarpSize;
+  const int ilane = tid % kWarpSize;
+
+  // Per-block vocab slice. Round cols_per_block UP to a multiple of
+  // kItemsPerThread (4) so each thread's 16B vec load stays aligned.
+  constexpr int kItemsPerThread = 4;  // 16B vec
+  const int cols_raw = (kVocabSize + n_blocks_per_row - 1) / n_blocks_per_row;
+  const int cols_per_block = (cols_raw + kItemsPerThread - 1) / kItemsPerThread * kItemsPerThread;
+  const int col_lo = bid * cols_per_block;
+  const int col_hi = min(col_lo + cols_per_block, kVocabSize);
+
+  // ---- Resolve per-batch temperature.
+  const float t = temperature_arr ? temperature_arr[ibatch] : temperature_val;
+
+  // ---- RNG init (self-drawn noise only). Unique cuRAND `sequence` per
+  // (row, block, thread); rng_base_offset advances per launch.
+  curandStatePhilox4_32_10_t rng_state;
+  if constexpr (!kHasExternalGumbel) {
+    uint64_t sequence =
+        (static_cast<uint64_t>(ibatch) * scratch_stride + bid) * kThreadsPerBlock + tid;
+    curand_init(rng_seed, sequence, rng_base_offset, &rng_state);
+  }
+
+  const DType* row = logits + static_cast<int64_t>(ibatch) * logits_row_stride;
+  const float* gumbel_row =
+      kHasExternalGumbel ? (gumbel_noise + static_cast<int64_t>(ibatch) * kVocabSize) : nullptr;
+
+  // ---- Resolve per-row draft mask (at most one masked token per row).
+  __shared__ int32_t s_mask_tok;
+  if constexpr (kHasDraftMask) {
+    if (tid == 0) {
+      int64_t tok = draft_token_ids[ibatch];
+      // -1 / out-of-range → no mask (kVocabSize is unreachable by `col`).
+      s_mask_tok = (tok >= 0 && tok < static_cast<int64_t>(kVocabSize))
+                       ? static_cast<int32_t>(tok)
+                       : static_cast<int32_t>(kVocabSize);
+    }
+    __syncthreads();
+  }
+  const int32_t reg_mask = kHasDraftMask ? s_mask_tok : static_cast<int32_t>(kVocabSize);
+
+  // ---- Phase 1: streaming scan over [col_lo, col_hi), per-thread argmax.
+  float best_score = kNegInf;
+  int best_tok = -1;
+
+  constexpr int kStride = kThreadsPerBlock * kItemsPerThread;  // 1024 items/iter
+  // Runtime-bounded iters; `unroll 1` keeps register usage low and stable.
+  const int base0 = col_lo + tid * kItemsPerThread;
+  const int iters = (cols_per_block + kStride - 1) / kStride;
+
+#pragma unroll 1
+  for (int it = 0; it < iters; it++) {
+    int col_base = base0 + it * kStride;
+    if (col_base >= col_hi) {
+      break;
+    }
+
+    float tmp[kItemsPerThread];
+    const bool full_in_bounds = (col_base + kItemsPerThread) <= col_hi;
+    if (full_in_bounds) {
+      load_as_float_local<DType, kItemsPerThread>(row + col_base, tmp);
+    } else {
+#pragma unroll
+      for (int i = 0; i < kItemsPerThread; i++) {
+        int col = col_base + i;
+        if (col < col_hi) {
+          if constexpr (std::is_same_v<DType, float>) {
+            tmp[i] = row[col];
+          } else {
+            tmp[i] = __bfloat162float(row[col]);
+          }
+        } else {
+          tmp[i] = kNegInf;
+        }
+      }
+    }
+
+    // Draw 4 uniforms per thread via cuRAND Philox.
+    float u_vec[kItemsPerThread];
+    if constexpr (!kHasExternalGumbel) {
+      float4 r = curand_uniform4(&rng_state);
+      u_vec[0] = r.x;
+      u_vec[1] = r.y;
+      u_vec[2] = r.z;
+      u_vec[3] = r.w;
+    }
+
+#pragma unroll
+    for (int i = 0; i < kItemsPerThread; i++) {
+      int col = col_base + i;
+      if (col >= col_hi) {
+        continue;
+      }
+      float x = tmp[i] / t;
+      if constexpr (kHasDraftMask) {
+        if (col == reg_mask) {
+          x = kNegInf;
+        }
+      }
+      float g;
+      if constexpr (kHasExternalGumbel) {
+        g = gumbel_row[col];
+      } else {
+        g = ::hpc::sampler::rng::gumbel_noise_from_uniform(u_vec[i]);
+      }
+      float score = x + g;
+      if (take_other(score, col, best_score, best_tok)) {
+        best_score = score;
+        best_tok = col;
+      }
+    }
+  }
+
+  // ---- Phase 2: warp argmax butterfly on (score, tok) pair.
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+    float o_s = __shfl_xor_sync(0xffffffff, best_score, offset);
+    int o_t = __shfl_xor_sync(0xffffffff, best_tok, offset);
+    if (take_other(o_s, o_t, best_score, best_tok)) {
+      best_score = o_s;
+      best_tok = o_t;
+    }
+  }
+
+  // ---- Phase 3: block argmax — warp leaders stage to SMEM, warp 0 reduces
+  //              into (block_score, block_tok) (held by lane 0 of warp 0).
+  __shared__ float s_key[kWarpCount];
+  __shared__ int s_tok[kWarpCount];
+  if (ilane == 0) {
+    s_key[iwarp] = best_score;
+    s_tok[iwarp] = best_tok;
+  }
+  __syncthreads();
+
+  __shared__ float s_block_score;
+  __shared__ int s_block_tok;
+  if (iwarp == 0) {
+    float k;
+    int v;
+    if (ilane < kWarpCount) {
+      k = s_key[ilane];
+      v = s_tok[ilane];
+    } else {
+      k = kNegInf;
+      v = -1;
+    }
+#pragma unroll
+    for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+      float o_s = __shfl_xor_sync(0xffffffff, k, offset);
+      int o_t = __shfl_xor_sync(0xffffffff, v, offset);
+      if (take_other(o_s, o_t, k, v)) {
+        k = o_s;
+        v = o_t;
+      }
+    }
+    if (ilane == 0) {
+      s_block_score = k;
+      s_block_tok = v;
+    }
+  }
+  __syncthreads();
+
+  // ---- Phase 4: publish partial to scratch, atomicAdd counter to find the
+  //              last block.
+  __shared__ int s_prev;
+  if (tid == 0) {
+    scratch_score[ibatch * scratch_stride + bid] = s_block_score;
+    scratch_tok[ibatch * scratch_stride + bid] = s_block_tok;
+    __threadfence();                          // release scratch before counter increment
+    s_prev = atomicAdd(&counter[ibatch], 1);  // 0..N-1; N-1 is the last block
+  }
+  __syncthreads();
+  if (s_prev != n_blocks_per_row - 1) {
+    return;
+  }
+
+  // ---- Phase 5: last block reduces N partials → final token.
+  __threadfence();  // observe other blocks' scratch writes
+
+  float my_s = kNegInf;
+  int my_t = -1;
+  if (tid < n_blocks_per_row) {  // n_blocks_per_row ≤ scratch_stride ≤ kThreadsPerBlock
+    my_s = scratch_score[ibatch * scratch_stride + tid];
+    my_t = scratch_tok[ibatch * scratch_stride + tid];
+  }
+
+  // Warp butterfly.
+#pragma unroll
+  for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+    float o_s = __shfl_xor_sync(0xffffffff, my_s, offset);
+    int o_t = __shfl_xor_sync(0xffffffff, my_t, offset);
+    if (take_other(o_s, o_t, my_s, my_t)) {
+      my_s = o_s;
+      my_t = o_t;
+    }
+  }
+  // Cross-warp via SMEM (reuse s_key / s_tok slots).
+  if (ilane == 0) {
+    s_key[iwarp] = my_s;
+    s_tok[iwarp] = my_t;
+  }
+  __syncthreads();
+  if (iwarp == 0) {
+    float k = (ilane < kWarpCount) ? s_key[ilane] : kNegInf;
+    int v = (ilane < kWarpCount) ? s_tok[ilane] : -1;
+#pragma unroll
+    for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+      float o_s = __shfl_xor_sync(0xffffffff, k, offset);
+      int o_t = __shfl_xor_sync(0xffffffff, v, offset);
+      if (take_other(o_s, o_t, k, v)) {
+        k = o_s;
+        v = o_t;
+      }
+    }
+    if (ilane == 0) {
+      int tok = (v >= 0) ? v : 0;  // degenerate fallback
+      token_ids_out[ibatch] = tok;
+      counter[ibatch] = 0;  // self-reset: keeps counter==0 invariant for next launch
+    }
+  }
+}
+
+}  // namespace kernels
+
+// ============================================================================
+// Launcher: runtime dispatch over (dtype, vocab_size, kHasExternalGumbel,
+// kHasDraftMask).
+// ============================================================================
+namespace {
+
+constexpr int kThreadsPerBlock = 256;
+constexpr int kItemsPerThread = 4;                           // matches kernel-side vec width
+constexpr int kStride = kThreadsPerBlock * kItemsPerThread;  // cols swept per iter
+constexpr int kVocabSizeMax = 120832;                        // largest supported vocab
+// kNMin: smallest N keeping per-block iters ≤ kMaxItersPerBlock (the cap with
+// 0 register spill on the cluster prototype).
+constexpr int kMaxItersPerBlock = 16;
+constexpr int kNMin =
+    (kVocabSizeMax + kStride * kMaxItersPerBlock - 1) / (kStride * kMaxItersPerBlock);
+
+// Shared per-launch Philox advance (sampler_rng.cuh). Assert it covers a
+// thread's max draws per launch.
+static_assert(::hpc::sampler::rng::kPerLaunchOffsetIncrement >=
+                  static_cast<uint64_t>(kMaxItersPerBlock * kItemsPerThread),
+              "Philox offset advance must cover all per-thread draws per launch");
+
+// Pick N blocks per row: ceil(SMs / B) clamped to [kNMin, n_max_per_row].
+inline int pick_n_blocks_per_row(int batch_size, int n_max_per_row) {
+  int n = (n_max_per_row + batch_size - 1) / batch_size;
+  if (n < kNMin) {
+    n = kNMin;
+  }
+  if (n > n_max_per_row) {
+    n = n_max_per_row;
+  }
+  return n;
+}
+
+template <typename DType, int kVocabSize, bool kHasExternalGumbel, bool kHasDraftMask>
+void launch_kernel(int32_t* token_ids_out, const void* logits_ptr, int logits_row_stride,
+                   const float* temperature_arr, float temperature_val, const float* gumbel_noise,
+                   const int64_t* draft_token_ids, float* scratch_score, int32_t* scratch_tok,
+                   int32_t* counter, int batch_size, int n_blocks_per_row, int scratch_stride,
+                   uint64_t rng_seed, uint64_t rng_base_offset, cudaStream_t stream) {
+  auto kernel = kernels::fused_sampler_temperature_kernel<DType, kVocabSize, kThreadsPerBlock,
+                                                          kHasExternalGumbel, kHasDraftMask>;
+
+  // No per-launch counter memset: the counter==0 invariant is maintained by the
+  // kernel's per-row self-reset (established once by acquire_workspace).
+
+  dim3 grid(n_blocks_per_row, batch_size);
+  dim3 block(kThreadsPerBlock);
+  kernel<<<grid, block, 0, stream>>>(
+      token_ids_out, reinterpret_cast<const DType*>(logits_ptr), logits_row_stride, temperature_arr,
+      temperature_val, gumbel_noise, draft_token_ids, scratch_score, scratch_tok, counter,
+      n_blocks_per_row, scratch_stride, rng_seed, rng_base_offset);
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string("fused_sampler_temperature: kernel launch failed: ") +
+                             cudaGetErrorString(err));
+  }
+}
+
+template <typename T>
+struct type_tag {
+  using type = T;
+};
+
+}  // namespace
+
+void fused_sampler_temperature_async(int32_t* token_ids_out, const void* logits_ptr,
+                                     int logits_dtype, int logits_row_stride,
+                                     const float* temperature_arr, float temperature_val,
+                                     const float* gumbel_noise_ptr,
+                                     const int64_t* draft_token_ids_ptr, float* scratch_score,
+                                     int32_t* scratch_tok, int32_t* counter, int batch_size,
+                                     int vocab_size, uint64_t rng_seed, cudaStream_t stream) {
+  const bool has_external_gumbel = (gumbel_noise_ptr != nullptr);
+  const bool has_draft_mask = (draft_token_ids_ptr != nullptr);
+
+  // Advance the global counter to obtain a unique RNG offset for this launch.
+  uint64_t rng_base_offset = 0;
+  if (!has_external_gumbel) {
+    rng_base_offset = ::hpc::sampler::rng::next_launch_offset();
+  }
+
+  // n_max_per_row = SM count, also the upper clamp on N. The last-block reduce
+  // loads N partials with `if (tid < N)`, so require N ≤ kThreadsPerBlock.
+  // Must match fused_sampler_temperature_n_max_per_row() used by the host to
+  // size the scratch buffers.
+  const int n_max_per_row = ::hpc::get_sm_count();
+  if (n_max_per_row > kThreadsPerBlock) {
+    throw std::runtime_error("fused_sampler_temperature: device SM count exceeds kThreadsPerBlock");
+  }
+  const int n_blocks_per_row = pick_n_blocks_per_row(batch_size, n_max_per_row);
+
+  auto launch = [&](auto dtype_tag, auto vocab_tag, auto gumbel_tag, auto mask_tag) {
+    using DType = typename decltype(dtype_tag)::type;
+    constexpr int kVocabSize = decltype(vocab_tag)::value;
+    constexpr bool kHasExternalGumbel = decltype(gumbel_tag)::value;
+    constexpr bool kHasDraftMask = decltype(mask_tag)::value;
+    launch_kernel<DType, kVocabSize, kHasExternalGumbel, kHasDraftMask>(
+        token_ids_out, logits_ptr, logits_row_stride, temperature_arr, temperature_val,
+        gumbel_noise_ptr, draft_token_ids_ptr, scratch_score, scratch_tok, counter, batch_size,
+        n_blocks_per_row, n_max_per_row, rng_seed, rng_base_offset, stream);
+  };
+
+  auto dispatch_mask = [&](auto dtype_tag, auto vocab_tag, auto gumbel_tag) {
+    if (has_draft_mask) {
+      launch(dtype_tag, vocab_tag, gumbel_tag, std::true_type{});
+    } else {
+      launch(dtype_tag, vocab_tag, gumbel_tag, std::false_type{});
+    }
+  };
+
+  auto dispatch_gumbel = [&](auto dtype_tag, auto vocab_tag) {
+    if (has_external_gumbel) {
+      dispatch_mask(dtype_tag, vocab_tag, std::true_type{});
+    } else {
+      dispatch_mask(dtype_tag, vocab_tag, std::false_type{});
+    }
+  };
+
+  auto dispatch_vocab = [&](auto dtype_tag) {
+    switch (vocab_size) {
+      case 120832:
+        dispatch_gumbel(dtype_tag, std::integral_constant<int, 120832>{});
+        break;
+      default:
+        throw std::invalid_argument("fused_sampler_temperature: unsupported vocab_size=" +
+                                    std::to_string(vocab_size) + " (supported: {120832})");
+    }
+  };
+
+  if (logits_dtype == 0) {
+    dispatch_vocab(type_tag<float>{});
+  } else if (logits_dtype == 1) {
+    dispatch_vocab(type_tag<__nv_bfloat16>{});
+  } else {
+    throw std::invalid_argument(
+        "fused_sampler_temperature: logits_dtype must be 0 (fp32) or 1 (bf16)");
+  }
+}
+
+}  // namespace fused_sampler_temperature
+
+int fused_sampler_temperature_n_max_per_row() { return ::hpc::get_sm_count(); }
+
+// Public entry for the header — forwards to the detail namespace.
+void fused_sampler_temperature_async(int32_t* token_ids_out, const void* logits_ptr,
+                                     int logits_dtype, int logits_row_stride,
+                                     const float* temperature_arr, float temperature_val,
+                                     const float* gumbel_noise_ptr,
+                                     const int64_t* draft_token_ids_ptr, float* scratch_score,
+                                     int32_t* scratch_tok, int32_t* counter, int batch_size,
+                                     int vocab_size, uint64_t rng_seed, cudaStream_t stream) {
+  fused_sampler_temperature::fused_sampler_temperature_async(
+      token_ids_out, logits_ptr, logits_dtype, logits_row_stride, temperature_arr, temperature_val,
+      gumbel_noise_ptr, draft_token_ids_ptr, scratch_score, scratch_tok, counter, batch_size,
+      vocab_size, rng_seed, stream);
+}
+
+}  // namespace sampler
+}  // namespace hpc

--- a/src/sampler/fused_sampler_temperature.cu
+++ b/src/sampler/fused_sampler_temperature.cu
@@ -349,6 +349,89 @@ static_assert(::hpc::sampler::rng::kPerLaunchOffsetIncrement >=
                   static_cast<uint64_t>(kMaxItersPerBlock * kItemsPerThread),
               "Philox offset advance must cover all per-thread draws per launch");
 
+// Per-device workspace, lazily grown 2×. Counter is zero-initialized on
+// (re)alloc; the kernel maintains counter[*] == 0 across launches via per-row
+// self-reset, so no host memset is needed. scratch_score/tok are
+// write-before-read each launch. n_max_per_row is captured at first acquire
+// (= get_sm_count()) so the device stride matches pick_n_blocks_per_row's cap.
+//
+// CONCURRENCY CONSTRAINT: this workspace (scratch + counter) is shared per
+// device across all streams. The counter==0 invariant and the last-block
+// reduction only hold under single-stream serial use. Concurrent invocations of
+// this sampler on multiple streams of the SAME device are NOT supported — they
+// would race on the shared scratch/counter. Use one stream per device, or
+// serialize calls.
+struct WorkspaceCache {
+  std::mutex mu;
+  float* scratch_score = nullptr;  // [max_B * n_max_per_row]
+  int32_t* scratch_tok = nullptr;  // [max_B * n_max_per_row]
+  int32_t* counter = nullptr;      // [max_B]
+  int max_B = 0;
+  int n_max_per_row = 0;
+  int device_id = -1;
+};
+
+constexpr int kMaxDevices = 16;
+static WorkspaceCache g_ws[kMaxDevices];
+
+// Acquire the workspace for `device_id`, growing it if needed to hold
+// `batch_size` rows at the requested `n_max_per_row` stride. Returned
+// pointers are valid until the next grow on the same device.
+WorkspaceCache* acquire_workspace(int device_id, int batch_size, int n_max_per_row,
+                                  cudaStream_t stream) {
+  if (device_id < 0 || device_id >= kMaxDevices) {
+    throw std::runtime_error("fused_sampler_temperature: device_id out of range: " +
+                             std::to_string(device_id));
+  }
+  WorkspaceCache& c = g_ws[device_id];
+  std::lock_guard<std::mutex> lk(c.mu);
+  if (c.scratch_score != nullptr && batch_size <= c.max_B && n_max_per_row == c.n_max_per_row) {
+    return &c;
+  }
+  int new_max = batch_size;
+  if (c.max_B * 2 > new_max) {
+    new_max = c.max_B * 2;
+  }
+
+  if (c.scratch_score) {
+    cudaStreamSynchronize(stream);
+    cudaFree(c.scratch_score);
+    cudaFree(c.scratch_tok);
+    cudaFree(c.counter);
+  }
+
+  cudaError_t err;
+  err = cudaMalloc(&c.scratch_score, static_cast<size_t>(new_max) * n_max_per_row * sizeof(float));
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string("fused_sampler_temperature: cudaMalloc(scratch_score) "
+                                         "failed: ") +
+                             cudaGetErrorString(err));
+  }
+  err = cudaMalloc(&c.scratch_tok, static_cast<size_t>(new_max) * n_max_per_row * sizeof(int32_t));
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("fused_sampler_temperature: cudaMalloc(scratch_tok) failed: ") +
+        cudaGetErrorString(err));
+  }
+  err = cudaMalloc(&c.counter, static_cast<size_t>(new_max) * sizeof(int32_t));
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("fused_sampler_temperature: cudaMalloc(counter) failed: ") +
+        cudaGetErrorString(err));
+  }
+  // Establish counter[*] == 0 invariant; kernel maintains it from here on.
+  err = cudaMemsetAsync(c.counter, 0, static_cast<size_t>(new_max) * sizeof(int32_t), stream);
+  if (err != cudaSuccess) {
+    throw std::runtime_error(
+        std::string("fused_sampler_temperature: cudaMemsetAsync(counter) failed: ") +
+        cudaGetErrorString(err));
+  }
+  c.max_B = new_max;
+  c.n_max_per_row = n_max_per_row;
+  c.device_id = device_id;
+  return &c;
+}
+
 // Pick N blocks per row: ceil(SMs / B) clamped to [kNMin, n_max_per_row].
 inline int pick_n_blocks_per_row(int batch_size, int n_max_per_row) {
   int n = (n_max_per_row + batch_size - 1) / batch_size;
@@ -397,8 +480,7 @@ void fused_sampler_temperature_async(int32_t* token_ids_out, const void* logits_
                                      int logits_dtype, int logits_row_stride,
                                      const float* temperature_arr, float temperature_val,
                                      const float* gumbel_noise_ptr,
-                                     const int64_t* draft_token_ids_ptr, float* scratch_score,
-                                     int32_t* scratch_tok, int32_t* counter, int batch_size,
+                                     const int64_t* draft_token_ids_ptr, int batch_size,
                                      int vocab_size, uint64_t rng_seed, cudaStream_t stream) {
   const bool has_external_gumbel = (gumbel_noise_ptr != nullptr);
   const bool has_draft_mask = (draft_token_ids_ptr != nullptr);
@@ -411,13 +493,20 @@ void fused_sampler_temperature_async(int32_t* token_ids_out, const void* logits_
 
   // n_max_per_row = SM count, also the upper clamp on N. The last-block reduce
   // loads N partials with `if (tid < N)`, so require N ≤ kThreadsPerBlock.
-  // Must match fused_sampler_temperature_n_max_per_row() used by the host to
-  // size the scratch buffers.
   const int n_max_per_row = ::hpc::get_sm_count();
   if (n_max_per_row > kThreadsPerBlock) {
     throw std::runtime_error("fused_sampler_temperature: device SM count exceeds kThreadsPerBlock");
   }
   const int n_blocks_per_row = pick_n_blocks_per_row(batch_size, n_max_per_row);
+
+  int device_id = -1;
+  if (cudaGetDevice(&device_id) != cudaSuccess) {
+    device_id = 0;
+  }
+  WorkspaceCache* ws = acquire_workspace(device_id, batch_size, n_max_per_row, stream);
+  float* scratch_score = ws->scratch_score;
+  int32_t* scratch_tok = ws->scratch_tok;
+  int32_t* counter = ws->counter;
 
   auto launch = [&](auto dtype_tag, auto vocab_tag, auto gumbel_tag, auto mask_tag) {
     using DType = typename decltype(dtype_tag)::type;
@@ -469,20 +558,16 @@ void fused_sampler_temperature_async(int32_t* token_ids_out, const void* logits_
 
 }  // namespace fused_sampler_temperature
 
-int fused_sampler_temperature_n_max_per_row() { return ::hpc::get_sm_count(); }
-
 // Public entry for the header — forwards to the detail namespace.
 void fused_sampler_temperature_async(int32_t* token_ids_out, const void* logits_ptr,
                                      int logits_dtype, int logits_row_stride,
                                      const float* temperature_arr, float temperature_val,
                                      const float* gumbel_noise_ptr,
-                                     const int64_t* draft_token_ids_ptr, float* scratch_score,
-                                     int32_t* scratch_tok, int32_t* counter, int batch_size,
+                                     const int64_t* draft_token_ids_ptr, int batch_size,
                                      int vocab_size, uint64_t rng_seed, cudaStream_t stream) {
   fused_sampler_temperature::fused_sampler_temperature_async(
       token_ids_out, logits_ptr, logits_dtype, logits_row_stride, temperature_arr, temperature_val,
-      gumbel_noise_ptr, draft_token_ids_ptr, scratch_score, scratch_tok, counter, batch_size,
-      vocab_size, rng_seed, stream);
+      gumbel_noise_ptr, draft_token_ids_ptr, batch_size, vocab_size, rng_seed, stream);
 }
 
 }  // namespace sampler

--- a/src/sampler/sampler.h
+++ b/src/sampler/sampler.h
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 Tencent.
+#ifndef SRC_SAMPLER_SAMPLER_H_
+#define SRC_SAMPLER_SAMPLER_H_
+
+#include <cuda_runtime_api.h>
+#include <stdint.h>
+
+namespace hpc {
+namespace sampler {
+int fused_sampler_nmax(int max_topk);
+
+// fused_sampler: 2-kernel pipeline — rp / temperature / [softmax1] / topk /
+// [softmax2] / topp / Gumbel-max sampling + penalty_mask writeback.
+//   logits_dtype: 0 = fp32, 1 = bf16
+//   softmax_policy: 0 = NONE, 1 = BEFORE_TOPK, 2 = AFTER_TOPK
+// This is a top-`max_topk` (32/64) bounded sampler: the kernel always collapses
+// the vocab to the top-`max_topk` candidates before sampling. topk=0 (or unset)
+// does NOT mean full-vocab sampling — it only means "do not tighten below
+// max_topk". Low-probability tokens outside the top-`max_topk` are never drawn.
+void fused_sampler_async(int32_t* token_ids_out, const void* logits_ptr, int logits_dtype,
+                         uint8_t* penalty_mask_ptr, const int32_t* slot_id_ptr,
+                         const float* repetition_penalty_ptr, float repetition_penalty_val,
+                         const float* temperature_ptr, float temperature_val, int softmax_policy,
+                         const void* topk_ptr, int topk_int_bytes, int topk_val,
+                         const float* topp_ptr, float topp_val, const float* gumbel_noise_ptr,
+                         float* partial_max_ptr, float* partial_sum_ptr, float* mid_logits_ptr,
+                         int32_t* mid_tokens_ptr, int batch_size, int vocab_size,
+                         int logits_row_stride, int max_topk, uint64_t rng_seed,
+                         cudaStream_t stream);
+
+int fused_sampler_temperature_n_max_per_row();
+
+// fused_sampler_temperature: temperature-only fast-path. token = argmax_v
+// (logit/temperature + Gumbel(0)).
+//   logits_dtype: 0 = fp32, 1 = bf16
+//   gumbel_noise_ptr: nullable [B, V] fp32. If set, read noise from it
+//     (bit-exact tests); else draw via curand.
+//   draft_token_ids_ptr: nullable [B] int64 speculative-decoding mask. b's
+//     entry != -1 → logits[b, that token] treated as -inf (tensor unmodified);
+//     -1 → unmasked. nullptr → zero-overhead no-mask specialization.
+void fused_sampler_temperature_async(int32_t* token_ids_out, const void* logits_ptr,
+                                     int logits_dtype, int logits_row_stride,
+                                     const float* temperature_arr, float temperature_val,
+                                     const float* gumbel_noise_ptr,
+                                     const int64_t* draft_token_ids_ptr, float* scratch_score,
+                                     int32_t* scratch_tok, int32_t* counter, int batch_size,
+                                     int vocab_size, uint64_t rng_seed, cudaStream_t stream);
+
+}  // namespace sampler
+}  // namespace hpc
+
+#endif  // SRC_SAMPLER_SAMPLER_H_

--- a/src/sampler/sampler.h
+++ b/src/sampler/sampler.h
@@ -7,7 +7,6 @@
 
 namespace hpc {
 namespace sampler {
-int fused_sampler_nmax(int max_topk);
 
 // fused_sampler: 2-kernel pipeline — rp / temperature / [softmax1] / topk /
 // [softmax2] / topp / Gumbel-max sampling + penalty_mask writeback.
@@ -23,12 +22,8 @@ void fused_sampler_async(int32_t* token_ids_out, const void* logits_ptr, int log
                          const float* temperature_ptr, float temperature_val, int softmax_policy,
                          const void* topk_ptr, int topk_int_bytes, int topk_val,
                          const float* topp_ptr, float topp_val, const float* gumbel_noise_ptr,
-                         float* partial_max_ptr, float* partial_sum_ptr, float* mid_logits_ptr,
-                         int32_t* mid_tokens_ptr, int batch_size, int vocab_size,
-                         int logits_row_stride, int max_topk, uint64_t rng_seed,
-                         cudaStream_t stream);
-
-int fused_sampler_temperature_n_max_per_row();
+                         int batch_size, int vocab_size, int logits_row_stride, int max_topk,
+                         uint64_t rng_seed, cudaStream_t stream);
 
 // fused_sampler_temperature: temperature-only fast-path. token = argmax_v
 // (logit/temperature + Gumbel(0)).
@@ -38,12 +33,13 @@ int fused_sampler_temperature_n_max_per_row();
 //   draft_token_ids_ptr: nullable [B] int64 speculative-decoding mask. b's
 //     entry != -1 → logits[b, that token] treated as -inf (tensor unmodified);
 //     -1 → unmasked. nullptr → zero-overhead no-mask specialization.
+// Concurrency: not safe to call concurrently on multiple streams of the same
+// device (the per-device scratch workspace is shared across streams).
 void fused_sampler_temperature_async(int32_t* token_ids_out, const void* logits_ptr,
                                      int logits_dtype, int logits_row_stride,
                                      const float* temperature_arr, float temperature_val,
                                      const float* gumbel_noise_ptr,
-                                     const int64_t* draft_token_ids_ptr, float* scratch_score,
-                                     int32_t* scratch_tok, int32_t* counter, int batch_size,
+                                     const int64_t* draft_token_ids_ptr, int batch_size,
                                      int vocab_size, uint64_t rng_seed, cudaStream_t stream);
 
 }  // namespace sampler

--- a/src/sampler/sampler_rng.cuh
+++ b/src/sampler/sampler_rng.cuh
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 Tencent.
+//
+// Shared RNG for the sampler kernels' self-drawn Gumbel-max noise (cuRAND
+// Philox-4x32-10), so fused_sampler.cu and fused_sampler_temperature.cu stay
+// byte-for-byte identical on the self-drawn path:
+//   seed   — forwarded from the caller unchanged.
+//   offset — host atomic counter advanced once per launch (shared single
+//            instance, `inline`); makes the same seed give fresh samples.
+//   init   — curand_init(seed, sequence, offset). `sequence` is the only
+//            per-kernel difference (a function of block/thread geometry).
+//   draw   — curand_uniform4 (4 uniforms/call).
+//   noise  — gumbel_noise_from_uniform(u) = -log(-log(U)), inner clamped so
+//            U→1 cannot poison the score. Matches the PyTorch test reference.
+
+#ifndef SRC_SAMPLER_SAMPLER_RNG_CUH_
+#define SRC_SAMPLER_SAMPLER_RNG_CUH_
+
+#include <curand_kernel.h>
+#include <stdint.h>
+
+#include <atomic>
+
+#include "src/utils/utils.cuh"
+
+namespace hpc {
+namespace sampler {
+namespace rng {
+
+// Per-launch advance in the Philox `offset`. 128 covers every per-thread draw
+// on both kernels and stays on a power-of-two boundary.
+constexpr uint64_t kPerLaunchOffsetIncrement = 128;
+
+// Gumbel(0) noise from a uniform draw U ~ (0, 1].
+//   inner = max(-log(U), 1e-20)        // guard U -> 1
+//   g     = -log(inner)                // = -log(-log(U))
+__device__ __forceinline__ float gumbel_noise_from_uniform(float u) {
+  float inner = fmaxf(-logf_ftz(u), 1e-20f);
+  return -logf_ftz(inner);
+}
+
+// Host-side per-launch RNG offset counter, shared by all sampler kernels
+// (`inline` → single instance program-wide).
+inline std::atomic<uint64_t>& launch_offset_counter() {
+  static std::atomic<uint64_t> counter{0};
+  return counter;
+}
+
+// Reserve the Philox `offset` base for one launch, then advance the counter.
+inline uint64_t next_launch_offset() {
+  return launch_offset_counter().fetch_add(kPerLaunchOffsetIncrement, std::memory_order_relaxed);
+}
+
+}  // namespace rng
+}  // namespace sampler
+}  // namespace hpc
+
+#endif  // SRC_SAMPLER_SAMPLER_RNG_CUH_

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,625 @@
+# Copyright (C) 2026 Tencent.
+"""Tests covering the fused sampler operators exposed via ``import hpc``.
+
+1. ``hpc.fused_sampler`` — the 2-kernel fused sampler (top-``max_topk`` bounded)
+   covering rep_penalty/temperature/softmax_policy/topk/topp/Gumbel-max/penalty
+   writeback. With injected ``gumbel_noise`` it is bit-exact against the pure
+   torch reference ``ref_fused_sampler``.
+2. The temperature fast-path: ``hpc.fused_sampler(logits, temperature=...)`` with
+   no other feature auto-dispatches to ``fused_sampler_temperature_sample``;
+   it supports injected ``gumbel_noise`` (bit-exact) and a ``[B]`` int64
+   ``draft_token_ids`` mask.
+"""
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+sys.path.insert(0, os.path.realpath(list(Path(__file__).parent.glob("../build/lib.*/"))[0]))
+
+import torch
+
+import hpc
+from hpc.sampler import SoftmaxPolicy
+
+
+# Vocab sizes that the cluster (fused) path supports (see the .cu launcher).
+CLUSTER_VOCAB_SIZES = [120832]
+
+
+# ===========================================================================
+# (1) fused_sampler: pure-torch reference + bit-exact tests.
+# ===========================================================================
+def _gumbel0_like(logits: torch.Tensor) -> torch.Tensor:
+    """External Gumbel(0) noise matching the kernel convention:
+    g = -log(-log(U)), U ~ Uniform(0, 1].
+
+    Always float32 with the logits' [B, V] shape — the op requires the
+    gumbel_noise buffer to be float32 regardless of the logits dtype.
+    """
+    u = torch.rand(logits.shape, dtype=torch.float32, device=logits.device)
+    u = u.clamp_min_(1e-20)
+    return -(-u.log()).log()
+
+
+def ref_fused_sampler(
+    logits: torch.Tensor,
+    *,
+    penalty_mask: torch.Tensor | None = None,
+    slot_id: torch.Tensor | None = None,
+    repetition_penalty: float | torch.Tensor = 0.0,
+    temperature: float | torch.Tensor = 0.0,
+    softmax_policy: SoftmaxPolicy = SoftmaxPolicy.NONE,
+    topk: int | torch.Tensor = 0,
+    topp: float | torch.Tensor = 0.0,
+    max_topk: int = 32,
+    gumbel_noise: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Python reference that mimics the kernel's numerical flow exactly.
+
+    Returns (token_ids[B,1], expected penalty_mask after writeback-or-None).
+
+    IMPORTANT: the kernel always collapses the vocab to the top-``max_topk``
+    candidates (via cluster topk) before sampling, regardless of the user-
+    supplied ``topk``. If the caller omits ``topk`` the kernel still sees
+    ``effK = max_topk``, so the reference mirrors that.
+    """
+    device = logits.device
+    B, V = logits.shape
+    work = logits.float().clone()
+
+    def _as_tensor(x, dtype):
+        if isinstance(x, torch.Tensor):
+            return x.to(device=device, dtype=dtype)
+        return torch.full((B,), float(x), device=device, dtype=dtype)
+
+    rp = _as_tensor(repetition_penalty, torch.float32)
+    temp = _as_tensor(temperature, torch.float32)
+    tp = _as_tensor(topp, torch.float32)
+    if isinstance(topk, torch.Tensor):
+        tk = topk.to(device=device, dtype=torch.int64)
+    else:
+        tk = torch.full((B,), int(topk), device=device, dtype=torch.int64)
+
+    # 1. Repetition penalty: where mask bit set, logit *= (>0 ? 1/rp : rp).
+    if penalty_mask is not None and slot_id is not None:
+        for b in range(B):
+            if rp[b].item() <= 0:
+                continue
+            row = penalty_mask[int(slot_id[b].item())]
+            # Expand bits.
+            bits = torch.zeros(row.numel() * 8, dtype=torch.bool, device=device)
+            for bit in range(8):
+                bits[bit::8] = ((row >> bit) & 1).bool()
+            keep = bits[:V]
+            r = rp[b].item()
+            inv_r = 1.0 / r
+            wb = work[b]
+            pos = keep & (wb > 0)
+            neg = keep & (wb <= 0)
+            wb[pos] = wb[pos] * inv_r
+            wb[neg] = wb[neg] * r
+
+    # 2. Temperature.
+    for b in range(B):
+        t = temp[b].item()
+        if t > 0:
+            work[b] = work[b] / t
+
+    # 3. Optional softmax1 over full vocab.
+    if softmax_policy == SoftmaxPolicy.BEFORE_TOPK:
+        work = torch.softmax(work, dim=-1)
+
+    # 5. Topk (or full vocab).
+    tokens_out = torch.empty((B, 1), dtype=torch.int32, device=device)
+    for b in range(B):
+        k_b = int(tk[b].item())
+        # Kernel clamps: 0 or out-of-range -> max_topk.
+        if k_b <= 0 or k_b > max_topk:
+            k_b = max_topk
+        vals, idx = torch.topk(work[b], k=k_b, largest=True, sorted=True)
+
+        # softmax2 over top-K if AFTER_TOPK.
+        if softmax_policy == SoftmaxPolicy.AFTER_TOPK:
+            probs = torch.softmax(vals, dim=-1)
+            val_for_gumbel = probs.log()
+        elif softmax_policy == SoftmaxPolicy.BEFORE_TOPK:
+            probs = vals  # already probs
+            val_for_gumbel = torch.where(
+                probs > 0, probs.log(), torch.full_like(probs, float("-inf"))
+            )
+        else:
+            probs = None
+            val_for_gumbel = vals  # use logits directly
+
+        keep = torch.ones(k_b, dtype=torch.bool, device=device)
+        tp_b = tp[b].item()
+        if tp_b > 0:
+            cumsum = torch.cumsum(probs, dim=-1)
+            cumsum_excl = cumsum - probs
+            keep = (torch.arange(k_b, device=device) == 0) | (cumsum_excl < tp_b)
+
+        # Gumbel-max: key = val_for_gumbel + gumbel_noise[b, tok].
+        noise = gumbel_noise[b, idx]
+        key = val_for_gumbel + noise
+        key = torch.where(keep, key, torch.full_like(key, float("-inf")))
+        # Tie-break toward smaller token id.
+        max_key = key.max()
+        cand = (key == max_key).nonzero(as_tuple=True)[0]
+        if cand.numel() == 0:
+            best_pos = torch.tensor(0, device=device)
+        else:
+            cand_tokens = idx[cand]
+            best_local = torch.argmin(cand_tokens)
+            best_pos = cand[best_local]
+        tok = int(idx[best_pos].item())
+        tokens_out[b, 0] = tok
+
+    # Penalty writeback.
+    expected_mask = None
+    if penalty_mask is not None and slot_id is not None:
+        expected_mask = penalty_mask.clone()
+        for b in range(B):
+            tok = int(tokens_out[b, 0].item())
+            row = int(slot_id[b].item())
+            expected_mask[row, tok // 8] |= 1 << (tok % 8)
+    return tokens_out, expected_mask
+
+
+@pytest.mark.parametrize("vocab_size", [120832])
+@pytest.mark.parametrize("batch_size", [1, 4])
+def test_only_logits(batch_size, vocab_size):
+    torch.manual_seed(0)
+    logits = torch.randn(batch_size, vocab_size, device="cuda")
+    gumbel = _gumbel0_like(logits)
+
+    tok = hpc.fused_sampler(logits, gumbel_noise=gumbel)
+    assert tok.shape == (batch_size, 1)
+    assert tok.dtype == torch.int32
+
+    ref, _ = ref_fused_sampler(logits, gumbel_noise=gumbel, max_topk=32)
+    assert torch.equal(tok, ref), f"mismatch my={tok.flatten()} ref={ref.flatten()}"
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("max_topk,topk_val", [(32, 20), (64, 50)])
+@pytest.mark.parametrize(
+    "softmax_policy,topp_val",
+    [
+        (SoftmaxPolicy.NONE, 0.0),
+        (SoftmaxPolicy.BEFORE_TOPK, 0.9),
+        (SoftmaxPolicy.AFTER_TOPK, 0.9),
+    ],
+)
+def test_topk_topp_softmax_matrix(batch_size, max_topk, topk_val, softmax_policy, topp_val):
+    vocab_size = 120832
+    torch.manual_seed(1234 + max_topk + topk_val + int(topp_val * 10))
+    logits = torch.randn(batch_size, vocab_size, device="cuda")
+    gumbel = _gumbel0_like(logits)
+
+    topk_t = torch.full((batch_size,), topk_val, dtype=torch.int32, device="cuda")
+    if topp_val > 0:
+        topp_t = torch.full((batch_size,), topp_val, dtype=torch.float32, device="cuda")
+    else:
+        topp_t = 0.0
+
+    tok = hpc.fused_sampler(
+        logits,
+        softmax_policy=softmax_policy,
+        topk=topk_t,
+        topp=topp_t,
+        max_topk=max_topk,
+        gumbel_noise=gumbel,
+    )
+    ref, _ = ref_fused_sampler(
+        logits,
+        softmax_policy=softmax_policy,
+        topk=topk_t,
+        topp=topp_t,
+        max_topk=max_topk,
+        gumbel_noise=gumbel,
+    )
+    assert torch.equal(tok, ref), (
+        f"mismatch @ max_topk={max_topk} policy={softmax_policy} topp={topp_val}:"
+        f" my={tok.flatten()[:5]} ref={ref.flatten()[:5]}"
+    )
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+def test_repetition_penalty_and_writeback(batch_size):
+    vocab_size = 120832
+    torch.manual_seed(7)
+    logits = torch.randn(batch_size, vocab_size, device="cuda")
+    gumbel = _gumbel0_like(logits)
+
+    # MAX_BS > batch_size so writeback must honor slot_id routing.
+    max_bs = batch_size + 3
+    row_bytes = (vocab_size + 7) // 8
+    penalty = torch.zeros((max_bs, row_bytes), dtype=torch.uint8, device="cuda")
+    # Pre-seed random bits (checks OR semantics).
+    penalty.random_(0, 256)
+    slot_id = torch.randperm(max_bs, device="cuda", dtype=torch.int32)[:batch_size]
+
+    penalty_hpc = penalty.clone()
+    ref_tok, ref_penalty = ref_fused_sampler(
+        logits,
+        penalty_mask=penalty.clone(),
+        slot_id=slot_id,
+        repetition_penalty=1.05,
+        temperature=0.7,
+        softmax_policy=SoftmaxPolicy.AFTER_TOPK,
+        topk=torch.full((batch_size,), 20, dtype=torch.int32, device="cuda"),
+        topp=torch.full((batch_size,), 0.9, dtype=torch.float32, device="cuda"),
+        max_topk=32,
+        gumbel_noise=gumbel,
+    )
+
+    tok = hpc.fused_sampler(
+        logits,
+        penalty_mask=penalty_hpc,
+        slot_id=slot_id,
+        repetition_penalty=1.05,
+        temperature=0.7,
+        softmax_policy=SoftmaxPolicy.AFTER_TOPK,
+        topk=torch.full((batch_size,), 20, dtype=torch.int32, device="cuda"),
+        topp=torch.full((batch_size,), 0.9, dtype=torch.float32, device="cuda"),
+        max_topk=32,
+        gumbel_noise=gumbel,
+    )
+    assert torch.equal(tok, ref_tok)
+    assert torch.equal(penalty_hpc, ref_penalty), "penalty writeback mismatch"
+
+
+def test_bf16_logits():
+    torch.manual_seed(3)
+    B, V = 2, 120832
+    logits = torch.randn(B, V, device="cuda", dtype=torch.bfloat16)
+    gumbel = _gumbel0_like(logits)
+    tok = hpc.fused_sampler(
+        logits,
+        softmax_policy=SoftmaxPolicy.AFTER_TOPK,
+        topk=20,
+        topp=0.9,
+        max_topk=32,
+        gumbel_noise=gumbel,
+    )
+    # Reference uses fp32-cast logits (same as kernel).
+    ref, _ = ref_fused_sampler(
+        logits.float(),
+        softmax_policy=SoftmaxPolicy.AFTER_TOPK,
+        topk=20,
+        topp=0.9,
+        max_topk=32,
+        gumbel_noise=gumbel,
+    )
+    assert torch.equal(tok, ref), f"my={tok.flatten()} ref={ref.flatten()}"
+
+
+def test_scalar_vs_tensor_equivalence():
+    torch.manual_seed(5)
+    B, V = 4, 120832
+    logits = torch.randn(B, V, device="cuda")
+    gumbel = _gumbel0_like(logits)
+    t1 = hpc.fused_sampler(
+        logits,
+        temperature=0.7,
+        topk=20,
+        max_topk=32,
+        softmax_policy=SoftmaxPolicy.AFTER_TOPK,
+        topp=0.9,
+        gumbel_noise=gumbel,
+    )
+    t2 = hpc.fused_sampler(
+        logits,
+        temperature=torch.full((B,), 0.7, device="cuda"),
+        topk=torch.full((B,), 20, dtype=torch.int32, device="cuda"),
+        max_topk=32,
+        softmax_policy=SoftmaxPolicy.AFTER_TOPK,
+        topp=torch.full((B,), 0.9, device="cuda"),
+        gumbel_noise=gumbel,
+    )
+    assert torch.equal(t1, t2)
+
+
+def test_curand_smoke():
+    """Curand fallback smoke test (no gumbel injection)."""
+    torch.manual_seed(9)
+    B, V = 2, 120832
+    logits = torch.randn(B, V, device="cuda")
+    tok = hpc.fused_sampler(logits, topk=20, max_topk=32, seed=42)
+    assert tok.shape == (B, 1)
+    assert tok.dtype == torch.int32
+    # Sanity: sampled token is in top-20 per batch.
+    top20 = torch.topk(logits, k=20, dim=-1).indices
+    for b in range(B):
+        assert tok[b, 0].item() in top20[b].tolist()
+
+
+@pytest.mark.parametrize("pad", [4, 256])
+def test_padded_logits_stride(pad):
+    """Padded logits: stride(0) > vocab_size. The kernel steps between rows by
+    the row stride (not vocab_size), so a padded buffer yields identical token
+    ids as the compact slice."""
+    vocab_size = 120832
+    torch.manual_seed(17)
+    B = 4
+    V_pad = vocab_size + pad
+    padded = torch.randn(B, V_pad, device="cuda")
+    # Poison the padding so the kernel would fail matching if it read it.
+    padded[:, vocab_size:] = float("inf")
+    logits = padded[:, :vocab_size]
+    assert logits.stride(0) == V_pad
+    assert not logits.is_contiguous()
+
+    gumbel = _gumbel0_like(logits)
+
+    tok = hpc.fused_sampler(
+        logits,
+        softmax_policy=SoftmaxPolicy.AFTER_TOPK,
+        topk=20,
+        topp=0.9,
+        max_topk=32,
+        gumbel_noise=gumbel,
+    )
+    ref, _ = ref_fused_sampler(
+        logits.contiguous(),
+        softmax_policy=SoftmaxPolicy.AFTER_TOPK,
+        topk=20,
+        topp=0.9,
+        max_topk=32,
+        gumbel_noise=gumbel,
+    )
+    assert torch.equal(tok, ref), f"padded-stride mismatch my={tok.flatten()} ref={ref.flatten()}"
+
+
+# ---------------------------------------------------------------------------
+# fused_sampler error paths.
+# ---------------------------------------------------------------------------
+def test_error_topp_without_topk():
+    logits = torch.randn(1, 120832, device="cuda")
+    with pytest.raises((RuntimeError, ValueError)):
+        hpc.fused_sampler(logits, softmax_policy=SoftmaxPolicy.AFTER_TOPK, topp=0.9)
+
+
+def test_error_topp_without_softmax():
+    logits = torch.randn(1, 120832, device="cuda")
+    with pytest.raises((RuntimeError, ValueError)):
+        hpc.fused_sampler(logits, topk=20, topp=0.9, max_topk=32)
+
+
+def test_error_penalty_without_slot_id():
+    logits = torch.randn(1, 120832, device="cuda")
+    penalty = torch.zeros((4, (120832 + 7) // 8), dtype=torch.uint8, device="cuda")
+    with pytest.raises((RuntimeError, ValueError)):
+        hpc.fused_sampler(logits, penalty_mask=penalty)
+
+
+def test_error_unsupported_vocab():
+    logits = torch.randn(1, 12345, device="cuda")
+    with pytest.raises((RuntimeError, ValueError)):
+        hpc.fused_sampler(logits, seed=42)
+
+
+def test_error_bad_max_topk():
+    logits = torch.randn(1, 120832, device="cuda")
+    with pytest.raises((RuntimeError, ValueError)):
+        hpc.fused_sampler(logits, topk=20, max_topk=16)
+
+
+def test_error_inner_stride_not_one():
+    """stride(1) must be 1 — only row-major with inner-contiguous rows is
+    supported (padding only allowed on the row stride)."""
+    V = 120832
+    base = torch.randn(2, V * 2, device="cuda")
+    logits = base[:, ::2]  # strided inner dim
+    assert logits.stride(1) != 1
+    with pytest.raises((RuntimeError, ValueError)):
+        hpc.fused_sampler(logits)
+
+
+# ===========================================================================
+# (2) Temperature-only fast-path tests.
+#
+# `fused_sampler(logits, temperature=t)` with every other feature disabled
+# auto-dispatches to `fused_sampler_temperature_sample`. The reference mirrors
+# the in-kernel scoring:
+#   scores = logits.float() / temperature + gumbel
+#   token  = argmax(scores, dim=-1)
+# ===========================================================================
+def ref_temperature_sample(
+    logits: torch.Tensor, temperature: torch.Tensor, gumbel: torch.Tensor
+) -> torch.Tensor:
+    """PyTorch reference for temperature-only Gumbel-max sampling."""
+    scores = logits.float() / temperature.view(-1, 1).float() + gumbel.float()
+    return scores.argmax(dim=-1).to(torch.int32).view(-1, 1)
+
+
+@pytest.mark.parametrize("batch_size", [1, 8])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("temp_mode", ["scalar", "tensor"])
+@pytest.mark.parametrize("stride_mode", ["compact", "padded"])
+def test_fused_sampler_temperature_only_golden(batch_size, dtype, temp_mode, stride_mode):
+    """Bit-exact golden test using external Gumbel(0) noise."""
+    vocab_size = 120832
+    torch.manual_seed(0xC0FFEE + batch_size * 17 + vocab_size)
+
+    # Build a logits tensor, optionally with stride(0) > vocab_size (padded).
+    if stride_mode == "compact":
+        logits = torch.randn(batch_size, vocab_size, dtype=dtype, device="cuda")
+    else:
+        pad = 128
+        big = torch.randn(batch_size, vocab_size + pad, dtype=dtype, device="cuda")
+        logits = big[:, :vocab_size]
+        assert logits.stride(0) == vocab_size + pad
+        assert logits.stride(1) == 1
+
+    # Temperature: either scalar or per-batch tensor.
+    if temp_mode == "scalar":
+        temperature_arg = 0.7
+        temperature_ref = torch.full((batch_size,), 0.7, dtype=torch.float32, device="cuda")
+    else:
+        temperature_ref = torch.rand(batch_size, dtype=torch.float32, device="cuda") * 1.5 + 0.3
+        temperature_arg = temperature_ref
+
+    # External Gumbel(0) noise: g = -log(-log(U)), U ~ Uniform(0, 1].
+    u = torch.rand(batch_size, vocab_size, dtype=torch.float32, device="cuda")
+    u = u.clamp_min_(1e-20)
+    gumbel = -(-u.log()).log()
+
+    ref_tokens = ref_temperature_sample(logits, temperature_ref, gumbel)
+
+    out_tokens = hpc.fused_sampler(logits, temperature=temperature_arg, gumbel_noise=gumbel)
+
+    assert out_tokens.shape == (batch_size, 1)
+    assert out_tokens.dtype == torch.int32
+    # bf16 quantization of logits is applied before division, so the reference
+    # consumes the already-cast tensor; bit-exact match is expected.
+    assert torch.equal(out_tokens, ref_tokens), (
+        f"mismatch: out[:10]={out_tokens[:10].flatten().tolist()}, "
+        f"ref[:10]={ref_tokens[:10].flatten().tolist()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Draft-mask coverage. A single [B] int64 tensor where
+#   draft_token_ids[b] == -1  -> row b unmasked
+#   draft_token_ids[b] >= 0   -> mask logits[b, draft_token_ids[b]] (-inf)
+# Out-of-range non-negative values are silently ignored by the kernel.
+# ---------------------------------------------------------------------------
+def _ref_temperature_sample_with_mask(
+    logits: torch.Tensor,
+    temperature: torch.Tensor,
+    gumbel: torch.Tensor,
+    draft_token_ids: Optional[torch.Tensor],
+    vocab_size: int,
+) -> torch.Tensor:
+    """PyTorch reference: scatter -inf onto a copy of (logits/T), then argmax."""
+    scaled = logits.float() / temperature.view(-1, 1).float()
+    if draft_token_ids is not None:
+        valid = (draft_token_ids >= 0) & (draft_token_ids < vocab_size)
+        if valid.any():
+            rows = torch.nonzero(valid, as_tuple=False).squeeze(1).to(torch.int64)
+            cols = draft_token_ids[valid].to(torch.int64)
+            scaled[rows, cols] = float("-inf")
+    scores = scaled + gumbel.float()
+    return scores.argmax(dim=-1).to(torch.int32).view(-1, 1)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize(
+    "mask_case",
+    [
+        "all_minus_one",  # all entries == -1: equivalent to no mask
+        "single_per_row",  # one mask token per row, with some -1 sentinels
+        "out_of_range_token",  # token ids >= vocab_size: silently ignored
+    ],
+)
+def test_fused_sampler_temperature_only_with_draft_mask_golden(dtype, mask_case):
+    """Bit-exact golden test for the [B]-shaped draft_token_ids arg."""
+    torch.manual_seed(0xBEEF + hash(mask_case) % 1024)
+    batch_size = 8
+    vocab_size = 120832
+
+    logits = torch.randn(batch_size, vocab_size, dtype=dtype, device="cuda")
+    temperature = torch.rand(batch_size, dtype=torch.float32, device="cuda") * 1.5 + 0.3
+
+    u = torch.rand(batch_size, vocab_size, dtype=torch.float32, device="cuda").clamp_min_(1e-20)
+    gumbel = -(-u.log()).log()
+
+    # Build a [B] mask tensor per case.
+    if mask_case == "all_minus_one":
+        draft_token_ids = torch.full((batch_size,), -1, dtype=torch.int64, device="cuda")
+    elif mask_case == "single_per_row":
+        draft_token_ids = torch.randint(
+            0, vocab_size, (batch_size,), dtype=torch.int64, device="cuda"
+        )
+        # Sprinkle a -1 sentinel so that row stays unmasked.
+        draft_token_ids[1] = -1
+    elif mask_case == "out_of_range_token":
+        # Mix of valid token ids, -1 sentinels, and out-of-range values
+        # (>= vocab_size). The kernel must silently treat out-of-range as
+        # no-mask (equivalent to -1).
+        draft_token_ids = torch.tensor(
+            [0, -1, vocab_size, 100, vocab_size + 17, -1, 200, vocab_size * 2],
+            dtype=torch.int64,
+            device="cuda",
+        )
+    else:
+        raise AssertionError(mask_case)
+
+    ref_tokens = _ref_temperature_sample_with_mask(
+        logits, temperature, gumbel, draft_token_ids, vocab_size
+    )
+
+    out_tokens = hpc.fused_sampler(
+        logits,
+        temperature=temperature,
+        gumbel_noise=gumbel,
+        draft_token_ids=draft_token_ids,
+    )
+
+    assert out_tokens.shape == (batch_size, 1)
+    assert out_tokens.dtype == torch.int32
+    assert torch.equal(out_tokens, ref_tokens), (
+        f"mismatch ({mask_case}): out[:10]={out_tokens[:10].flatten().tolist()}, "
+        f"ref[:10]={ref_tokens[:10].flatten().tolist()}"
+    )
+
+    # Sanity: confirm the kernel did not modify the caller's logits in place.
+    baseline_ref = ref_temperature_sample(logits, temperature, gumbel)
+    baseline_out = hpc.fused_sampler(logits, temperature=temperature, gumbel_noise=gumbel)
+    assert torch.equal(baseline_out, baseline_ref), (
+        "logits appear to have been mutated by the masked call: "
+        "baseline output diverged from baseline reference."
+    )
+
+
+def test_fused_sampler_temperature_draft_mask_shape_validation():
+    """draft_token_ids must be [B] int64."""
+    batch_size = 4
+    logits = torch.randn(batch_size, 120832, dtype=torch.float32, device="cuda")
+
+    # No mask: ok.
+    _ = hpc.fused_sampler(logits, temperature=1.0, seed=42)
+    # Correct shape: ok.
+    draft = torch.full((batch_size,), -1, dtype=torch.int64, device="cuda")
+    _ = hpc.fused_sampler(logits, temperature=1.0, draft_token_ids=draft, seed=42)
+    # Wrong size: must raise.
+    bad = torch.full((batch_size + 1,), -1, dtype=torch.int64, device="cuda")
+    with pytest.raises(RuntimeError, match="draft_token_ids size must be"):
+        hpc.fused_sampler(logits, temperature=1.0, draft_token_ids=bad, seed=42)
+    # Wrong dtype: must raise.
+    bad_dtype = torch.full((batch_size,), -1, dtype=torch.int32, device="cuda")
+    with pytest.raises(RuntimeError, match="draft_token_ids dtype must be int64"):
+        hpc.fused_sampler(logits, temperature=1.0, draft_token_ids=bad_dtype, seed=42)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_fused_sampler_temperature_distribution(dtype):
+    """Sanity test: empirical sampling frequencies track softmax(logits/T)."""
+    vocab_size = 120832
+    torch.manual_seed(1234)
+    batch_size = 4
+    # Concentrate probability on a small set of tokens so we can test with
+    # modest iteration counts.
+    K = 16
+    top_tokens = torch.randint(0, vocab_size, (batch_size, K), device="cuda")
+    logits = torch.full((batch_size, vocab_size), -20.0, dtype=torch.float32, device="cuda")
+    for b in range(batch_size):
+        logits[b, top_tokens[b]] = torch.randn(K, device="cuda") * 2.0 + 3.0
+    logits_in = logits.to(dtype)
+    temperature = 1.0
+
+    N = 2000
+    counts = torch.zeros(batch_size, vocab_size, dtype=torch.float32, device="cuda")
+    for _ in range(N):
+        tok = hpc.fused_sampler(logits_in, temperature=temperature, seed=42)  # [B, 1]
+        counts.scatter_add_(1, tok.to(torch.int64), torch.ones_like(tok, dtype=torch.float32))
+    freq = counts / N
+    ref_prob = torch.softmax(logits / temperature, dim=-1)
+
+    # TV distance between empirical freq and true prob should be small.
+    tv = 0.5 * (freq - ref_prob).abs().sum(dim=-1)
+    assert (tv < 0.1).all(), f"TV distance too large: {tv.tolist()}"


### PR DESCRIPTION
## Summary
  - Fuse the per-step sampling pipeline (rep/presence penalty → temperature → top-k → top-p → categorical sampling) into single CUDA kernels, removing the multi-kernel launch + repeated `[batch, vocab]` logits round-trips that dominate small-batch decode
  - 2 new ops: `fused_sampler`, `fused_sampler_temperature_sample`
  - `fused_sampler`: BlockRadixSort top-k path (`max_topk ∈ {32, 64}`) + Gumbel-max sampling, with `NONE` / `BEFORE_TOPK` / `AFTER_TOPK` softmax policies
  - `fused_sampler_temperature_sample`: temperature-only fast path; supports injected `gumbel_noise` (bit-reproducible) and a `[B]` int64 `draft_token_ids` mask for speculative decoding

  ## Test results
  - [x] `pytest tests/test_sampler.py` — all passed
  - [x] bit-exact against the pure-torch reference when `gumbel_noise` is injected

  ## Benchmark
  - batch 1–512: **4.6×–8.5×** vs vLLM, **2.1×–5.2×** vs FlashInfer
