### PR TITLE
fix: add missing <array> include in fuse_allreduce_rmsnorm_low_latency.h

### DIFF
--- a/src/allreduce/fuse_allreduce_rmsnorm_low_latency.h
+++ b/src/allreduce/fuse_allreduce_rmsnorm_low_latency.h
@@ -9,6 +9,7 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
+#include <array>
 #include <iostream>
 #include <type_traits>
 #include <atomic>


### PR DESCRIPTION
`std::array` is used in this header without `#include <array>`.
It used to compile because `<vector>`/`<tuple>` pulled `<array>` in
transitively, but that no longer holds on newer libstdc++.

Repro: gcc 13.3 / libstdc++ 20240904 / CUDA 12.8

```
fuse_allreduce_rmsnorm_low_latency.h:289: error: incomplete type
"std::array<uint32_t, 4UL>" is not allowed
    alignas(16) std::array<uint32_t, 4> mBytesToClear;
```

Fix: add the explicit include. One line, no behavior change.
Verified `pip install -e .` and `import hpc` both pass after the fix.