### PR TITLE
perf(rope): optimize rope norm store kv with grid-y smem staging

### DIFF
--- a/benchmark/rope_norm_store_kv/README.md
+++ b/benchmark/rope_norm_store_kv/README.md
@@ -1,0 +1,118 @@
+# RoPE + Norm + Store KV Benchmark
+
+This directory benchmarks RoPE + optional QK norm + KV cache store paths.
+
+## Figure Mapping
+
+- Operator (HPC backend, BF16): `hpc.rope_norm_store_kv`
+- Operator (HPC backend, FP8): `hpc.rope_norm_store_kv_fp8`
+- Operator (FlashInfer backend, BF16 path): `apply_rope_with_cos_sin_cache_inplace + append_paged_kv_cache`
+- Operator (FlashInfer backend, FP8 path): `rope_quantize_fp8_append_paged_kv_cache`
+- Hardware expectation:
+  - `--backend hpc`: SM90 class GPU (H100/H20)
+  - `--backend flashinfer`: non-SM90 GPUs are supported by FlashInfer stack (for example SM89/SM120)
+  - `--backend auto` (default): picks `hpc` on SM90 (if importable), otherwise picks `flashinfer`
+- Default dtype:
+  - BF16 when `--fp8` is not set
+  - FP8 path when `--fp8` is set
+- Default head config: `--heads 64,8,128` (`num_q_heads,num_kv_heads,qk_head_dim`)
+- Default request sweep: `--num-req 16 64 256`
+- Default mode sweep: `--modes prefill,decode0,decode1`
+- Default norm sweep: `--norm-policies 0,1,2`
+- Default quant sweep (FP8 only): `--quant-policies 1,2`
+- Timing mode: CUDA event timing with median latency in microseconds
+- Default samples: `--warmup 10 --iters 50`
+
+## Recommended Reproduction Commands
+
+Run from repository root:
+
+```bash
+cd benchmark/rope_norm_store_kv
+
+# Auto backend selection (recommended first run)
+python3 bench_rope_norm_store_kv.py \
+  --backend auto \
+  --num-req 16 64 256 \
+  --heads 64,8,128
+```
+
+Force FlashInfer path (recommended for non-SM90 GPUs):
+
+```bash
+python3 bench_rope_norm_store_kv.py \
+  --backend flashinfer \
+  --modes prefill,decode0,decode1 \
+  --num-req 16 64 256 \
+  --heads 64,8,128
+```
+
+FP8 sweep:
+
+```bash
+python3 bench_rope_norm_store_kv.py \
+  --backend flashinfer \
+  --fp8 \
+  --quant-policies 1,2 \
+  --num-req 16 64 \
+  --heads 64,8,128
+```
+
+## Profiling Notes
+
+Torch profiler trace:
+
+```bash
+python3 bench_rope_norm_store_kv.py \
+  --backend flashinfer \
+  --profile \
+  --profile-trace-dir ./rope_profile_trace
+```
+
+Then open the trace with TensorBoard:
+
+```bash
+tensorboard --logdir ./rope_profile_trace
+```
+
+NVTX range annotation (for Nsight Systems / Nsight Compute filtering):
+
+```bash
+python3 bench_rope_norm_store_kv.py --backend flashinfer --nvtx
+```
+
+Example Nsight Systems command:
+
+```bash
+nsys profile -t cuda,nvtx,osrt -o rope_kv_report \
+  python3 bench_rope_norm_store_kv.py --backend flashinfer --nvtx --iters 100 --warmup 20
+```
+
+## Output Fields
+
+Printed table columns:
+
+- `mode`: `prefill` or `dec(mtp=0/1)`
+- `num_req`: request count in the batch
+- `norm`: `qk_norm_policy`
+  - `0`: no norm
+  - `1`: RoPE then RMSNorm
+  - `2`: RMSNorm then RoPE
+- `quant`: FP8 quant policy (`1`/`2`) or `None` in BF16 mode
+- `us`: median latency per call in microseconds
+
+## Compatibility Notes
+
+- If runtime reports `no kernel image is available for execution on the device`, the selected backend does not have a matching kernel image for your GPU architecture.
+- For non-SM90 GPUs, prefer `--backend flashinfer`.
+- `--backend hpc` requires a compatible SM90 build of HPC kernels.
+
+## Troubleshooting
+
+- `backend=hpc requested but hpc package is not available`
+  - Install/build `hpc-ops` extension in the current environment.
+- `backend=flashinfer requested but flashinfer package is not available`
+  - Install FlashInfer in the current environment.
+- Empty/invalid `--modes`
+  - Use a subset of: `prefill,decode0,decode1`.
+

--- a/benchmark/rope_norm_store_kv/bench_rope_norm_store_kv.py
+++ b/benchmark/rope_norm_store_kv/bench_rope_norm_store_kv.py
@@ -1,0 +1,529 @@
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from statistics import median
+
+import torch
+
+try:
+    import hpc
+except ImportError:
+    hpc = None
+
+try:
+    import flashinfer
+except ImportError:
+    flashinfer = None
+
+
+@dataclass
+class RopeInput:
+    qkv: torch.Tensor
+    num_seqlen: torch.Tensor
+    q_index: torch.Tensor
+    kcache: torch.Tensor
+    vcache: torch.Tensor
+    kv_indices: torch.Tensor
+    q_norm_w: torch.Tensor
+    k_norm_w: torch.Tensor
+    cos_sin: torch.Tensor
+    real_rows: int | None
+
+
+def generate_cos_sin_cache(max_position, head_dim, base=10000.0):
+    # Keep trig ops on CPU for wider compatibility across CUDA stacks.
+    inv_freq = 1.0 / (base ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
+    t = torch.arange(max_position, dtype=torch.float32)
+    freqs = torch.outer(t, inv_freq)
+    return torch.cat([freqs.cos(), freqs.sin()], dim=-1)
+
+
+def generate_kv_block_indices(kcache, req_length, device):
+    num_req = len(req_length)
+    kv_block_size = kcache.shape[1]
+    num_blocks_per_req = [(l + kv_block_size - 1) // kv_block_size for l in req_length]
+    shuffled = torch.randperm(kcache.shape[0], device=device)
+    kv_idx = torch.ones(num_req, max(num_blocks_per_req) + 4, dtype=torch.int32, device=device) * -1
+    offset = 0
+    for i, n in enumerate(num_blocks_per_req):
+        kv_idx[i, :n] = shuffled[offset : offset + n]
+        offset += n
+    return kv_idx
+
+
+def pad_decode_inputs_to_align8(qkv, num_seqlen, q_index, kv_indices):
+    nb = qkv.shape[0]
+    pb = ((nb + 7) // 8) * 8
+    if pb == nb:
+        return qkv, num_seqlen, q_index, kv_indices, nb
+
+    pr = q_index[-1].item()
+    qkv = torch.cat([qkv, torch.zeros(pb - nb, qkv.shape[1], dtype=qkv.dtype, device=qkv.device)])
+    num_seqlen = torch.cat(
+        [
+            num_seqlen,
+            torch.zeros(pb - nb, dtype=num_seqlen.dtype, device=num_seqlen.device),
+        ]
+    )
+    q_index = torch.cat(
+        [q_index, torch.full((pb - nb,), pr, dtype=q_index.dtype, device=q_index.device)]
+    )
+    kv_indices = torch.cat(
+        [
+            kv_indices,
+            torch.zeros(pb - nb, kv_indices.shape[1], dtype=kv_indices.dtype, device=kv_indices.device),
+        ]
+    )
+    return qkv, num_seqlen, q_index, kv_indices, nb
+
+
+def prepare_inputs(
+    num_req,
+    is_prefill,
+    mtp,
+    num_q_heads,
+    num_kv_heads,
+    qk_head_dim,
+    v_head_dim=None,
+    kv_block_size=64,
+    max_num_kv_blocks=1024,
+    max_rope_position=2048,
+    dtype=torch.bfloat16,
+    device="cuda",
+):
+    if v_head_dim is None:
+        v_head_dim = qk_head_dim
+
+    hidden = num_q_heads * qk_head_dim + num_kv_heads * qk_head_dim + num_kv_heads * v_head_dim
+
+    cos_sin = generate_cos_sin_cache(max_rope_position, qk_head_dim).to(torch.float32).to(device)
+    kcache = torch.randn(
+        max_num_kv_blocks,
+        kv_block_size,
+        num_kv_heads,
+        qk_head_dim,
+        dtype=dtype,
+        device=device,
+    )
+    vcache = torch.randn(
+        max_num_kv_blocks,
+        kv_block_size,
+        num_kv_heads,
+        v_head_dim,
+        dtype=dtype,
+        device=device,
+    )
+    q_norm_w = torch.randn(qk_head_dim, dtype=torch.float32, device=device)
+    k_norm_w = torch.randn(qk_head_dim, dtype=torch.float32, device=device)
+
+    if is_prefill:
+        req_len = torch.randint(20, 200, (num_req,), device=device).tolist()
+        qkv_full = torch.randn(sum(req_len), hidden, dtype=dtype, device=device)
+        req_len_t = torch.tensor(req_len, device=device)
+        q_len_t = torch.min((torch.rand(num_req, device=device) * req_len_t).long() + 1, req_len_t)
+        cumsum = torch.cumsum(req_len_t, dim=0)
+        qkv = torch.cat([qkv_full[cumsum[i] - q_len_t[i] : cumsum[i]] for i in range(num_req)])
+        q_index = torch.cat(
+            [torch.zeros(1, device=device, dtype=torch.int64), torch.cumsum(q_len_t, 0)]
+        ).to(torch.int32)
+        num_seqlen = torch.tensor(req_len, dtype=torch.int32, device=device)
+        kv_indices = generate_kv_block_indices(kcache, req_len, device)
+        real_rows = None
+    else:
+        tpr = mtp + 1
+        exist_len = torch.randint(20, 200, (num_req,), device=device).tolist()
+        upd_len = [x + tpr for x in exist_len]
+        qkv_raw = torch.randn(num_req * tpr, hidden, dtype=dtype, device=device)
+        q_idx_raw = torch.arange(0, (num_req + 1) * tpr, tpr, device=device, dtype=torch.int32)
+        num_seqlen_raw = torch.tensor(upd_len, dtype=torch.int32, device=device)
+        kv_idx_raw = generate_kv_block_indices(kcache, upd_len, device)
+        qkv, num_seqlen, q_index, kv_indices, real_rows = pad_decode_inputs_to_align8(
+            qkv_raw,
+            num_seqlen_raw,
+            q_idx_raw,
+            kv_idx_raw,
+        )
+
+    return RopeInput(
+        qkv=qkv,
+        num_seqlen=num_seqlen,
+        q_index=q_index,
+        kcache=kcache,
+        vcache=vcache,
+        kv_indices=kv_indices,
+        q_norm_w=q_norm_w,
+        k_norm_w=k_norm_w,
+        cos_sin=cos_sin,
+        real_rows=real_rows,
+    )
+
+
+def bench_us(step_fn, warmup, iters):
+    for _ in range(warmup):
+        step_fn()
+    torch.cuda.synchronize()
+    events = [
+        (torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True))
+        for _ in range(iters)
+    ]
+    for s, e in events:
+        s.record()
+        step_fn()
+        e.record()
+    torch.cuda.synchronize()
+    return median(s.elapsed_time(e) * 1000.0 for s, e in events)  # us
+
+
+def rms_norm(x, weight, eps=1e-6):
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps) * weight
+
+
+def split_qkv(inp, num_q_heads, num_kv_heads, qk_head_dim):
+    q_dim = num_q_heads * qk_head_dim
+    k_dim = num_kv_heads * qk_head_dim
+    q = inp.qkv[:, :q_dim].view(-1, num_q_heads, qk_head_dim)
+    k = inp.qkv[:, q_dim : q_dim + k_dim].view(-1, num_kv_heads, qk_head_dim)
+    v = inp.qkv[:, q_dim + k_dim : q_dim + 2 * k_dim].view(-1, num_kv_heads, qk_head_dim)
+    return q, k, v
+
+
+def build_flashinfer_meta(inp):
+    num_req = inp.q_index.numel() - 1
+    q_lens = (inp.q_index[1:] - inp.q_index[:-1]).to(torch.int32)
+    kv_block_size = inp.kcache.shape[1]
+
+    num_pages_per_req = []
+    kv_last_page_len = []
+    kv_indices_flat = []
+    for i in range(num_req):
+        seqlen = int(inp.num_seqlen[i].item())
+        pages = (seqlen + kv_block_size - 1) // kv_block_size if seqlen > 0 else 0
+        num_pages_per_req.append(pages)
+        kv_last_page_len.append(((seqlen - 1) % kv_block_size) + 1 if seqlen > 0 else 0)
+        if pages > 0:
+            kv_indices_flat.append(inp.kv_indices[i, :pages])
+
+    device = inp.qkv.device
+    num_pages_per_req_t = torch.tensor(num_pages_per_req, dtype=torch.int32, device=device)
+    kv_last_page_len_t = torch.tensor(kv_last_page_len, dtype=torch.int32, device=device)
+    kv_indptr = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device=device),
+            torch.cumsum(num_pages_per_req_t, dim=0),
+        ]
+    )
+    kv_append_indptr = torch.cat(
+        [torch.zeros(1, dtype=torch.int32, device=device), torch.cumsum(q_lens, dim=0)]
+    )
+    nnz = int(kv_append_indptr[-1].item())
+    seq_lens = flashinfer.get_seq_lens(kv_indptr, kv_last_page_len_t, kv_block_size)
+    batch_indices, positions = flashinfer.get_batch_indices_positions(kv_append_indptr, seq_lens, nnz)
+    if kv_indices_flat:
+        kv_indices = torch.cat(kv_indices_flat).to(torch.int32)
+    else:
+        kv_indices = torch.empty(0, dtype=torch.int32, device=device)
+
+    return {
+        "batch_indices": batch_indices,
+        "positions": positions,
+        "kv_indices": kv_indices,
+        "kv_indptr": kv_indptr,
+        "kv_last_page_len": kv_last_page_len_t,
+        "page_size": kv_block_size,
+        "nnz": nnz,
+    }
+
+
+def make_step_bf16(inp, is_prefill, qk_norm_policy, use_nvtx=False):
+    qkv, num_seqlen, q_index = inp.qkv, inp.num_seqlen, inp.q_index
+    kcache, vcache = inp.kcache, inp.vcache
+    kv_indices, q_norm_w, k_norm_w, cos_sin = inp.kv_indices, inp.q_norm_w, inp.k_norm_w, inp.cos_sin
+
+    def step():
+        if use_nvtx:
+            torch.cuda.nvtx.range_push("rope_norm_store_kv")
+        hpc.rope_norm_store_kv(
+            kcache, vcache, qkv, cos_sin, num_seqlen, q_index, kv_indices, is_prefill,
+            q_norm_weight=q_norm_w if qk_norm_policy > 0 else None,
+            k_norm_weight=k_norm_w if qk_norm_policy > 0 else None,
+            qk_norm_policy=qk_norm_policy,
+        )
+        if use_nvtx:
+            torch.cuda.nvtx.range_pop()
+
+    return step
+
+
+def make_step_fp8(inp, is_prefill, qk_norm_policy, quant_policy, mtp, use_nvtx=False):
+    qkv, num_seqlen, q_index = inp.qkv, inp.num_seqlen, inp.q_index
+    kcache, vcache = inp.kcache, inp.vcache
+    kv_indices, q_norm_w, k_norm_w, cos_sin = inp.kv_indices, inp.q_norm_w, inp.k_norm_w, inp.cos_sin
+    kcache_fp8 = kcache.to(torch.float8_e4m3fn)
+    vcache_fp8 = vcache.to(torch.float8_e4m3fn)
+    k_scale = torch.tensor([0.1], dtype=torch.float32, device=qkv.device)
+    v_scale = torch.tensor([0.1], dtype=torch.float32, device=qkv.device)
+    q_scale_inv = torch.tensor([0.5], dtype=torch.float32, device=qkv.device)
+    max_seqlens = (
+        int((q_index[1:] - q_index[:-1]).max().item()) if is_prefill else mtp + 1
+    )
+
+    def step():
+        if use_nvtx:
+            torch.cuda.nvtx.range_push("rope_norm_store_kv_fp8")
+        hpc.rope_norm_store_kv_fp8(
+            key_cache=kcache_fp8, value_cache=vcache_fp8, qkv=qkv, cos_sin=cos_sin,
+            num_seqlen_per_req=num_seqlen, q_index=q_index, kvcache_indices=kv_indices,
+            is_prefill=is_prefill, k_scale=k_scale, v_scale=v_scale,
+            quant_policy=quant_policy, max_seqlens=max_seqlens,
+            q_scale_inv=q_scale_inv if quant_policy == 2 else None,
+            q_norm_weight=q_norm_w if qk_norm_policy > 0 else None,
+            k_norm_weight=k_norm_w if qk_norm_policy > 0 else None,
+            qk_norm_policy=qk_norm_policy,
+        )
+        if use_nvtx:
+            torch.cuda.nvtx.range_pop()
+
+    return step
+
+
+def make_step_flashinfer_bf16(inp, num_q_heads, num_kv_heads, qk_head_dim, qk_norm_policy, use_nvtx=False):
+    q, k, v = split_qkv(inp, num_q_heads, num_kv_heads, qk_head_dim)
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+    meta = build_flashinfer_meta(inp)
+    q_norm_w = inp.q_norm_w
+    k_norm_w = inp.k_norm_w
+    q_flat = q.view(q.shape[0], -1)
+    k_flat = k.view(k.shape[0], -1)
+
+    def step():
+        if use_nvtx:
+            torch.cuda.nvtx.range_push("flashinfer_rope_append")
+
+        if qk_norm_policy == 2:
+            q.copy_(rms_norm(q, q_norm_w))
+            k.copy_(rms_norm(k, k_norm_w))
+
+        flashinfer.rope.apply_rope_with_cos_sin_cache_inplace(
+            positions=meta["positions"],
+            query=q_flat,
+            key=k_flat,
+            head_size=qk_head_dim,
+            cos_sin_cache=inp.cos_sin,
+            is_neox=True,
+        )
+
+        if qk_norm_policy == 1:
+            q.copy_(rms_norm(q, q_norm_w))
+            k.copy_(rms_norm(k, k_norm_w))
+
+        flashinfer.append_paged_kv_cache(
+            append_key=k,
+            append_value=v,
+            batch_indices=meta["batch_indices"],
+            positions=meta["positions"],
+            paged_kv_cache=(inp.kcache, inp.vcache),
+            kv_indices=meta["kv_indices"],
+            kv_indptr=meta["kv_indptr"],
+            kv_last_page_len=meta["kv_last_page_len"],
+            kv_layout="NHD",
+        )
+
+        if use_nvtx:
+            torch.cuda.nvtx.range_pop()
+
+    return step
+
+
+def make_step_flashinfer_fp8(inp, num_q_heads, num_kv_heads, qk_head_dim, use_nvtx=False):
+    q, k, v = split_qkv(inp, num_q_heads, num_kv_heads, qk_head_dim)
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+    meta = build_flashinfer_meta(inp)
+    kcache_fp8 = inp.kcache.to(torch.float8_e4m3fn)
+    vcache_fp8 = inp.vcache.to(torch.float8_e4m3fn)
+
+    def step():
+        if use_nvtx:
+            torch.cuda.nvtx.range_push("flashinfer_rope_quantize_append")
+
+        flashinfer.rope.rope_quantize_fp8_append_paged_kv_cache(
+            q_rope=q,
+            k_rope=k,
+            q_nope=None,
+            k_nope=None,
+            v=v,
+            cos_sin_cache=inp.cos_sin,
+            pos_ids=meta["positions"],
+            paged_kv_cache=(kcache_fp8, vcache_fp8),
+            kv_indices=meta["kv_indices"],
+            kv_indptr=meta["kv_indptr"],
+            batch_indices=meta["batch_indices"],
+            positions=meta["positions"],
+            is_neox=True,
+            quantize_dtype=torch.float8_e4m3fn,
+            quant_scale_q=1.0,
+            quant_scale_kv=1.0,
+            page_size=meta["page_size"],
+            kv_layout="NHD",
+            enable_pdl=False,
+        )
+
+        if use_nvtx:
+            torch.cuda.nvtx.range_pop()
+
+    return step
+
+
+def resolve_backend(backend_arg):
+    if backend_arg in ("hpc", "flashinfer"):
+        return backend_arg
+
+    major, _ = torch.cuda.get_device_capability(torch.cuda.current_device())
+    if major == 9 and hpc is not None:
+        return "hpc"
+    return "flashinfer"
+
+
+def run_torch_profile(step_fn, trace_path, active_iters=20):
+    with torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+        schedule=torch.profiler.schedule(wait=2, warmup=2, active=active_iters, repeat=1),
+        on_trace_ready=torch.profiler.tensorboard_trace_handler(trace_path),
+        record_shapes=True,
+        with_stack=False,
+        profile_memory=False,
+    ) as prof:
+        total = 2 + 2 + active_iters
+        for _ in range(total):
+            step_fn()
+            prof.step()
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--backend", default="auto", choices=["auto", "hpc", "flashinfer"])
+    p.add_argument("--fp8", action="store_true", help="bench the fp8 (quant) variant")
+    p.add_argument("--num-req", type=int, nargs="+", default=[16, 64, 256])
+    p.add_argument("--heads", default="64,8,128", help="num_q,num_kv,qk_head_dim")
+    p.add_argument("--modes", default="prefill,decode0,decode1", help="comma list: prefill,decode0,decode1")
+    p.add_argument("--norm-policies", default="0,1,2", help="comma list of qk_norm_policy")
+    p.add_argument("--quant-policies", default="1,2", help="comma list, used only when --fp8")
+    p.add_argument("--device", default="cuda:0", help="cuda device")
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--nvtx", action="store_true", help="wrap kernel calls with NVTX ranges")
+    p.add_argument("--profile", action="store_true", help="run torch profiler for the first case")
+    p.add_argument("--profile-trace-dir", default="./rope_profile_trace", help="torch profiler trace directory")
+    p.add_argument("--profile-active-iters", type=int, default=20)
+    p.add_argument("--warmup", type=int, default=10)
+    p.add_argument("--iters", type=int, default=50)
+    args = p.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is not available. This benchmark requires a CUDA device.")
+
+    torch.manual_seed(args.seed)
+    torch.cuda.set_device(args.device)
+    backend = resolve_backend(args.backend)
+
+    if backend == "hpc" and hpc is None:
+        raise RuntimeError("backend=hpc requested but hpc package is not available")
+    if backend == "flashinfer" and flashinfer is None:
+        raise RuntimeError(
+            "backend=flashinfer requested but flashinfer package is not available"
+        )
+
+    nq, nkv, hd = (int(x) for x in args.heads.split(","))
+
+    mode_lut = {
+        "prefill": (True, None),
+        "decode0": (False, 0),
+        "decode1": (False, 1),
+    }
+    modes = [mode_lut[m.strip()] for m in args.modes.split(",") if m.strip() in mode_lut]
+    if not modes:
+        raise ValueError("--modes must include at least one of: prefill,decode0,decode1")
+
+    norm_policies = [int(x) for x in args.norm_policies.split(",") if x.strip()]
+    quant_policies = [int(x) for x in args.quant_policies.split(",") if x.strip()] if args.fp8 else [None]
+
+    print(f"[backend] {backend}")
+    print(f"{'mode':>8} {'num_req':>8} {'norm':>5} {'quant':>6} {'us':>10}")
+    profiled = False
+    for is_prefill, mtp in modes:
+        for num_req in args.num_req:
+            inp = prepare_inputs(
+                num_req=num_req,
+                is_prefill=is_prefill,
+                mtp=mtp,
+                num_q_heads=nq,
+                num_kv_heads=nkv,
+                qk_head_dim=hd,
+                device=args.device,
+            )
+            for qk_norm_policy in norm_policies:
+                for quant_policy in quant_policies:
+                    if args.fp8:
+                        if backend == "hpc":
+                            step = make_step_fp8(
+                                inp,
+                                is_prefill,
+                                qk_norm_policy,
+                                quant_policy,
+                                mtp,
+                                use_nvtx=args.nvtx,
+                            )
+                        else:
+                            step = make_step_flashinfer_fp8(
+                                inp,
+                                nq,
+                                nkv,
+                                hd,
+                                use_nvtx=args.nvtx,
+                            )
+                    else:
+                        if backend == "hpc":
+                            step = make_step_bf16(
+                                inp,
+                                is_prefill,
+                                qk_norm_policy,
+                                use_nvtx=args.nvtx,
+                            )
+                        else:
+                            step = make_step_flashinfer_bf16(
+                                inp,
+                                nq,
+                                nkv,
+                                hd,
+                                qk_norm_policy,
+                                use_nvtx=args.nvtx,
+                            )
+
+                    if args.profile and not profiled:
+                        os.makedirs(args.profile_trace_dir, exist_ok=True)
+                        run_torch_profile(step, args.profile_trace_dir, args.profile_active_iters)
+                        profiled = True
+
+                    us = bench_us(step, args.warmup, args.iters)
+                    tag = "prefill" if is_prefill else f"dec(mtp={mtp})"
+                    print(f"{tag:>8} {num_req:>8} {qk_norm_policy:>5} "
+                          f"{str(quant_policy):>6} {us:>10.2f}")
+
+    if args.profile:
+        print(f"[profile] torch profiler trace written to: {args.profile_trace_dir}")
+        print("[profile] open with TensorBoard: tensorboard --logdir <trace_dir>")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except RuntimeError as e:
+        msg = str(e)
+        if "no kernel image is available for execution on the device" in msg:
+            print("[error] CUDA runtime reports no kernel image for this GPU architecture.")
+            print("[hint] Try --backend flashinfer on non-SM90 GPUs, or rebuild for your target SM.")
+            sys.exit(2)
+        raise

--- a/src/rope/rope.cu
+++ b/src/rope/rope.cu
@@ -62,6 +62,23 @@ __device__ __forceinline__ float warp_abs_max(vec_t<T, N> &data) {
   return warp_reduce_max_xor(m);
 }
 
+/// Load a NeoX-layout BF16 head into float registers.
+template <int kQKHeadDim, int kNumItemPerThread, int kWarpSize = 32>
+__device__ __forceinline__ void vectorized_load_neox(vec_t<float, kNumItemPerThread> &data,
+                                                     const __nv_bfloat16 *src, int ilane) {
+  constexpr int kNumRoundsHalf = ceil_div<kQKHeadDim / 2, kWarpSize>();
+  static_assert(kNumItemPerThread == kNumRoundsHalf * 2,
+                "kNumItemPerThread must match NeoX load rounds");
+#pragma unroll
+  for (int r = 0; r < kNumRoundsHalf; ++r) {
+    int i = r * kWarpSize + ilane;
+    if (i < kQKHeadDim / 2) {
+      data[r * 2] = __bfloat162float(src[i]);
+      data[r * 2 + 1] = __bfloat162float(src[i + kQKHeadDim / 2]);
+    }
+  }
+}
+
 /// Zero rows [from_row, to_row) of a KV cache block
 template <typename CacheT, int kElemPerRow, int kWarpSize = 32>
 __device__ __forceinline__ void zero_kv_rows(CacheT *block_start, int from_row, int to_row,
@@ -88,11 +105,22 @@ __global__ void rope_norm_store_kv_kernel(
     cutlass::FastDivmod kv_block_size_divider, int num_rows, int num_compute_blocks) {
   using DType = __nv_bfloat16;
 
+  static_assert(kNumQHeads % kNumKVHeads == 0, "kNumQHeads must be divisible by kNumKVHeads");
+  constexpr int kQPerKV = kNumQHeads / kNumKVHeads;
+  constexpr int kKVPerCTA = 1;
+  constexpr int kQPerCTA = kQPerKV;
+  const int kv_head_start = blockIdx.y;
+  const int q_head_start = kv_head_start * kQPerKV;
+
   constexpr int kWarpSize = 32;
   constexpr int kNumElemPerRow =
       kNumQHeads * kQKHeadDim + kNumKVHeads * kQKHeadDim + kNumKVHeads * kVHeadDim;
   constexpr int kNumRoundsHalf = ceil_div<kQKHeadDim / 2, kWarpSize>();
   constexpr int kNumItemPerThread = kNumRoundsHalf * 2;
+
+  constexpr int kNumSmemQElemPerRow = kQPerCTA * kQKHeadDim;
+  constexpr int kNumSmemKElemPerRow = kKVPerCTA * kQKHeadDim;
+  constexpr int kNumSmemElemPerRow = kNumSmemQElemPerRow + kNumSmemKElemPerRow;
 
   int tid = threadIdx.x;
   int bid = blockIdx.x;
@@ -104,8 +132,10 @@ __global__ void rope_norm_store_kv_kernel(
   __shared__ float smem_k_norm_w[kQKHeadDim];
   __shared__ int smem_batch_id[kWarpsPerBlock];
   __shared__ int smem_token_pos[kWarpsPerBlock];
+  extern __shared__ DType smem_qkv[];
 
   // ---- Clear blocks: bid >= num_compute_blocks → one block per request -----
+  // Each clear block clears one KV head slice.
   if (bid >= num_compute_blocks) {
     int req_id = bid - num_compute_blocks;
     if (req_id >= num_batch) return;
@@ -122,54 +152,67 @@ __global__ void rope_norm_store_kv_kernel(
     int zero_from = pos_in_block + 1;
     int zero_to = kv_block_size_divider.divisor;
     if (zero_from < zero_to) {
-      // Use all kWarpsPerBlock warps cooperatively to zero rows
-      for (int row = zero_from + iwarp; row < zero_to; row += kWarpsPerBlock) {
-        DType *k_row = kcache_ptr + (int64_t)phys_block_id * (int64_t)kcache_block_offset +
-                       row * (kNumKVHeads * kQKHeadDim);
-        DType *v_row = vcache_ptr + (int64_t)phys_block_id * (int64_t)vcache_block_offset +
-                       row * (kNumKVHeads * kVHeadDim);
-        constexpr int kKItemPerThread = 16 / sizeof(DType);
-        vec_t<DType, kKItemPerThread> zero_vec;
+      constexpr int kKItemPerThread = 16 / sizeof(DType);
+      static_assert(kQKHeadDim % kKItemPerThread == 0,
+                    "kQKHeadDim must be divisible by kKItemPerThread");
+      static_assert(kVHeadDim % kKItemPerThread == 0,
+                    "kVHeadDim must be divisible by kKItemPerThread");
+      vec_t<DType, kKItemPerThread> zero_vec;
 #pragma unroll
-        for (int z = 0; z < kKItemPerThread; ++z) zero_vec[z] = DType(0);
-        for (int idx = ilane * kKItemPerThread; idx < kNumKVHeads * kQKHeadDim;
-             idx += kWarpSize * kKItemPerThread)
-          store(k_row + idx, zero_vec);
-        for (int idx = ilane * kKItemPerThread; idx < kNumKVHeads * kVHeadDim;
-             idx += kWarpSize * kKItemPerThread)
-          store(v_row + idx, zero_vec);
+      for (int z = 0; z < kKItemPerThread; ++z) zero_vec[z] = DType(0);
+      // Each clear block clears the kKVPerCTA KV head slice it owns.
+      for (int row = zero_from + iwarp; row < zero_to; row += kWarpsPerBlock) {
+#pragma unroll
+        for (int h = 0; h < kKVPerCTA; ++h) {
+          int kv_head = kv_head_start + h;
+          DType *k_row = kcache_ptr + (int64_t)phys_block_id * (int64_t)kcache_block_offset +
+                         row * (kNumKVHeads * kQKHeadDim) + kv_head * kQKHeadDim;
+          DType *v_row = vcache_ptr + (int64_t)phys_block_id * (int64_t)vcache_block_offset +
+                         row * (kNumKVHeads * kVHeadDim) + kv_head * kVHeadDim;
+          for (int idx = ilane * kKItemPerThread; idx < kQKHeadDim;
+               idx += kWarpSize * kKItemPerThread)
+            store(k_row + idx, zero_vec);
+          for (int idx = ilane * kKItemPerThread; idx < kVHeadDim;
+               idx += kWarpSize * kKItemPerThread)
+            store(v_row + idx, zero_vec);
+        }
       }
     }
     return;
   }
 
-  // Search q_index to find batch_id
+  // Search q_index to find batch_id.
   int batch_id = 0;
   int token_id = 0;
   int irow = bid * kWarpsPerBlock + iwarp;
 
-  // First kWarpsPerBlock threads do the q_index search for the whole block
+  // Initialize sentinels for padding rows.
   if (tid < kWarpsPerBlock) {
-    int global_row = bid * kWarpsPerBlock + tid;
-    if (global_row < num_rows) {
-      int b = -1;
-      for (int i = 0; i < num_batch; ++i) {
-        if (global_row < q_index_ptr[i + 1]) {
-          b = i;
-          break;
+    smem_batch_id[tid] = -1;
+    smem_token_pos[tid] = -1;
+  }
+  __syncthreads();
+
+  // Each thread claims one batch id and checks whether it covers any of this
+  // block's kWarpsPerBlock rows. q_index segments are non-overlapping so at
+  // most one thread writes each smem[iw].
+  {
+    constexpr int kNumSearchThreads = kWarpSize * kWarpsPerBlock;
+    int num_search_rounds = (num_batch + kNumSearchThreads - 1) / kNumSearchThreads;
+    for (int round = 0; round < num_search_rounds; round++) {
+      int b = round * kNumSearchThreads + tid;
+      if (b < num_batch) {
+        int q_begin = q_index_ptr[b];
+        int q_end = q_index_ptr[b + 1];
+#pragma unroll
+        for (int iw = 0; iw < kWarpsPerBlock; iw++) {
+          int global_row = bid * kWarpsPerBlock + iw;
+          if (q_begin <= global_row && global_row < q_end) {
+            smem_batch_id[iw] = b;
+            smem_token_pos[iw] = global_row + num_seqlen_per_req_ptr[b] - q_index_ptr[b + 1];
+          }
         }
       }
-      if (b >= 0) {
-        smem_batch_id[tid] = b;
-        smem_token_pos[tid] = global_row + num_seqlen_per_req_ptr[b] - q_index_ptr[b + 1];
-      } else {
-        // Padding row: global_row >= q_index[num_batch] (CUDA graph padding)
-        smem_batch_id[tid] = -1;
-        smem_token_pos[tid] = -1;
-      }
-    } else {
-      smem_batch_id[tid] = -1;
-      smem_token_pos[tid] = -1;
     }
   }
 
@@ -184,6 +227,41 @@ __global__ void rope_norm_store_kv_kernel(
       int ioffset = tid * kItemPerThread;
       store(smem_q_norm_w + ioffset, load<float, kItemPerThread>(q_norm_weight_ptr + ioffset));
       store(smem_k_norm_w + ioffset, load<float, kItemPerThread>(k_norm_weight_ptr + ioffset));
+    }
+  }
+
+  // Stage this CTA's Q/K slice into shared memory. V is streamed from global memory.
+  {
+    constexpr int kElemPerThread = 16 / sizeof(DType);
+    static_assert(kNumSmemQElemPerRow % kElemPerThread == 0,
+                  "Q slice must align to packed load width");
+    static_assert(kNumSmemKElemPerRow % kElemPerThread == 0,
+                  "K slice must align to packed load width");
+    constexpr int kQPacks = kNumSmemQElemPerRow / kElemPerThread;
+    constexpr int kKPacks = kNumSmemKElemPerRow / kElemPerThread;
+    constexpr int kQRounds = ceil_div<kQPacks, kWarpSize>();
+    constexpr int kKRounds = ceil_div<kKPacks, kWarpSize>();
+    int irow_local = bid * kWarpsPerBlock + iwarp;
+    if (irow_local < num_rows) {
+      const DType *src_q = in_qkv_ptr + irow_local * kNumElemPerRow + q_head_start * kQKHeadDim;
+      const DType *src_k = in_qkv_ptr + irow_local * kNumElemPerRow + kNumQHeads * kQKHeadDim +
+                           kv_head_start * kQKHeadDim;
+      DType *dst_q = smem_qkv + iwarp * kNumSmemElemPerRow;
+      DType *dst_k = dst_q + kNumSmemQElemPerRow;
+#pragma unroll
+      for (int r = 0; r < kQRounds; ++r) {
+        int ioffset = (r * kWarpSize + ilane) * kElemPerThread;
+        if (ioffset < kNumSmemQElemPerRow) {
+          store(dst_q + ioffset, load<DType, kElemPerThread>(src_q + ioffset));
+        }
+      }
+#pragma unroll
+      for (int r = 0; r < kKRounds; ++r) {
+        int ioffset = (r * kWarpSize + ilane) * kElemPerThread;
+        if (ioffset < kNumSmemKElemPerRow) {
+          store(dst_k + ioffset, load<DType, kElemPerThread>(src_k + ioffset));
+        }
+      }
     }
   }
 
@@ -220,25 +298,23 @@ __global__ void rope_norm_store_kv_kernel(
   DType *v_cache_row_start = vcache_ptr + (int64_t)phys_block_id * (int64_t)vcache_block_offset +
                              block_row * (kNumKVHeads * kVHeadDim);
 
-  const DType *qkv_row = in_qkv_ptr + irow * kNumElemPerRow;
+  // Q/K heads for this CTA are staged in smem_qkv. V is streamed from global memory.
+  const DType *qkv_row_smem = smem_qkv + iwarp * kNumSmemElemPerRow;
+  const DType *qkv_row_global = in_qkv_ptr + irow * kNumElemPerRow;
 
-  // Process Q heads – load from global, optional norm, RoPE, optional norm, store
+  // Process Q heads for this CTA's KV group range:
+  // [q_head_start, q_head_start + kQPerCTA)
 #pragma unroll
-  for (int q_head = 0; q_head < kNumQHeads; ++q_head) {
-    const DType *q_src = qkv_row + q_head * kQKHeadDim;
+  for (int dq = 0; dq < kQPerCTA; ++dq) {
+    int q_head = q_head_start + dq;
+    // Q is indexed by dq within this CTA's Q slice.
+    const DType *q_src = qkv_row_smem + dq * kQKHeadDim;
     DType *q_dst = out_q_ptr + irow * kNumQHeads * kQKHeadDim + q_head * kQKHeadDim;
 
     vec_t<float, kNumItemPerThread> data = {0};
 
-    // Load Q head from global memory directly into registers
-#pragma unroll
-    for (int r = 0; r < kNumRoundsHalf; ++r) {
-      int i = r * kWarpSize + ilane;
-      if (i < kQKHeadDim / 2) {
-        data[r * 2] = __bfloat162float(q_src[i]);
-        data[r * 2 + 1] = __bfloat162float(q_src[i + kQKHeadDim / 2]);
-      }
-    }
+    // Load Q head from shared memory into registers.
+    vectorized_load_neox<kQKHeadDim, kNumItemPerThread, kWarpSize>(data, q_src, ilane);
 
     // norm-then-rope
     if constexpr (kNormPolicy == 2) {
@@ -271,22 +347,16 @@ __global__ void rope_norm_store_kv_kernel(
     }
   }
 
-  // Process K heads – load from global, optional norm, RoPE, optional norm,
-  // write to KV cache (or out_k_ptr if non-null)
+  // Process K heads owned by this CTA: [kv_head_start, kv_head_start + kKVPerCTA)
 #pragma unroll
-  for (int kv_head = 0; kv_head < kNumKVHeads; ++kv_head) {
-    const DType *k_src = qkv_row + kNumQHeads * kQKHeadDim + kv_head * kQKHeadDim;
+  for (int dh = 0; dh < kKVPerCTA; ++dh) {
+    const int kv_head = kv_head_start + dh;
+    // K is indexed by dh within this CTA's K slice.
+    const DType *k_src = qkv_row_smem + kNumSmemQElemPerRow + dh * kQKHeadDim;
 
     vec_t<float, kNumItemPerThread> data = {0};
 
-#pragma unroll
-    for (int r = 0; r < kNumRoundsHalf; ++r) {
-      int i = r * kWarpSize + ilane;
-      if (i < kQKHeadDim / 2) {
-        data[r * 2] = __bfloat162float(k_src[i]);
-        data[r * 2 + 1] = __bfloat162float(k_src[i + kQKHeadDim / 2]);
-      }
-    }
+    vectorized_load_neox<kQKHeadDim, kNumItemPerThread, kWarpSize>(data, k_src, ilane);
 
     if constexpr (kNormPolicy == 2) {
       rms_norm_apply<kNumItemPerThread, kQKHeadDim>(data, smem_k_norm_w, ilane);
@@ -320,24 +390,26 @@ __global__ void rope_norm_store_kv_kernel(
     }
   }
 
-  // Process V heads – no RoPE
+  // Process V heads owned by this CTA: [kv_head_start, kv_head_start + kKVPerCTA)
   {
-    constexpr int kNumVElemPerRow = kNumKVHeads * kVHeadDim;
     constexpr int kItemPerThread = 16 / sizeof(DType);
-    static_assert(kNumVElemPerRow % kItemPerThread == 0,
-                  "kNumKVHeads * kVHeadDim must be multiple of kItemPerThread");
-    constexpr int kNumPackPerRow = kNumVElemPerRow / kItemPerThread;
-
-    const DType *v_src = qkv_row + (kNumQHeads + kNumKVHeads) * kQKHeadDim;
-    DType *v_dst =
-        (out_v_ptr != nullptr) ? out_v_ptr + irow * kNumKVHeads * kVHeadDim : v_cache_row_start;
-
-    constexpr int kNumLoadRound = ceil_div<kNumPackPerRow, kWarpSize>();
+    static_assert(kVHeadDim % kItemPerThread == 0, "kVHeadDim must be divisible by kItemPerThread");
+    constexpr int kNumPackPerHead = kVHeadDim / kItemPerThread;
+    constexpr int kNumLoadRound = ceil_div<kNumPackPerHead, kWarpSize>();
 #pragma unroll
-    for (int r = 0; r < kNumLoadRound; ++r) {
-      int ioffset = (r * kWarpSize + ilane) * kItemPerThread;
-      if (ioffset < kNumVElemPerRow) {
-        store(v_dst + ioffset, load<DType, kItemPerThread>(v_src + ioffset));
+    for (int dh = 0; dh < kKVPerCTA; ++dh) {
+      const int kv_head = kv_head_start + dh;
+      const DType *v_src =
+          qkv_row_global + (kNumQHeads + kNumKVHeads) * kQKHeadDim + kv_head * kVHeadDim;
+      DType *v_dst = (out_v_ptr != nullptr)
+                         ? out_v_ptr + irow * kNumKVHeads * kVHeadDim + kv_head * kVHeadDim
+                         : v_cache_row_start + kv_head * kVHeadDim;
+#pragma unroll
+      for (int r = 0; r < kNumLoadRound; ++r) {
+        int ioffset = (r * kWarpSize + ilane) * kItemPerThread;
+        if (ioffset < kVHeadDim) {
+          store(v_dst + ioffset, load<DType, kItemPerThread>(v_src + ioffset));
+        }
       }
     }
   }
@@ -358,11 +430,21 @@ __global__ void rope_norm_store_kv_fp8_kernel(
   using DType = __nv_bfloat16;
   using QType = __nv_fp8_e4m3;
 
+  static_assert(kNumQHeads % kNumKVHeads == 0, "kNumQHeads must be divisible by kNumKVHeads");
+  constexpr int kQPerKV = kNumQHeads / kNumKVHeads;
+  constexpr int kKVPerCTA = 1;
+  constexpr int kQPerCTA = kQPerKV;
+  const int kv_head_start = blockIdx.y;
+  const int q_head_start = kv_head_start * kQPerKV;
+
   constexpr int kWarpSize = 32;
   constexpr int kNumElemPerRow =
       kNumQHeads * kQKHeadDim + kNumKVHeads * kQKHeadDim + kNumKVHeads * kVHeadDim;
   constexpr int kNumRoundsHalf = ceil_div<kQKHeadDim / 2, kWarpSize>();
   constexpr int kNumItemPerThread = kNumRoundsHalf * 2;
+  constexpr int kNumSmemQElemPerRow = kQPerCTA * kQKHeadDim;
+  constexpr int kNumSmemKElemPerRow = kKVPerCTA * kQKHeadDim;
+  constexpr int kNumSmemElemPerRow = kNumSmemQElemPerRow + kNumSmemKElemPerRow;
 
   int tid = threadIdx.x;
   int bid = blockIdx.x;
@@ -375,6 +457,7 @@ __global__ void rope_norm_store_kv_fp8_kernel(
   __shared__ float smem_k_norm_w[kQKHeadDim];
   __shared__ int smem_batch_id[kWarpsPerBlock];
   __shared__ int smem_token_pos[kWarpsPerBlock];
+  extern __shared__ DType smem_qkv[];
 
   // ---- Clear blocks: bid >= num_compute_blocks → one block per request -----
   if (bid >= num_compute_blocks) {
@@ -392,51 +475,62 @@ __global__ void rope_norm_store_kv_fp8_kernel(
     int zero_from = pos_in_block + 1;
     int zero_to = kv_block_size_divider.divisor;
     if (zero_from < zero_to) {
-      for (int row = zero_from + iwarp; row < zero_to; row += kWarpsPerBlock) {
-        QType *k_row = kcache_ptr + (int64_t)phys_block_id * (int64_t)kcache_block_offset +
-                       row * (kNumKVHeads * kQKHeadDim);
-        QType *v_row = vcache_ptr + (int64_t)phys_block_id * (int64_t)vcache_block_offset +
-                       row * (kNumKVHeads * kVHeadDim);
-        constexpr int kKItemPerThread = 16 / sizeof(QType);
-        vec_t<QType, kKItemPerThread> zero_vec;
+      constexpr int kKItemPerThread = 16 / sizeof(QType);
+      static_assert(kQKHeadDim % kKItemPerThread == 0,
+                    "kQKHeadDim must be divisible by kKItemPerThread");
+      static_assert(kVHeadDim % kKItemPerThread == 0,
+                    "kVHeadDim must be divisible by kKItemPerThread");
+      vec_t<QType, kKItemPerThread> zero_vec;
 #pragma unroll
-        for (int z = 0; z < kKItemPerThread; ++z) zero_vec[z] = QType(0);
-        for (int idx = ilane * kKItemPerThread; idx < kNumKVHeads * kQKHeadDim;
-             idx += kWarpSize * kKItemPerThread)
-          store(k_row + idx, zero_vec);
-        for (int idx = ilane * kKItemPerThread; idx < kNumKVHeads * kVHeadDim;
-             idx += kWarpSize * kKItemPerThread)
-          store(v_row + idx, zero_vec);
+      for (int z = 0; z < kKItemPerThread; ++z) zero_vec[z] = QType(0);
+      for (int row = zero_from + iwarp; row < zero_to; row += kWarpsPerBlock) {
+#pragma unroll
+        for (int h = 0; h < kKVPerCTA; ++h) {
+          int kv_head = kv_head_start + h;
+          QType *k_row = kcache_ptr + (int64_t)phys_block_id * (int64_t)kcache_block_offset +
+                         row * (kNumKVHeads * kQKHeadDim) + kv_head * kQKHeadDim;
+          QType *v_row = vcache_ptr + (int64_t)phys_block_id * (int64_t)vcache_block_offset +
+                         row * (kNumKVHeads * kVHeadDim) + kv_head * kVHeadDim;
+          for (int idx = ilane * kKItemPerThread; idx < kQKHeadDim;
+               idx += kWarpSize * kKItemPerThread)
+            store(k_row + idx, zero_vec);
+          for (int idx = ilane * kKItemPerThread; idx < kVHeadDim;
+               idx += kWarpSize * kKItemPerThread)
+            store(v_row + idx, zero_vec);
+        }
       }
     }
     return;
   }
 
-  // Determine batch_id and token position — unified for prefill and decode
+  // Determine batch_id and token position.
   int batch_id = 0;
   int token_id = 0;
   int irow = bid * kWarpsPerBlock + iwarp;
 
   if (tid < kWarpsPerBlock) {
-    int global_row = bid * kWarpsPerBlock + tid;
-    if (global_row < num_rows) {
-      int b = -1;
-      for (int i = 0; i < num_batch; ++i) {
-        if (global_row < q_index_ptr[i + 1]) {
-          b = i;
-          break;
+    smem_batch_id[tid] = -1;
+    smem_token_pos[tid] = -1;
+  }
+  __syncthreads();
+
+  {
+    constexpr int kNumSearchThreads = kWarpSize * kWarpsPerBlock;
+    int num_search_rounds = (num_batch + kNumSearchThreads - 1) / kNumSearchThreads;
+    for (int round = 0; round < num_search_rounds; round++) {
+      int b = round * kNumSearchThreads + tid;
+      if (b < num_batch) {
+        int q_begin = q_index_ptr[b];
+        int q_end = q_index_ptr[b + 1];
+#pragma unroll
+        for (int iw = 0; iw < kWarpsPerBlock; iw++) {
+          int global_row = bid * kWarpsPerBlock + iw;
+          if (q_begin <= global_row && global_row < q_end) {
+            smem_batch_id[iw] = b;
+            smem_token_pos[iw] = global_row + num_seqlen_per_req_ptr[b] - q_index_ptr[b + 1];
+          }
         }
       }
-      if (b >= 0) {
-        smem_batch_id[tid] = b;
-        smem_token_pos[tid] = global_row + num_seqlen_per_req_ptr[b] - q_index_ptr[b + 1];
-      } else {
-        smem_batch_id[tid] = -1;
-        smem_token_pos[tid] = -1;
-      }
-    } else {
-      smem_batch_id[tid] = -1;
-      smem_token_pos[tid] = -1;
     }
   }
 
@@ -453,7 +547,42 @@ __global__ void rope_norm_store_kv_fp8_kernel(
     }
   }
 
-  // Single barrier: makes batch_id, token_pos, and norm weights visible
+  // Stage this CTA's Q/K slice into shared memory. V is streamed from global memory.
+  {
+    constexpr int kElemPerThread = 16 / sizeof(DType);
+    static_assert(kNumSmemQElemPerRow % kElemPerThread == 0,
+                  "Q slice must align to packed load width");
+    static_assert(kNumSmemKElemPerRow % kElemPerThread == 0,
+                  "K slice must align to packed load width");
+    constexpr int kQPacks = kNumSmemQElemPerRow / kElemPerThread;
+    constexpr int kKPacks = kNumSmemKElemPerRow / kElemPerThread;
+    constexpr int kQRounds = ceil_div<kQPacks, kWarpSize>();
+    constexpr int kKRounds = ceil_div<kKPacks, kWarpSize>();
+    int irow_local = bid * kWarpsPerBlock + iwarp;
+    if (irow_local < num_rows) {
+      const DType *src_q = in_qkv_ptr + irow_local * kNumElemPerRow + q_head_start * kQKHeadDim;
+      const DType *src_k = in_qkv_ptr + irow_local * kNumElemPerRow + kNumQHeads * kQKHeadDim +
+                           kv_head_start * kQKHeadDim;
+      DType *dst_q = smem_qkv + iwarp * kNumSmemElemPerRow;
+      DType *dst_k = dst_q + kNumSmemQElemPerRow;
+#pragma unroll
+      for (int r = 0; r < kQRounds; ++r) {
+        int ioffset = (r * kWarpSize + ilane) * kElemPerThread;
+        if (ioffset < kNumSmemQElemPerRow) {
+          store(dst_q + ioffset, load<DType, kElemPerThread>(src_q + ioffset));
+        }
+      }
+#pragma unroll
+      for (int r = 0; r < kKRounds; ++r) {
+        int ioffset = (r * kWarpSize + ilane) * kElemPerThread;
+        if (ioffset < kNumSmemKElemPerRow) {
+          store(dst_k + ioffset, load<DType, kElemPerThread>(src_k + ioffset));
+        }
+      }
+    }
+  }
+
+  // Single barrier: makes batch_id, token_pos, norm weights, and Q/K smem visible.
   __syncthreads();
 
   // Early-exit for invalid/padding rows
@@ -485,24 +614,21 @@ __global__ void rope_norm_store_kv_fp8_kernel(
   QType *v_cache_row_start = vcache_ptr + (int64_t)phys_block_id * (int64_t)vcache_block_offset +
                              block_row * (kNumKVHeads * kVHeadDim);
 
-  const DType *qkv_row = in_qkv_ptr + irow * kNumElemPerRow;
+  // Q/K heads for this CTA are staged in smem_qkv. V is streamed from global memory.
+  const DType *qkv_row_smem = smem_qkv + iwarp * kNumSmemElemPerRow;
+  const DType *qkv_row_global = in_qkv_ptr + irow * kNumElemPerRow;
 
-  // ========= Process Q heads =========
+  // ========= Process Q heads for this CTA's KV group range =========
 #pragma unroll
-  for (int q_head = 0; q_head < kNumQHeads; ++q_head) {
-    const DType *q_src = qkv_row + q_head * kQKHeadDim;
+  for (int dq = 0; dq < kQPerCTA; ++dq) {
+    int q_head = q_head_start + dq;
+    // Q is indexed by dq within this CTA's Q slice.
+    const DType *q_src = qkv_row_smem + dq * kQKHeadDim;
     QType *q_dst = out_q_ptr + irow * kNumQHeads * kQKHeadDim + q_head * kQKHeadDim;
 
     vec_t<float, kNumItemPerThread> data = {0};
 
-#pragma unroll
-    for (int r = 0; r < kNumRoundsHalf; ++r) {
-      int i = r * kWarpSize + ilane;
-      if (i < kQKHeadDim / 2) {
-        data[r * 2] = __bfloat162float(q_src[i]);
-        data[r * 2 + 1] = __bfloat162float(q_src[i + kQKHeadDim / 2]);
-      }
-    }
+    vectorized_load_neox<kQKHeadDim, kNumItemPerThread, kWarpSize>(data, q_src, ilane);
 
     if constexpr (kNormPolicy == 2) {
       rms_norm_apply<kNumItemPerThread, kQKHeadDim>(data, smem_q_norm_w, ilane);
@@ -529,18 +655,15 @@ __global__ void rope_norm_store_kv_fp8_kernel(
       float q_scale_val = max_abs / upper_max;
       if (ilane == 0) {
         if (is_prefill) {
-          // Prefill layout: [batch_id, q_head, tok_in_chunk]
           int tok_in_chunk = irow - q_index_ptr[batch_id];
           q_scale_ptr[batch_id * kNumQHeads * max_seqlen_aligned + q_head * max_seqlen_aligned +
                       tok_in_chunk] = q_scale_val;
         } else {
-          // Decode layout: [irow, q_head]
           q_scale_ptr[irow * kNumQHeads + q_head] = q_scale_val;
         }
       }
       q_mult = __frcp_rn(q_scale_val);
     } else if constexpr (kQuantPolicy == 2) {
-      // sqskv: static per-tensor
       q_mult = q_scale_inv_ptr[0];
     }
 
@@ -555,85 +678,90 @@ __global__ void rope_norm_store_kv_fp8_kernel(
     }
   }
 
-  // ========= Process K heads =========
-  float k_scale_inv = __frcp_rn(k_scale_ptr[0]);
+  // ========= Process K heads owned by this CTA =========
+  {
+    float k_scale_inv = __frcp_rn(k_scale_ptr[0]);
+
+    // Zero split_k_flag once per (batch, kv_head). Only the CTA carrying the
+    // first row of this batch writes it, to avoid repeated writes.
+    if (irow == q_index_ptr[batch_id] && ilane == 0) {
 #pragma unroll
-  for (int kv_head = 0; kv_head < kNumKVHeads; ++kv_head) {
-    const DType *k_src = qkv_row + kNumQHeads * kQKHeadDim + kv_head * kQKHeadDim;
-
-    // Zero split_k_flag inside K loop
-    if (ilane == 0) {
-      split_k_flag_ptr[batch_id * kNumKVHeads + kv_head] = 0;
-    }
-
-    vec_t<float, kNumItemPerThread> data = {0};
-
-#pragma unroll
-    for (int r = 0; r < kNumRoundsHalf; ++r) {
-      int i = r * kWarpSize + ilane;
-      if (i < kQKHeadDim / 2) {
-        data[r * 2] = __bfloat162float(k_src[i]);
-        data[r * 2 + 1] = __bfloat162float(k_src[i + kQKHeadDim / 2]);
+      for (int dh = 0; dh < kKVPerCTA; ++dh) {
+        split_k_flag_ptr[batch_id * kNumKVHeads + kv_head_start + dh] = 0;
       }
     }
 
-    if constexpr (kNormPolicy == 2) {
-      rms_norm_apply<kNumItemPerThread, kQKHeadDim>(data, smem_k_norm_w, ilane);
-    }
-
 #pragma unroll
-    for (int r = 0; r < kNumRoundsHalf; ++r) {
-      int i = r * kWarpSize + ilane;
-      if (i < kQKHeadDim / 2) {
-        rope_rotate_pair(data[r * 2], data[r * 2 + 1], smem_cos_sin[iwarp][i],
-                         smem_cos_sin[iwarp][i + kQKHeadDim / 2]);
+    for (int dh = 0; dh < kKVPerCTA; ++dh) {
+      const int kv_head = kv_head_start + dh;
+      // K is indexed by dh within this CTA's K slice.
+      const DType *k_src = qkv_row_smem + kNumSmemQElemPerRow + dh * kQKHeadDim;
+
+      vec_t<float, kNumItemPerThread> data = {0};
+
+      vectorized_load_neox<kQKHeadDim, kNumItemPerThread, kWarpSize>(data, k_src, ilane);
+
+      if constexpr (kNormPolicy == 2) {
+        rms_norm_apply<kNumItemPerThread, kQKHeadDim>(data, smem_k_norm_w, ilane);
       }
-    }
-
-    if constexpr (kNormPolicy == 1) {
-      rms_norm_apply<kNumItemPerThread, kQKHeadDim>(data, smem_k_norm_w, ilane);
-    }
-
-    QType *k_dst = (out_k_ptr != nullptr)
-                       ? out_k_ptr + irow * kNumKVHeads * kQKHeadDim + kv_head * kQKHeadDim
-                       : k_cache_row_start + kv_head * kQKHeadDim;
 
 #pragma unroll
-    for (int r = 0; r < kNumRoundsHalf; ++r) {
-      int i = r * kWarpSize + ilane;
-      if (i < kQKHeadDim / 2) {
-        k_dst[i] = QType(data[r * 2] * k_scale_inv);
-        k_dst[i + kQKHeadDim / 2] = QType(data[r * 2 + 1] * k_scale_inv);
+      for (int r = 0; r < kNumRoundsHalf; ++r) {
+        int i = r * kWarpSize + ilane;
+        if (i < kQKHeadDim / 2) {
+          rope_rotate_pair(data[r * 2], data[r * 2 + 1], smem_cos_sin[iwarp][i],
+                           smem_cos_sin[iwarp][i + kQKHeadDim / 2]);
+        }
+      }
+
+      if constexpr (kNormPolicy == 1) {
+        rms_norm_apply<kNumItemPerThread, kQKHeadDim>(data, smem_k_norm_w, ilane);
+      }
+
+      QType *k_dst = (out_k_ptr != nullptr)
+                         ? out_k_ptr + irow * kNumKVHeads * kQKHeadDim + kv_head * kQKHeadDim
+                         : k_cache_row_start + kv_head * kQKHeadDim;
+
+#pragma unroll
+      for (int r = 0; r < kNumRoundsHalf; ++r) {
+        int i = r * kWarpSize + ilane;
+        if (i < kQKHeadDim / 2) {
+          k_dst[i] = QType(data[r * 2] * k_scale_inv);
+          k_dst[i + kQKHeadDim / 2] = QType(data[r * 2 + 1] * k_scale_inv);
+        }
       }
     }
   }
 
-  // ========= Process V heads (no RoPE, bf16→fp8) =========
+  // ========= Process V heads owned by this CTA (no RoPE, bf16→fp8) =========
   {
     float v_scale_inv = __frcp_rn(v_scale_ptr[0]);
     using LoadDType = __nv_bfloat162;
     using PackQType = __nv_fp8x4_e4m3;
-    constexpr int kNumVElemPerRow = kNumKVHeads * kVHeadDim;
     constexpr int kItemPerThread = 16 / sizeof(DType);
-    static_assert(kNumVElemPerRow % kItemPerThread == 0, "");
-    constexpr int kNumPackPerRow = kNumVElemPerRow / kItemPerThread;
-
-    const DType *v_src = qkv_row + (kNumQHeads + kNumKVHeads) * kQKHeadDim;
-    QType *v_dst = (out_v_ptr != nullptr) ? out_v_ptr + irow * kNumKVHeads * kVHeadDim
-                                          : reinterpret_cast<QType *>(v_cache_row_start);
-
-    constexpr int kNumLoadRound = ceil_div<kNumPackPerRow, kWarpSize>();
+    static_assert(kVHeadDim % kItemPerThread == 0, "kVHeadDim must be divisible by kItemPerThread");
+    constexpr int kNumPackPerHead = kVHeadDim / kItemPerThread;
+    constexpr int kNumLoadRound = ceil_div<kNumPackPerHead, kWarpSize>();
 #pragma unroll
-    for (int r = 0; r < kNumLoadRound; ++r) {
-      int ioffset = (r * kWarpSize + ilane) * kItemPerThread;
-      if (ioffset < kNumVElemPerRow) {
-        auto vec_bf162 = load<LoadDType, kItemPerThread / 2>(v_src + ioffset);
-        auto vec_float = to<float>(vec_bf162);
+    for (int dh = 0; dh < kKVPerCTA; ++dh) {
+      const int kv_head = kv_head_start + dh;
+      const DType *v_src =
+          qkv_row_global + (kNumQHeads + kNumKVHeads) * kQKHeadDim + kv_head * kVHeadDim;
+      QType *v_dst = (out_v_ptr != nullptr)
+                         ? out_v_ptr + irow * kNumKVHeads * kVHeadDim + kv_head * kVHeadDim
+                         : reinterpret_cast<QType *>(v_cache_row_start) + kv_head * kVHeadDim;
 #pragma unroll
-        for (int i = 0; i < size(vec_float); i++) {
-          vec_float[i] = vec_float[i] * v_scale_inv;
+      for (int r = 0; r < kNumLoadRound; ++r) {
+        int ioffset = (r * kWarpSize + ilane) * kItemPerThread;
+        if (ioffset < kVHeadDim) {
+          auto vec_bf162 = load<LoadDType, kItemPerThread / 2>(v_src + ioffset);
+          auto vec_float = to<float>(vec_bf162);
+#pragma unroll
+          for (int i = 0; i < size(vec_float); i++) {
+            vec_float[i] = vec_float[i] * v_scale_inv;
+          }
+          store(v_dst + ioffset, to<PackQType>(vec_float));
         }
-        store(v_dst + ioffset, to<PackQType>(vec_float));
       }
     }
   }
@@ -656,13 +784,23 @@ void launch_rope_norm_store_kv(__nv_bfloat16 *out_q_ptr, __nv_bfloat16 *kcache_p
   constexpr int kWarpSize = 32;
 
   int num_compute_blocks = (num_rows + kWarpsPerBlock - 1) / kWarpsPerBlock;
+  int num_grid_x = num_compute_blocks + num_batch;
+
+  // Each blockIdx.y processes one KV head and its corresponding Q heads.
   dim3 block(kWarpsPerBlock * kWarpSize);
-  dim3 grid(num_compute_blocks + num_batch);  // compute blocks + 1 clear block per request
+  dim3 grid(num_grid_x, kNumKVHeads);
 
   auto launch = [&](auto norm_tag) {
     constexpr int kNP = decltype(norm_tag)::value;
-    kernels::rope_norm_store_kv_kernel<kWarpsPerBlock, kNumQHeads, kNumKVHeads, kQKHeadDim,
-                                       kVHeadDim, kNP><<<grid, block, 0, stream>>>(
+    constexpr int kQPerKV = kNumQHeads / kNumKVHeads;
+    constexpr int kNumSmemElemPerRow = (kQPerKV + 1) * kQKHeadDim;
+    constexpr int kDynSmemBytes = kWarpsPerBlock * kNumSmemElemPerRow * sizeof(__nv_bfloat16);
+    auto *kernel = kernels::rope_norm_store_kv_kernel<kWarpsPerBlock, kNumQHeads, kNumKVHeads,
+                                                      kQKHeadDim, kVHeadDim, kNP>;
+    if constexpr (kDynSmemBytes > 48 * 1024) {
+      cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kDynSmemBytes);
+    }
+    kernel<<<grid, block, kDynSmemBytes, stream>>>(
         out_q_ptr, kcache_ptr, vcache_ptr, out_k_ptr, out_v_ptr, in_qkv_ptr, cos_sin_ptr,
         num_seqlen_per_req_ptr, q_index_ptr, kvcache_indices_ptr, q_norm_weight_ptr,
         k_norm_weight_ptr, kcache_block_offset, vcache_block_offset, num_batch,
@@ -727,14 +865,24 @@ void launch_rope_norm_store_kv_fp8(
   constexpr int kWarpSize = 32;
 
   int num_compute_blocks = (num_rows + kWarpsPerBlock - 1) / kWarpsPerBlock;
+  int num_grid_x = num_compute_blocks + num_batch;
+
+  // Each blockIdx.y processes one KV head and its corresponding Q heads.
   dim3 block(kWarpsPerBlock * kWarpSize);
-  dim3 grid(num_compute_blocks + num_batch);
+  dim3 grid(num_grid_x, kNumKVHeads);
 
   auto launch = [&](auto quant_tag, auto norm_tag) {
     constexpr int kQP = decltype(quant_tag)::value;
     constexpr int kNP = decltype(norm_tag)::value;
-    kernels::rope_norm_store_kv_fp8_kernel<kQP, kWarpsPerBlock, kNumQHeads, kNumKVHeads, kQKHeadDim,
-                                           kVHeadDim, kNP><<<grid, block, 0, stream>>>(
+    constexpr int kQPerKV = kNumQHeads / kNumKVHeads;
+    constexpr int kNumSmemElemPerRow = (kQPerKV + 1) * kQKHeadDim;
+    constexpr int kDynSmemBytes = kWarpsPerBlock * kNumSmemElemPerRow * sizeof(__nv_bfloat16);
+    auto *kernel = kernels::rope_norm_store_kv_fp8_kernel<kQP, kWarpsPerBlock, kNumQHeads,
+                                                          kNumKVHeads, kQKHeadDim, kVHeadDim, kNP>;
+    if constexpr (kDynSmemBytes > 48 * 1024) {
+      cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kDynSmemBytes);
+    }
+    kernel<<<grid, block, kDynSmemBytes, stream>>>(
         out_q_ptr, kcache_ptr, vcache_ptr, out_k_ptr, out_v_ptr, split_k_flag_ptr, q_scale_ptr,
         in_qkv_ptr, cos_sin_ptr, num_seqlen_per_req_ptr, q_index_ptr, kvcache_indices_ptr,
         q_norm_weight_ptr, k_norm_weight_ptr, k_scale_ptr, v_scale_ptr, q_scale_inv_ptr, upper_max,

--- a/tests/test_rope.py
+++ b/tests/test_rope.py
@@ -330,6 +330,7 @@ def test_rope_norm_store_kv_fp8(
 
     assert split_k_flag.shape == (num_seqlen.shape[0], num_kv_heads)
     assert split_k_flag.dtype == torch.int32
+    assert torch.all(split_k_flag[:num_req] == 0)
 
     if quant_policy == 1:  # dqskv: kernel computes dynamic per-token per-head scale
         if is_prefill:


### PR DESCRIPTION
## Summary

Thanks @xiaolong-intel for the work in #61 and for adding the RoPE norm/store-kv benchmark script. Shortly after the first hpc-ops release, we noticed the same performance issue in `rope_norm_store_kv` and made a set of optimizations similar in spirit to #61.

In the optimized implementation, request lookup uses a tiled / fan-out search to find the batch id. Compared with the binary-search approach, this gives a small advantage over binary search under common batch settings. This PR also moves the KV head dimension to `grid.y`, increasing parallelism for small batches and leaving enough room to stage the input Q/K slice in shared memory before the RoPE/norm/store work.

## Changes

- Split work across `grid.y` by KV head; each CTA handles one KV head and its corresponding Q heads.
- Stage the CTA-local Q/K slice in shared memory; V is still streamed from global memory.
- Use the tiled request lookup path for batch-id discovery.
- Add compile-time shape/alignment assertions and clean up naming/comments to match existing code style.
- Add the RoPE norm/store-kv benchmark script from #61, plus a three-way benchmark result record.

## Notes on PR #61 optimization items

- **Batch lookup:** #61 uses binary search to replace the original linear scan. This PR uses a tiled / fan-out search instead; in the common batch settings we tested, it has a small performance edge over the binary-search version.
- **FMA arithmetic:** I evaluated the FMA-style RoPE/RMSNorm arithmetic change from #61, but it did not bring measurable performance gain in this kernel, so this PR keeps the original arithmetic form for readability.
- **Code cleanliness:** I adopted the `vectorized_load_neox` helper from #61 and migrated it into this PR's `grid.y` + shared-memory implementation to deduplicate the Q/K NeoX load path.

## Benchmark

The benchmark script from #61 is included under `benchmark/rope_norm_store_kv/` so the comparison can be reproduced locally.

In our local H20 runs, the current PR is faster than both upstream `main` and PR #61 in every measured case.

| dtype | group | cases | current vs master | current vs PR #61 |
|---|---:|---:|---:|---:|
| BF16 | prefill | 9 | up to 2.33x | up to 2.33x |
| BF16 | decode | 18 | up to 3.52x | up to 2.84x |
| BF16 | all | 27 | up to 3.52x | up to 2.84x |
| FP8 | prefill | 18 | up to 2.17x | up to 2.10x |
| FP8 | decode | 36 | up to 3.04x | up to 2.44x |
| FP8 | all | 54 | up to 3.04x | up to 2.44x |
| ALL | all | 81 | up to 3.52x | up to 2.84x |

## Validation

- Built successfully with `python3 setup.py build`.
- Correctness was validated with 50 seeded runs of `pytest -q --no-header --disable-warnings tests/test_rope.py`; all runs passed (`108 passed` per run).
