### PR TITLE
perf: shrink assign_attention_decode_task grid based on actual workload

### DIFF
--- a/hpc/attention.py
+++ b/hpc/attention.py
@@ -586,6 +586,7 @@ def assign_attention_decode_task(
     mtp: int,
     new_kv_included: bool,
     min_process_len: int = 512,
+    num_seq_kvcache_cpu: Optional[Tensor] = None,
 ) -> Tensor:
     """Populate the task_map returned by ``get_attention_decode_task_workspace``.
 
@@ -605,10 +606,12 @@ def assign_attention_decode_task(
         mtp: number draft tokens.
         new_kv_included: whether ``num_seq_kvcache`` already counts new KV.
         min_process_len: each sm will process at_least 'min_process_len' token.
+        num_seq_kvcache_cpu: optional CPU copy of num_seq_kvcache (int32),
+            used to shrink the launch grid for sparse/short workloads.
     """
     if num_seq_kvcache.device.type == "cpu":
         task_map_host = torch.ops.hpc.assign_attention_decode_task(
-            num_seq_kvcache, num_head_kv, mtp, new_kv_included, min_process_len, None
+            num_seq_kvcache, num_head_kv, mtp, new_kv_included, min_process_len, None, None
         )
         task_map[:8].copy_(task_map_host.reshape(-1)[:8], non_blocking=True)
         task_map[48 : task_map_host.numel()].copy_(
@@ -617,7 +620,8 @@ def assign_attention_decode_task(
         return task_map
     else:
         return torch.ops.hpc.assign_attention_decode_task(
-            num_seq_kvcache, num_head_kv, mtp, new_kv_included, min_process_len, task_map
+            num_seq_kvcache, num_head_kv, mtp, new_kv_included, min_process_len, task_map,
+            num_seq_kvcache_cpu
         )
 
 

--- a/src/attention/decode/assign_task.cu
+++ b/src/attention/decode/assign_task.cu
@@ -72,7 +72,7 @@ __global__ void assign_attention_decode_task_kernel(int* task_map_ptr, const int
 
   int total_tiles_all_heads = smem_total_tiles[0] * num_head_kv;
 
-  // Must use max_splitk (not actual_num_ctas) to keep bin layout consistent
+  // Use max_splitk (not actual_num_ctas) to keep bin layout consistent
   // with the workspace allocated by get_attention_decode_task_workspace.
   int num_tile_per_cta = std::max((total_tiles_all_heads + max_splitk - 1) / max_splitk,
                                   min_process_len / kTileN);

--- a/src/attention/decode/assign_task.cu
+++ b/src/attention/decode/assign_task.cu
@@ -72,12 +72,16 @@ __global__ void assign_attention_decode_task_kernel(int* task_map_ptr, const int
 
   int total_tiles_all_heads = smem_total_tiles[0] * num_head_kv;
 
-  int num_tile_per_cta = std::max((total_tiles_all_heads + num_total_ctas - 1) / num_total_ctas,
+  // Must use max_splitk (not actual_num_ctas) to keep bin layout consistent
+  // with the workspace allocated by get_attention_decode_task_workspace.
+  int num_tile_per_cta = std::max((total_tiles_all_heads + max_splitk - 1) / max_splitk,
                                   min_process_len / kTileN);
 
   if (icta == 0 && idx == 1) {
     task_map_ptr[0] = num_tile_per_cta + 1;
-    task_map_ptr[1] = num_total_ctas;
+    // Store max_splitk (not actual_num_ctas) so combine kernels always find
+    // num_chunks at the correct offset regardless of actual grid size.
+    task_map_ptr[1] = max_splitk;
   }
 
   if (idx != 0) {
@@ -138,12 +142,16 @@ __global__ void assign_attention_decode_task_kernel(int* task_map_ptr, const int
   int max_num_batch_with_head = max_num_batch * num_head_kv;
   int max_num_batch_with_head_pad =
       (max_num_batch_with_head + kTaskStride - 1) / kTaskStride * kTaskStride;
-  int num_cta_count_pad = (num_total_ctas + kTaskStride - 1) / kTaskStride * kTaskStride;
+  // Use max_splitk for pointer arithmetic to keep chunk/sm_finish offsets stable.
+  int num_cta_count_pad = (max_splitk + kTaskStride - 1) / kTaskStride * kTaskStride;
 
   auto* task_map_chunk_ptr =
-      task_map_ptr + kTaskStride * ((num_tile_per_cta + 1) * num_total_ctas + 1);
+      task_map_ptr + kTaskStride * ((num_tile_per_cta + 1) * max_splitk + 1);
   auto* task_map_sm_finish_ptr = task_map_chunk_ptr + max_num_batch_with_head_pad;
   auto* num_task_map_ptr = task_map_sm_finish_ptr + num_cta_count_pad;
+  // Save base pointer before advancing; icta==0 needs it to write terminators
+  // into un-launched bins after all launched CTAs have finished.
+  int* task_map_base_ptr = task_map_ptr;
   task_map_ptr += ((num_tile_per_cta + 1) * icta + 1) * kTaskStride;
 
   int itask = 0;
@@ -288,8 +296,16 @@ __global__ void assign_attention_decode_task_kernel(int* task_map_ptr, const int
       }
     }
 
-    for (int i = 0; i < (num_total_ctas + 3) / 4; i++) {
+    // Clear full sm_finish_ptr (max_splitk slots) to avoid stale '2' values.
+    for (int i = 0; i < (max_splitk + 3) / 4; i++) {
       store(task_map_sm_finish_ptr + 4 * i, zeros);
+    }
+
+    // Write terminators into un-launched bins [num_total_ctas..max_splitk-1].
+    for (int i = num_total_ctas; i < max_splitk; i++) {
+      int* bin_ptr = task_map_base_ptr + ((num_tile_per_cta + 1) * i + 1) * kTaskStride;
+      bin_ptr[0] = -1;
+      bin_ptr[1] = -1;
     }
   }
 }
@@ -299,21 +315,25 @@ __global__ void assign_attention_decode_task_kernel(int* task_map_ptr, const int
 bool assign_attention_decode_task_async(int* task_map_ptr, const int* num_seq_kvcache,
                                         int num_total_ctas, int num_batch, int num_head_kv,
                                         int num_seq_q, int tilen, bool new_kv_included,
-                                        int min_process_len, cudaStream_t stream) {
-  dim3 grid(num_total_ctas);
-  dim3 block(128);
+                                        int min_process_len, cudaStream_t stream,
+                                        int actual_num_ctas) {
+  // actual_num_ctas: actual grid size (<= num_total_ctas); 0 means use num_total_ctas.
+  if (actual_num_ctas <= 0 || actual_num_ctas > num_total_ctas) {
+    actual_num_ctas = num_total_ctas;
+  }
 
-  int num_sm = get_sm_count();
+  dim3 grid(actual_num_ctas);
+  dim3 block(128);
 
   constexpr int kMaxNumBatch = 2048;
 
   auto launch = [&](auto tilen_tag) {
     constexpr int kTileN = decltype(tilen_tag)::value;
     int max_splitk = num_total_ctas;
-  
+
     kernels::assign_attention_decode_task_kernel<kMaxNumBatch, kTileN><<<grid, block, 0, stream>>>(
         task_map_ptr, num_seq_kvcache, num_batch, num_head_kv, num_seq_q, new_kv_included,
-        min_process_len, num_total_ctas, max_splitk);
+        min_process_len, actual_num_ctas, max_splitk);
   };
 
   if (tilen == 64) {

--- a/src/attention/decode/decode.h
+++ b/src/attention/decode/decode.h
@@ -42,7 +42,8 @@ assign_attention_decode_task_sync(const int *num_seq_kvcache, int num_total_ctas
 bool assign_attention_decode_task_async(int *task_map_ptr, const int *num_seq_kvcache,
                                         int num_total_ctas, int num_batch, int num_head_kv,
                                         int num_seq_q, int tilen, bool new_kv_included,
-                                        int min_process_len, cudaStream_t stream);
+                                        int min_process_len, cudaStream_t stream,
+                                        int actual_num_ctas = 0);
 
 }  // namespace decode
 }  // namespace attention

--- a/src/attention/entry.cc
+++ b/src/attention/entry.cc
@@ -684,7 +684,8 @@ torch::Tensor attention_decode_fp8_entry(const torch::Tensor &q, torch::Tensor &
 torch::Tensor assign_attention_decode_task_cpu_entry(const torch::Tensor &num_seq_kvcache,
                                                      int64_t num_head_kv, int64_t num_seq_q,
                                                      bool new_kv_included, int64_t min_process_len,
-                                                     std::optional<torch::Tensor> placehold) {
+                                                     std::optional<torch::Tensor> placehold,
+                                                     std::optional<torch::Tensor> /*num_seq_kvcache_cpu*/) {
   TORCH_CHECK(num_seq_kvcache.device().is_cpu(), "num_seq_kvcache tensor must be cpu");
   int num_batch = num_seq_kvcache.size(0);
 
@@ -728,7 +729,8 @@ torch::Tensor assign_attention_decode_task_cpu_entry(const torch::Tensor &num_se
 torch::Tensor assign_attention_decode_task_cuda_entry(const torch::Tensor &num_seq_kvcache,
                                                       int64_t num_head_kv, int64_t num_seq_q,
                                                       bool new_kv_included, int64_t min_process_len,
-                                                      std::optional<torch::Tensor> task_map) {
+                                                      std::optional<torch::Tensor> task_map,
+                                                      std::optional<torch::Tensor> num_seq_kvcache_cpu) {
   TORCH_CHECK(num_seq_kvcache.device().is_cuda(), "num_seq_kvcache tensor must be cuda");
   int num_batch = num_seq_kvcache.size(0);
 
@@ -742,22 +744,38 @@ torch::Tensor assign_attention_decode_task_cuda_entry(const torch::Tensor &num_s
   TORCH_CHECK(task_map.has_value(), "assign_attention_decode_task_cuda must use task_map output.")
 
   auto task_map_tensor = task_map.value();
-
   int *task_map_ptr = reinterpret_cast<int *>(task_map_tensor.mutable_data_ptr());
 
   int sm_major_version = get_sm_major_version();
   int num_total_ctas =
       decode::dynamic::kCtaPerSmMap.at(sm_major_version)[num_seq_q - 1] * get_sm_count();
 
-  int tilen = 0;
-  if (sm_major_version == 9) {
-    tilen = 64;
-  } else if (sm_major_version == 10) {
-    tilen = 128;
+  int tilen = (sm_major_version == 9) ? 64 : 128;
+
+  // Shrink launch grid if a CPU hint is available.
+  int actual_num_ctas = num_total_ctas;
+  if (num_seq_kvcache_cpu.has_value()) {
+    const torch::Tensor &cpu_lens = num_seq_kvcache_cpu.value();
+    TORCH_CHECK(cpu_lens.device().is_cpu(), "num_seq_kvcache_cpu must be a CPU tensor");
+    TORCH_CHECK(cpu_lens.dtype() == torch::kInt32, "num_seq_kvcache_cpu must be int32");
+    const int *lens = cpu_lens.const_data_ptr<int>();
+    int total_tiles = 0;
+    for (int i = 0; i < num_batch; i++) {
+      int seq = new_kv_included ? lens[i] : lens[i] + (int)num_seq_q;
+      total_tiles += (seq + tilen - 1) / tilen;
+    }
+    total_tiles *= num_head_kv;
+    int min_tiles_per_cta = std::max(1, (int)min_process_len / tilen);
+    int num_tile_per_cta = std::max((total_tiles + num_total_ctas - 1) / num_total_ctas,
+                                    min_tiles_per_cta);
+    actual_num_ctas = std::min((total_tiles + num_tile_per_cta - 1) / num_tile_per_cta,
+                               num_total_ctas);
+    actual_num_ctas = std::max(actual_num_ctas, 1);
   }
+
   auto running = decode::assign_attention_decode_task_async(
       task_map_ptr, num_seq_kvcache_ptr, num_total_ctas, num_batch, num_head_kv, num_seq_q, tilen,
-      new_kv_included, min_process_len, stream);
+      new_kv_included, min_process_len, stream, actual_num_ctas);
 
   TORCH_CHECK(running, "launch assign_attention_decode_task_async failed");
 
@@ -813,7 +831,7 @@ TORCH_LIBRARY_FRAGMENT(hpc, m) {
   m.def(
       "assign_attention_decode_task(Tensor num_seq_kvcache, int num_head_kv, int num_seq_q, bool "
       "new_kv_included, "
-      "int min_process_len, Tensor? task_map) -> "
+      "int min_process_len, Tensor? task_map, Tensor? num_seq_kvcache_cpu) -> "
       "(Tensor)");
   m.impl("assign_attention_decode_task", torch::kCPU,
          &hpc::attention::assign_attention_decode_task_cpu_entry);

--- a/tests/test_attention_decode_qkpertoken_perhead_vperhead_fp8.py
+++ b/tests/test_attention_decode_qkpertoken_perhead_vperhead_fp8.py
@@ -270,6 +270,7 @@ def attention_decode_fp8_test_func(
     splitk,
     use_dynamic_sched,
     kvcache_shape,
+    use_hint_task_map=False,
 ):
     torch.manual_seed(41)
     torch.cuda.manual_seed(41)
@@ -331,6 +332,24 @@ def attention_decode_fp8_test_func(
         assert torch.allclose(
             task_map_for_cpu[:sched_need_byte_size], task_map_for_cuda[:sched_need_byte_size]
         )
+
+        # Verify hint path produces the same task_map as the full-grid assign.
+        if use_hint_task_map and use_dynamic_sched:
+            task_map_for_hint = hpc.get_attention_decode_task_workspace(
+                num_batch, max_seq_kv + num_seq_q, num_head_kv, min_process_len=2048
+            )
+            hpc.assign_attention_decode_task(
+                num_seq_kvcache + num_seq_q,
+                task_map_for_hint,
+                num_head_kv,
+                num_seq_q,
+                new_kv_included,
+                min_process_len=2048,
+                num_seq_kvcache_cpu=(num_seq_kvcache + num_seq_q).cpu(),
+            )
+            assert torch.allclose(
+                task_map_for_hint[:sched_need_byte_size], task_map_for_cuda[:sched_need_byte_size]
+            )
 
         task_map = task_map_for_cuda
         # hpc.print_attention_decode_task(task_map)
@@ -453,6 +472,7 @@ def attention_decode_fp8_test_func(
 @pytest.mark.parametrize("use_output", [False])
 @pytest.mark.parametrize("splitk", [True])
 @pytest.mark.parametrize("use_dynamic_sched", [False, True])
+@pytest.mark.parametrize("use_hint_task_map", [True])
 @pytest.mark.parametrize("kvcache_shape", ["NHD", "HND"])
 def test_attn_fp8_sm90(
     num_batch,
@@ -465,6 +485,7 @@ def test_attn_fp8_sm90(
     use_output,
     splitk,
     use_dynamic_sched,
+    use_hint_task_map,
     kvcache_shape,
 ):
     attention_decode_fp8_test_func(
@@ -479,4 +500,5 @@ def test_attn_fp8_sm90(
         splitk,
         use_dynamic_sched,
         kvcache_shape,
+        use_hint_task_map=use_hint_task_map,
     )

--- a/tests/test_attention_decode_qpertoken_perhead_kvpertensor_fp8.py
+++ b/tests/test_attention_decode_qpertoken_perhead_kvpertensor_fp8.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from pathlib import Path
 
-sys.path.insert(0, os.path.realpath(list(Path(__file__).parent.glob("../build/lib.*/"))[0]))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import hpc
 import torch
@@ -91,6 +91,7 @@ def attention_decode_fp8_test_func(
     splitk,
     use_dynamic_sched,
     kvcache_shape,
+    use_hint_task_map=False,
 ):
     torch.manual_seed(41)
     torch.cuda.manual_seed(41)
@@ -157,6 +158,24 @@ def attention_decode_fp8_test_func(
         assert torch.allclose(
             task_map_for_cpu[:sched_need_byte_size], task_map_for_cuda[:sched_need_byte_size]
         )
+
+        # Verify hint path produces the same task_map as the full-grid assign.
+        if use_hint_task_map and use_dynamic_sched:
+            task_map_for_hint = hpc.get_attention_decode_task_workspace(
+                num_batch, max_seq_kv + num_seq_q, num_head_kv, min_process_len=1024
+            )
+            hpc.assign_attention_decode_task(
+                num_seq_kvcache + num_seq_q,
+                task_map_for_hint,
+                num_head_kv,
+                num_seq_q,
+                new_kv_included,
+                min_process_len=1024,
+                num_seq_kvcache_cpu=(num_seq_kvcache + num_seq_q).cpu(),
+            )
+            assert torch.allclose(
+                task_map_for_hint[:sched_need_byte_size], task_map_for_cuda[:sched_need_byte_size]
+            )
 
         task_map = task_map_for_cuda
         # hpc.print_attention_decode_task(task_map)
@@ -270,6 +289,7 @@ def attention_decode_fp8_test_func(
 @pytest.mark.parametrize("use_output", [False])
 @pytest.mark.parametrize("splitk", [True])
 @pytest.mark.parametrize("use_dynamic_sched", [True, False])
+@pytest.mark.parametrize("use_hint_task_map", [True])
 @pytest.mark.parametrize("kvcache_shape", ["NHD", "HND"])
 def test_attn_fp8_sm90(
     num_batch,
@@ -282,6 +302,7 @@ def test_attn_fp8_sm90(
     use_output,
     splitk,
     use_dynamic_sched,
+    use_hint_task_map,
     kvcache_shape,
 ):
     attention_decode_fp8_test_func(
@@ -296,4 +317,5 @@ def test_attn_fp8_sm90(
         splitk,
         use_dynamic_sched,
         kvcache_shape,
+        use_hint_task_map=use_hint_task_map,
     )


### PR DESCRIPTION
## Summary

The dynamic decode-attention path (SM90) runs in two steps: `assign_attention_decode_task` (a scheduling kernel that packs `(head, batch, chunk)` tuples into the `task_map`) followed by the main `attention_decode_fp8` kernel. The assign kernel always launched a **fixed grid of `num_sm × kCtaPerSm = 312` CTAs** on H20, regardless of the actual workload. 

This PR adds an **optional CPU-side hint** (`num_seq_kvcache_cpu`) that lets the entry compute the real number of CTAs needed and shrink the launch grid accordingly, while keeping the `task_map` memory layout fixed to `max_splitk` so the downstream combine kernel offsets staystable. When the hint is not provided, behavior is byte-for-byte identical to before (fully backward compatible).



## Changes

- **`hpc/attention.py`**: `assign_attention_decode_task` gains an optional `num_seq_kvcache_cpu` argument, passed through to the CUDA entry.
- **`src/attention/entry.cc`**: CUDA entry computes `actual_num_ctas` from the CPU hint; op schema updated.
- **`src/attention/decode/assign_task.cu`**: all `task_map` layout math (`num_tile_per_cta`, chunk/sm_finish offsets, header `num_total_ctas`) switched to `max_splitk`; only the grid launch size uses `actual_num_ctas`. CTA0 writes terminators into the un-launched bins.
- **`src/attention/decode/decode.h`**: `assign_attention_decode_task_async` declaration adds an `actual_num_ctas` parameter.
- **tests**: both fp8 decode attention tests add a `use_hint_task_map` parameter that verifies the hint path produces a task_map identical to the full-grid assign.


## Accuracy

All fp8 decode attention correctness tests pass, covering `num_seq_q ∈ {1,2,3,4}` (MTP 0–3), `kvcache_shape ∈ {NHD, HND}`, both quant types, and both `use_dynamic_sched` and `use_hint_task_map` paths:

```
tests/test_attention_decode_qpertoken_perhead_kvpertensor_fp8.py
tests/test_attention_decode_qkpertoken_perhead_vperhead_fp8.py
384 passed
```

## Assign-only Latency (H20, 78 SM)

Latency of the `assign_attention_decode_task` kernel in isolation (µs). **assign** = original fixed max-CTA grid; **optimized assign** = grid shrunk by the CPU-side `num_seq_kvcache_cpu` hint; **speedup** = assign / optimized assign. `actual/max CTAs` shows how far the grid was shrunk.

| Workload | Batch | actual/max CTAs | assign (us) | optimized assign (us) | Speedup |
|----------|:-----:|:---------------:|:-----------:|:----------------:|:-------:|
| uniform_512    | 64 | 64/312  | 63.17 | 20.19 | **3.13x** |
| skewed_extreme | 16 | 34/312  | 65.15 | 17.15 | **3.80x** |
| one_64k_7x4k   | 8  | 184/312 | 64.48 | 42.14 | **1.53x** |
| skewed_mix     | 64 | 264/312 | 65.73 | 57.89 | 1.14x |
| uniform_4096   | 64 | 293/312 | 63.62 | 60.35 | 1.05x |
| one_64k_31x4k  | 32 | 301/312 | 64.48 | 62.82 | 1.03x |
| one_128k_31x4k | 32 | 311/312 | 64.90 | 64.64 | ≈1.00x |

The assign kernel's fixed cost is ~63–65µs regardless of workload. When the grid shrinks (sparse/short workloads), the hint path cuts it to as low as ~17µs (**3.8x**). When the grid is already full (`311/312`), there is nothing to shrink and the two are equal — as expected.

## Attention Decode FP8 Performance (No MTP, num_seq_q=1)

Note these are single-layer numbers; see [Multi-layer amortization](#multi-layer-amortization) for the realistic deep-model picture.

**Environment**: H20, 78 SM, warmup=20, iters=100, min_process_len=512, num_head_kv=1, num_head_q=8, head_dim=128

**Column definitions**:

- **Static (us)** = static scheduling latency, fixed task partition (baseline)
- **Dynamic w/ assign (us)** = dynamic scheduling, full-grid assign + attention end-to-end
- **Optimized Dynamic w/ assign (us)** = optimized dynamic scheduling, CPU-hint grid-shrink assign + attention end-to-end
- **Dynamic vs Static** = static / dynamic (speedup)
- **Optimized vs Static** = static / optimized (speedup)
- **Optimized vs Dynamic** = dynamic / optimized (grid-shrink net gain)

| Workload | Quant Type | Batch | Max KV Len | Static (us) | Dynamic w/ assign (us) | Optimized Dynamic w/ assign (us) | Dynamic vs Static | Optimized vs Static | Optimized vs Dynamic |
|----------|-----------|:-----:|:----------:|:-----------:|:----------------------:|:-------------------------------:|:-----------------:|:-------------------:|:--------------------:|
| uniform_512    | qkpertoken_perhead_vperhead   | 64 | 512    | 14.05  | 75.20  | 43.81  | 0.19x | 0.32x | 1.72x |
| uniform_512    | qpertoken_perhead_kvpertensor | 64 | 512    | 13.82  | 75.14  | 42.21  | 0.18x | 0.33x | 1.78x |
| uniform_4096   | qkpertoken_perhead_vperhead   | 64 | 4096   | 42.72  | 93.66  | 90.72  | 0.46x | 0.47x | 1.03x |
| uniform_4096   | qpertoken_perhead_kvpertensor | 64 | 4096   | 41.47  | 89.63  | 86.94  | 0.46x | 0.48x | 1.03x |
| skewed_mix     | qkpertoken_perhead_vperhead   | 64 | 4096   | 32.99  | 82.88  | 74.43  | 0.40x | 0.44x | 1.11x |
| skewed_mix     | qpertoken_perhead_kvpertensor | 64 | 4096   | 31.23  | 81.44  | 72.74  | 0.38x | 0.43x | 1.12x |
| skewed_extreme | qkpertoken_perhead_vperhead   | 16 | 16384  | 32.10  | 91.81  | 45.63  | 0.35x | 0.70x | 2.01x |
| skewed_extreme | qpertoken_perhead_kvpertensor | 16 | 16384  | 30.53  | 87.97  | 44.93  | 0.35x | 0.68x | 1.96x |
| one_64k_7x4k   | qkpertoken_perhead_vperhead   | 8  | 65536  | 96.38  | 101.22 | 78.30  | 0.95x | **1.23x** | 1.29x |
| one_64k_7x4k   | qpertoken_perhead_kvpertensor | 8  | 65536  | 90.59  | 100.90 | 78.02  | 0.90x | **1.16x** | 1.29x |
| one_64k_15x4k  | qkpertoken_perhead_vperhead   | 16 | 65536  | 95.78  | 103.42 | 92.61  | 0.93x | **1.03x** | 1.12x |
| one_64k_15x4k  | qpertoken_perhead_kvpertensor | 16 | 65536  | 90.82  | 103.46 | 93.22  | 0.88x | 0.97x | 1.11x |
| one_64k_31x4k  | qkpertoken_perhead_vperhead   | 32 | 65536  | 99.52  | 103.49 | 101.60 | 0.96x | 0.98x | 1.02x |
| one_64k_31x4k  | qpertoken_perhead_kvpertensor | 32 | 65536  | 92.93  | 102.43 | 100.77 | 0.91x | 0.92x | 1.02x |
| one_128k_31x4k | qkpertoken_perhead_vperhead   | 32 | 131072 | 186.21 | 124.74 | 124.42 | 1.49x | **1.50x** | 1.00x |
| one_128k_31x4k | qpertoken_perhead_kvpertensor | 32 | 131072 | 172.13 | 121.02 | 121.41 | 1.42x | **1.42x** | 1.00x |


## Multi-layer amortization

In a real model the assign kernel runs **once per decode step** and the `task_map` is **reused by every attention layer**. To measure the realistic impact, this benchmark calls `assign` once and then runs `attention × N layers`, comparing optimized (hint) vs dynamic (full-grid) end-to-end (H20, quant `qpertoken_perhead_kvpertensor`, `Optimized vs Dynamic`):

| Workload | 1 layer | 8 layers | 32 layers | 61 layers |
|----------|:-------:|:--------:|:---------:|:---------:|
| uniform_512    | 1.71x (−41.6%) | 1.01x (−1.4%)  | 1.00x (0%) | 1.00x (0%) |
| skewed_extreme | 2.00x (−49.9%) | 1.12x (−10.5%) | 1.00x (0%) | 1.00x (0%) |
| one_128k_31x4k | 1.00x          | 1.00x          | 1.00x      | 1.00x      |

The assign kernel may save a fixed ~30–46µs per step, but attention work grows linearly with layer count, so the relative benefit decays quickly. For any deep model  the end-to-end gain is within noise.