### PR TITLE
feat: relax heads_per_group constraint to support 1~8 for BF16 and FP8 decode attention

### DIFF
--- a/src/attention/decode/sm90/dynamic/smallm_fp8_qkpertoken_perhead_vperhead_dim128_dynamic.cu
+++ b/src/attention/decode/sm90/dynamic/smallm_fp8_qkpertoken_perhead_vperhead_dim128_dynamic.cu
@@ -231,7 +231,7 @@ bool smallm_fp8_qkpertoken_perhead_vperhead_dim128_dynamic_async(
   }
 
   int heads_per_group = num_head_q / num_head_k;
-  if (heads_per_group != 8 && heads_per_group != 4) {
+  if (heads_per_group < 1 || heads_per_group > 8) {
     std::cout << "launch launch_attention_decode_bf16_dim128_smallm_fp8 failed with "
               << " heads_per_group:" << heads_per_group << ", num_head_q:" << num_head_q
               << ", num_head_k:" << num_head_k << std::endl;

--- a/src/attention/decode/sm90/dynamic/smallm_fp8_qpertoken_perhead_kvpertensor_dim128_dynamic.cu
+++ b/src/attention/decode/sm90/dynamic/smallm_fp8_qpertoken_perhead_kvpertensor_dim128_dynamic.cu
@@ -215,7 +215,7 @@ bool smallm_fp8_qpertoken_perhead_kvpertensor_dim128_dynamic_async(
   }
 
   int heads_per_group = num_head_q / num_head_k;
-  if (heads_per_group != 8 && heads_per_group != 4) {
+  if (heads_per_group < 1 || heads_per_group > 8) {
     std::cout << "launch launch_attention_decode_bf16_dim128_smallm_fp8 failed with "
               << " heads_per_group:" << heads_per_group << ", num_head_q:" << num_head_q
               << ", num_head_k:" << num_head_k << std::endl;

--- a/src/attention/decode/sm90/static/smallm_bf16_dim128_static.cu
+++ b/src/attention/decode/sm90/static/smallm_bf16_dim128_static.cu
@@ -159,15 +159,16 @@ bool smallm_bf16_dim128_static_async(
   constexpr int kTileK = 128;
   constexpr int kTileV = 128;
 
+  int heads_per_group = num_head_q / num_head_k;
+
   if (num_dim_qk != kTileK || num_dim_v != kTileV || (block_size != 32 && block_size != 64) ||
-      (splitk != 1 && splitk != 4 && splitk != 16)) {
+      (splitk != 1 && splitk != 4 && splitk != 16) || heads_per_group > 8) {
     std::cout << "launch launch_attention_decode_bf16_dim128_smallm failed with "
               << "  num_dim_qk: " << num_dim_qk << ", num_dim_v: " << num_dim_v
-              << ", block_size:" << block_size << std::endl;
+              << ", block_size:" << block_size << ", heads_per_group:" << heads_per_group
+              << std::endl;
     return false;
   }
-
-  int heads_per_group = num_head_q / num_head_k;
 
   auto launch = [&](auto splitk_tag, auto min_len_tag, auto tilem_tag, auto block_size_tag) {
     constexpr int kSplitK = decltype(splitk_tag)::value;

--- a/src/attention/decode/sm90/static/smallm_fp8_qkpertoken_perhead_vperhead_dim128_static.cu
+++ b/src/attention/decode/sm90/static/smallm_fp8_qkpertoken_perhead_vperhead_dim128_static.cu
@@ -209,7 +209,7 @@ bool smallm_fp8_qkpertoken_perhead_vperhead_dim128_static_async(
   }
 
   int heads_per_group = num_head_q / num_head_k;
-  if (heads_per_group != 8 && heads_per_group != 4) {
+  if (heads_per_group < 1 || heads_per_group > 8) {
     std::cout << "launch launch_attention_decode_bf16_dim128_smallm_fp8 failed with "
               << " heads_per_group:" << heads_per_group << ", num_head_q:" << num_head_q
               << ", num_head_k:" << num_head_k << std::endl;

--- a/src/attention/decode/sm90/static/smallm_fp8_qpertoken_perhead_kvpertensor_dim128_static.cu
+++ b/src/attention/decode/sm90/static/smallm_fp8_qpertoken_perhead_kvpertensor_dim128_static.cu
@@ -192,7 +192,7 @@ bool smallm_fp8_qpertoken_perhead_kvpertensor_dim128_static_async(
   }
 
   int heads_per_group = num_head_q / num_head_k;
-  if (heads_per_group != 8 && heads_per_group != 4) {
+  if (heads_per_group < 1 || heads_per_group > 8) {
     std::cout << "launch launch_attention_decode_bf16_dim128_smallm_fp8 failed with "
               << " heads_per_group:" << heads_per_group << ", num_head_q:" << num_head_q
               << ", num_head_k:" << num_head_k << std::endl;

--- a/src/attention/entry.cc
+++ b/src/attention/entry.cc
@@ -447,8 +447,8 @@ torch::Tensor attention_decode_bf16_entry(const torch::Tensor &q, torch::Tensor 
   int num_seq_max_blocks = block_ids.size(1);
 
   int heads_per_group = num_head_q / num_head_k;
-  TORCH_CHECK(heads_per_group == 4 || heads_per_group == 8,
-              "we only support num_head_q / num_head_k == 4 or 8.");
+  TORCH_CHECK(heads_per_group >= 1 && heads_per_group <= 8,
+              "we only support num_head_q / num_head_k in [1, 8].");
 
   const auto *q_ptr = q.const_data_ptr();
   auto *kcache_ptr = kcache.mutable_data_ptr();
@@ -569,8 +569,8 @@ torch::Tensor attention_decode_fp8_entry(const torch::Tensor &q, torch::Tensor &
   int qscale_pad_stride = qscale.stride(0);
 
   int heads_per_group = num_head_q / num_head_k;
-  TORCH_CHECK(heads_per_group == 4 || heads_per_group == 8,
-              "we only support num_head_q / num_head_k == 4 or 8.");
+  TORCH_CHECK(heads_per_group >= 1 && heads_per_group <= 8,
+              "we only support num_head_q / num_head_k in [1, 8].");
 
   const auto *q_ptr = q.const_data_ptr();
   auto *kcache_ptr = kcache.mutable_data_ptr();

--- a/tests/test_attention_decode_bf16.py
+++ b/tests/test_attention_decode_bf16.py
@@ -70,7 +70,20 @@ def ref_attn_with_paged_kvcache_func(
 @pytest.mark.parametrize("num_seq_q", [1, 2, 3])
 @pytest.mark.parametrize("max_seq_kv", [1024, 4096])
 @pytest.mark.parametrize("block_size", [64])
-@pytest.mark.parametrize("kv_head_q_head", [(1, 4), (1, 8), (2, 16), (4, 32)])
+@pytest.mark.parametrize(
+    "kv_head_q_head",
+    [
+        (8, 8),   # heads_per_group=1
+        (8, 16),  # heads_per_group=2
+        (8, 24),  # heads_per_group=3
+        (1, 4),   # heads_per_group=4
+        (8, 40),  # heads_per_group=5
+        (4, 24),  # heads_per_group=6
+        (8, 56),  # heads_per_group=7
+        (1, 8),   # heads_per_group=8
+        (4, 32),  # heads_per_group=8
+    ],
+)
 @pytest.mark.parametrize("head_dim", [128])
 @pytest.mark.parametrize("new_kv_included", [True, False])
 @pytest.mark.parametrize("splitk", [True, False])

--- a/tests/test_attention_decode_qkpertoken_perhead_vperhead_fp8.py
+++ b/tests/test_attention_decode_qkpertoken_perhead_vperhead_fp8.py
@@ -447,7 +447,20 @@ def attention_decode_fp8_test_func(
 @pytest.mark.parametrize("num_seq_q", [1, 2, 3, 4])
 @pytest.mark.parametrize("max_seq_kv", [1024, 4096])
 @pytest.mark.parametrize("block_size", [64])
-@pytest.mark.parametrize("kv_head_q_head", [(1, 8), (4, 32)])
+@pytest.mark.parametrize(
+    "kv_head_q_head",
+    [
+        (8, 8),   # heads_per_group=1
+        (8, 16),  # heads_per_group=2
+        (8, 24),  # heads_per_group=3
+        (1, 4),   # heads_per_group=4
+        (8, 40),  # heads_per_group=5
+        (4, 24),  # heads_per_group=6
+        (4, 28),  # heads_per_group=7
+        (1, 8),   # heads_per_group=8
+        (4, 32),  # heads_per_group=8
+    ],
+)
 @pytest.mark.parametrize("head_dim", [128])
 @pytest.mark.parametrize("new_kv_included", [True])
 @pytest.mark.parametrize("use_output", [False])

--- a/tests/test_attention_decode_qpertoken_perhead_kvpertensor_fp8.py
+++ b/tests/test_attention_decode_qpertoken_perhead_kvpertensor_fp8.py
@@ -264,7 +264,20 @@ def attention_decode_fp8_test_func(
 @pytest.mark.parametrize("num_seq_q", [1, 2, 3, 4])
 @pytest.mark.parametrize("max_seq_kv", [1024, 4096])
 @pytest.mark.parametrize("block_size", [64])
-@pytest.mark.parametrize("kv_head_q_head", [(1, 8), (4, 32)])
+@pytest.mark.parametrize(
+    "kv_head_q_head",
+    [
+        (8, 8),   # heads_per_group=1
+        (8, 16),  # heads_per_group=2
+        (8, 24),  # heads_per_group=3
+        (1, 4),   # heads_per_group=4
+        (8, 40),  # heads_per_group=5
+        (4, 24),  # heads_per_group=6
+        (4, 28),  # heads_per_group=7
+        (1, 8),   # heads_per_group=8
+        (4, 32),  # heads_per_group=8
+    ],
+)
 @pytest.mark.parametrize("head_dim", [128])
 @pytest.mark.parametrize("new_kv_included", [True])
 @pytest.mark.parametrize("use_output", [False])


### PR DESCRIPTION
## Summary
   Relax the `heads_per_group` (= `num_head_q / num_head_kv`) restriction from `{4, 8}` to `[1, 8]` for BF16 and FP8 decode attention kernels, enabling models with arbitrary GQA ratios (including MHA where hpg=1).

  ## Background

  The constraint existed because `kHeadsPerGroup=8` is hardcoded in the SM90 kernel launch path as the TMA Q/Y tile size. For `hpg < 8`, the tile over-extends the actual tensor — but this is safe due to SM90 TMA hardware guarantees:

  - **Load OOB**: coordinates outside the tensor box are **zero-filled** by hardware, not read from adjacent memory.
  - **Store OOB**: writes outside the tensor box are **silently discarded** by hardware.

  The zero-filled Q rows (Q=0) produce garbage attention outputs for those positions, but those outputs are always discarded by the TMA Y store clamp. 
  Softmax correctness is preserved because `gMax`/`gSum` are maintained independently per M-row — the ghost rows' `max=0` cannot contaminate valid rows. 

  ## Changes

  - **`src/attention/entry.cc`**: relax two `TORCH_CHECK` guards from `hpg == 4 || hpg == 8` to `hpg >= 1 && hpg <= 8` (one for BF16, one for FP8)
  - **`smallm_bf16_dim128_static.cu`**: add `hpg > 8 → return false` guard in the launch function to prevent silent mis-computation
  - **4 FP8 launch files** (static/dynamic × 2 quant types): same guard change from `!= 8 && != 4` to `< 1 || > 8`
  - **3 test files**: extend `kv_head_q_head` to cover hpg ∈ {1,2,3,4,5,6,7,8}

  ## Test Results
  ```bash
  # BF16
  python3 -m pytest tests/test_attention_decode_bf16.py -v
  # FP8
  python3 -m pytest tests/test_attention_decode_qkpertoken_perhead_vperhead_fp8.py \
                    tests/test_attention_decode_qpertoken_perhead_kvpertensor_fp8.py -v
```

  | Suite | Result |
  |-------|--------|
  | BF16 decode attention | 720 / 720 passed |
  | FP8 qkpertoken_perhead_vperhead | 864 / 864 passed |
  | FP8 qpertoken_perhead_kvpertensor | 864 / 864 passed |

  ## Benchmark

  Static splitk, `qpertoken_perhead_kvpertensor`, KV=4 fixed, 100 iterations:

  ```bash
  for hpg in 1 2 3 4 5 6 7 8; do
    python3 benchmark/attention_decode/bench_attention_decode_fp8.py \
      --cases uniform_512 uniform_4096 skewed_mix skewed_extreme one_64k_7x4k one_64k_31x4k \
      --quant-types qpertoken_perhead_kvpertensor \
      --num-head-kv 4 --num-head-q $((4 * hpg)) \
      --warmup 10 --iters 100
 done
 ```
  > Environment: NVIDIA H20 (SM90, 96 GB) · CUDA 13.0 · PyTorch 2.11.0

  | Scenario | hpg=1 | hpg=2 | hpg=3 | hpg=4 | hpg=5 | hpg=6 | hpg=7 | hpg=8 |
  |----------|------:|------:|------:|------:|------:|------:|------:|------:|
  | uniform\_512 | 20.2 | 20.2 | 20.4 | 20.5 | 20.6 | 20.6 | 20.8 | 20.7 |
  | uniform\_4096 | 112.5 | 114.3 | 113.0 | 113.5 | 113.9 | 114.6 | 114.1 | 114.6 |
  | skewed\_mix | 58.7 | 58.8 | 59.0 | 59.3 | 59.2 | 60.1 | 59.3 | 59.1 |
  | one\_64k\_31x4k | 148.0 | 147.0 | 147.6 | 148.4 | 147.8 | 147.8 | 149.5 | 148.3 |

 hpg means `heads_per_group = num_head_q / num_head_kv`，latency in **µs** (lower is better)

