### PR TITLE
feat: add qwen3 tts topk gumbel sampler

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -82,6 +82,14 @@ def sanitizer_check(file_name, check):
         raise e
 
 
+def get_hpc_import_path():
+    repo_root = Path(__file__).resolve().parent
+    build_libs = list((repo_root / "build").glob("lib.*/"))
+    if build_libs:
+        return build_libs[0]
+    return repo_root
+
+
 class TraceHook(object):
     def __init__(self, checks, module_name):
         self.checks_ = checks
@@ -103,7 +111,7 @@ class TraceHook(object):
             ret = org_func(*args, **kwargs)
             save_data(tmp_after_invoke_file, "hpc", func_name, ret, args, kwargs)
 
-            pypath = os.path.realpath(list(Path(__file__).parent.glob("./build/lib.*/"))[0])
+            pypath = os.path.realpath(get_hpc_import_path())
             dump_test_py(tmp_py_file, tmp_before_invoke_file, tmp_after_invoke_file, pypath)
             print(tmp_py_file)
 
@@ -123,7 +131,7 @@ class TraceHook(object):
         return True
 
     def hook(self):
-        sys.path.insert(0, os.path.realpath(list(Path(__file__).parent.glob("./build/lib.*/"))[0]))
+        sys.path.insert(0, os.path.realpath(get_hpc_import_path()))
         module = __import__(self.module_name)
 
         dirs = dir(module)

--- a/hpc/__init__.py
+++ b/hpc/__init__.py
@@ -18,6 +18,12 @@ def _discover_modules() -> Dict[str, ModuleType]:
 
         module_name = file.stem
 
+        selected = os.getenv("HPC_OPS_IMPORT_MODULES")
+        if selected:
+            selected_modules = {x.strip() for x in selected.split(",") if x.strip()}
+            if module_name not in selected_modules:
+                continue
+
         try:
             module = importlib.import_module(f".{module_name}", package=__package__)
             modules[module_name] = module
@@ -48,8 +54,18 @@ __all__ = []
 
 _export_functions(_discover_modules())
 
-__version__ = torch.ops.hpc.version()
-__built_json__ = torch.ops.hpc.built_json()
+
+def _call_optional_hpc_op(name: str, default: str) -> str:
+    try:
+        return getattr(torch.ops.hpc, name)()
+    except AttributeError:
+        if os.getenv("HPC_OPS_IMPORT_MODULES"):
+            return default
+        raise
+
+
+__version__ = _call_optional_hpc_op("version", "unknown")
+__built_json__ = _call_optional_hpc_op("built_json", "{}")
 
 __doc__ = """
 High Performance Computing Operators Library

--- a/hpc/sampler.py
+++ b/hpc/sampler.py
@@ -180,3 +180,38 @@ def fused_sampler(
         gumbel_noise,
         seed,
     )
+
+
+def qwen3_tts_topk_gumbel_sample(
+    logits: Tensor,
+    noise: Tensor,
+    topk: int = 50,
+    inv_temperature: float = 1.0,
+) -> Tensor:
+    """Qwen3-TTS short-vocab fused sampler: top-k filter + Gumbel-max.
+
+    Args:
+        logits: Contiguous float32 tensor, shape ``[batch_size, vocab_size]``.
+        noise: Contiguous float32 uniform random tensor in ``(0, 1)``, same shape as logits.
+        topk: Top-k bound; Qwen3-TTS uses 50. Supported range is ``1..64``.
+        inv_temperature: Multiplier applied to logits before Gumbel-max.
+
+    Returns:
+        int64 sampled token ids, shape ``[batch_size, 1]``.
+    """
+    return torch.ops.hpc.qwen3_tts_topk_gumbel_sample(
+        logits,
+        noise,
+        topk,
+        inv_temperature,
+    )
+
+
+@torch.library.register_fake("hpc::qwen3_tts_topk_gumbel_sample")
+def qwen3_tts_topk_gumbel_sample_fake(
+    logits: Tensor,
+    noise: Tensor,
+    topk: int = 50,
+    inv_temperature: float = 1.0,
+):
+    return torch.empty((logits.shape[0], 1), dtype=torch.int64, device=logits.device)

--- a/src/sampler/entry.cc
+++ b/src/sampler/entry.cc
@@ -251,6 +251,37 @@ torch::Tensor fused_sampler_temperature_sample_entry(const torch::Tensor& logits
   return token_ids;
 }
 
+// qwen3_tts_topk_gumbel_sample: Qwen3-TTS short-vocab fast path. Kernel in
+// src/sampler/qwen3_tts_topk_gumbel_sample.cu.
+torch::Tensor qwen3_tts_topk_gumbel_sample_entry(const torch::Tensor& logits,
+                                                 const torch::Tensor& noise, int64_t topk,
+                                                 double inv_temperature) {
+  TORCH_CHECK(logits.is_contiguous(), "logits tensor must be contiguous");
+  TORCH_CHECK(noise.is_contiguous(), "noise tensor must be contiguous");
+  TORCH_CHECK(logits.dim() == 2, "logits tensor must be dim == 2");
+  TORCH_CHECK(noise.sizes() == logits.sizes(), "noise shape must match logits");
+  TORCH_CHECK(logits.scalar_type() == torch::kFloat32, "logits must be float32");
+  TORCH_CHECK(noise.scalar_type() == torch::kFloat32, "noise must be float32");
+  TORCH_CHECK(topk > 0 && topk <= 64, "topk must be in (0, 64]");
+
+  const int batch_size = logits.size(0);
+  const int vocab_size = logits.size(1);
+  const int64_t logits_row_stride = logits.stride(0);
+  TORCH_CHECK(vocab_size <= 2048,
+              "qwen3_tts_topk_gumbel_sample only supports vocab_size <= 2048");
+  TORCH_CHECK(topk <= vocab_size, "topk must be <= vocab_size, got topk=", topk,
+              ", vocab_size=", vocab_size);
+
+  torch::Tensor token_ids =
+      torch::empty({batch_size, 1}, torch::dtype(torch::kInt64).device(logits.device()));
+  auto stream = at::cuda::getCurrentCUDAStream(logits.get_device());
+  qwen3_tts_topk_gumbel_sample_async(
+      token_ids.mutable_data_ptr<int64_t>(), logits.const_data_ptr<float>(),
+      noise.const_data_ptr<float>(), batch_size, vocab_size, static_cast<int>(logits_row_stride),
+      static_cast<int>(topk), static_cast<float>(inv_temperature), stream);
+  return token_ids;
+}
+
 }  // namespace sampler
 }  // namespace hpc
 
@@ -272,4 +303,9 @@ TORCH_LIBRARY_FRAGMENT(hpc, m) {
       "int seed=0) -> Tensor");
   m.impl("fused_sampler_temperature_sample", torch::kCUDA,
          &hpc::sampler::fused_sampler_temperature_sample_entry);
+  m.def(
+      "qwen3_tts_topk_gumbel_sample(Tensor logits, Tensor noise, int topk, "
+      "float inv_temperature) -> Tensor");
+  m.impl("qwen3_tts_topk_gumbel_sample", torch::kCUDA,
+         &hpc::sampler::qwen3_tts_topk_gumbel_sample_entry);
 }

--- a/src/sampler/qwen3_tts_topk_gumbel_sample.cu
+++ b/src/sampler/qwen3_tts_topk_gumbel_sample.cu
@@ -1,0 +1,187 @@
+// Copyright (C) 2026 Tencent.
+//
+// Qwen3-TTS short-vocab fused Gumbel-max top-k sampler.
+//
+// Qwen3-TTS code logits use vocab=2048 and top_k=50.  Reusing the generic
+// large-vocab sampler would launch more blocks per row and materialize a masked
+// logits tensor that the model never consumes.  This kernel keeps one CUDA block
+// per row, materializes only the top-K candidates, then runs Gumbel-max on that
+// compact candidate set.
+
+#include <cuda_runtime_api.h>
+
+#include <cub/cub.cuh>  // NOLINT
+#include <limits>
+
+#include "src/sampler/sampler.h"
+
+namespace hpc {
+namespace sampler {
+namespace qwen3_tts_topk_gumbel_sample_kernels {
+
+constexpr int kWarpSize = 32;
+constexpr float kNegInf = -std::numeric_limits<float>::infinity();
+
+template <int kThreadsPerBlock, int kMaxTopK, int kFixedTopK = 0>
+__global__ void qwen3_tts_topk_gumbel_argmax_kernel(int64_t* out, const float* logits,
+                                                    const float* noise, int vocab_size,
+                                                    int logits_row_stride, int topk,
+                                                    float inv_temperature) {
+  static_assert(kMaxTopK <= 64, "kMaxTopK kept small to stay in registers");
+  static_assert(kThreadsPerBlock >= 64 && kThreadsPerBlock % kWarpSize == 0, "");
+
+  using KV = cub::KeyValuePair<int, float>;
+  using BlockReduce = cub::BlockReduce<KV, kThreadsPerBlock>;
+  __shared__ typename BlockReduce::TempStorage reduce_temp;
+
+  constexpr int kNumWarps = kThreadsPerBlock / kWarpSize;
+  __shared__ float warp_topk[kNumWarps * kMaxTopK];
+  __shared__ int warp_topk_token[kNumWarps * kMaxTopK];
+  __shared__ float topk_logits[kMaxTopK];
+  __shared__ int topk_tokens[kMaxTopK];
+
+  const int ibatch = blockIdx.x;
+  const int tid = threadIdx.x;
+  const int iwarp = tid / kWarpSize;
+  const int ilane = tid % kWarpSize;
+  const float* logits_row = logits + static_cast<int64_t>(ibatch) * logits_row_stride;
+  const float* noise_row = noise + static_cast<int64_t>(ibatch) * vocab_size;
+
+  int actual_topk;
+  if constexpr (kFixedTopK > 0) {
+    actual_topk = kFixedTopK;
+  } else {
+    actual_topk = topk;
+    if (actual_topk > kMaxTopK) actual_topk = kMaxTopK;
+    if (actual_topk > vocab_size) actual_topk = vocab_size;
+  }
+
+  // === [perf sampler-localtopk 2026-06-25] shrink per-thread register list ===
+  // For Qwen3-TTS each thread scans at most ceil(2048/256)=8 tokens.  Keep only
+  // the maximum number of elements a thread can own locally, then merge globally.
+  constexpr int kMaxItemsPerThread = (2048 + kThreadsPerBlock - 1) / kThreadsPerBlock;
+  float per_thread_topk[kMaxItemsPerThread];
+  int per_thread_token[kMaxItemsPerThread];
+#pragma unroll
+  for (int i = 0; i < kMaxItemsPerThread; ++i) {
+    per_thread_topk[i] = kNegInf;
+    per_thread_token[i] = -1;
+  }
+
+  for (int token = tid; token < vocab_size; token += kThreadsPerBlock) {
+    const float val = logits_row[token];
+    if (val <= per_thread_topk[kMaxItemsPerThread - 1]) continue;
+    int j = kMaxItemsPerThread - 1;
+    while (j > 0 && val > per_thread_topk[j - 1]) {
+      per_thread_topk[j] = per_thread_topk[j - 1];
+      per_thread_token[j] = per_thread_token[j - 1];
+      --j;
+    }
+    per_thread_topk[j] = val;
+    per_thread_token[j] = token;
+  }
+
+  // Warp-level merge to get each warp's top-K logits. Equal logits are popped by
+  // the lowest owning lane so only one lane mutates its local list per round.
+  for (int k = 0; k < actual_topk; ++k) {
+    const float candidate = per_thread_topk[0];
+    float best = candidate;
+#pragma unroll
+    for (int offset = kWarpSize / 2; offset > 0; offset >>= 1) {
+      const float other = __shfl_xor_sync(0xffffffff, best, offset);
+      if (other > best) best = other;
+    }
+    const unsigned mask = __ballot_sync(0xffffffff, candidate == best);
+    const int popper = __ffs(mask) - 1;
+    const int candidate_token = per_thread_token[0];
+    const int best_token = __shfl_sync(0xffffffff, candidate_token, popper);
+    if (ilane == 0) {
+      warp_topk[iwarp * kMaxTopK + k] = best;
+      warp_topk_token[iwarp * kMaxTopK + k] = best_token;
+    }
+    if (ilane == popper) {
+#pragma unroll
+      for (int i = 0; i < kMaxItemsPerThread - 1; ++i) {
+        per_thread_topk[i] = per_thread_topk[i + 1];
+        per_thread_token[i] = per_thread_token[i + 1];
+      }
+      per_thread_topk[kMaxItemsPerThread - 1] = kNegInf;
+      per_thread_token[kMaxItemsPerThread - 1] = -1;
+    }
+    __syncwarp();
+  }
+  __syncthreads();
+
+  // CTA-level merge to materialize the exact top-K candidate token ids.
+  if (tid == 0) {
+    int idx_per_warp[kNumWarps];
+#pragma unroll
+    for (int w = 0; w < kNumWarps; ++w) idx_per_warp[w] = 0;
+    for (int k = 0; k < actual_topk; ++k) {
+      float best = kNegInf;
+      int best_w = 0;
+#pragma unroll
+      for (int w = 0; w < kNumWarps; ++w) {
+        if (idx_per_warp[w] < actual_topk) {
+          const float v = warp_topk[w * kMaxTopK + idx_per_warp[w]];
+          if (v > best) {
+            best = v;
+            best_w = w;
+          }
+        }
+      }
+      topk_logits[k] = best;
+      topk_tokens[k] = warp_topk_token[best_w * kMaxTopK + idx_per_warp[best_w]];
+      idx_per_warp[best_w]++;
+    }
+  }
+  __syncthreads();
+
+  // Fused Gumbel-max over the compact top-K candidate set.
+  KV thread_best;
+  thread_best.key = 0;
+  thread_best.value = kNegInf;
+  if (tid < actual_topk) {
+    const int token = topk_tokens[tid];
+    const float val = topk_logits[tid];
+    const float u = fminf(fmaxf(noise_row[token], 1.0e-20f), 1.0f - 1.0e-20f);
+    thread_best.value = val * inv_temperature - logf(-logf(u));
+    thread_best.key = token;
+  }
+  const KV block_best = BlockReduce(reduce_temp).Reduce(thread_best, cub::ArgMax());
+
+  if (tid == 0) {
+    out[ibatch] = static_cast<int64_t>(block_best.key);
+  }
+}
+
+}  // namespace qwen3_tts_topk_gumbel_sample_kernels
+
+void qwen3_tts_topk_gumbel_sample_async(int64_t* token_ids_out, const float* logits_ptr,
+                                        const float* noise_ptr, int batch_size, int vocab_size,
+                                        int logits_row_stride, int topk, float inv_temperature,
+                                        cudaStream_t stream) {
+  constexpr int kThreadsPerBlock = 256;
+  dim3 grid(batch_size);
+  dim3 block(kThreadsPerBlock);
+  if (topk == 50 && vocab_size <= 2048) {
+    // === [perf sampler-topk50 2026-06-25] production-specialized path ===
+    // Compile top_k as a constant and shrink kMaxTopK 64->50.  The generic path
+    // remains available for tests and non-production top_k values.
+    constexpr int kMaxTopK = 50;
+    constexpr int kFixedTopK = 50;
+    qwen3_tts_topk_gumbel_sample_kernels::qwen3_tts_topk_gumbel_argmax_kernel<
+        kThreadsPerBlock, kMaxTopK, kFixedTopK>
+        <<<grid, block, 0, stream>>>(token_ids_out, logits_ptr, noise_ptr, vocab_size,
+                                     logits_row_stride, topk, inv_temperature);
+  } else {
+    constexpr int kMaxTopK = 64;
+    qwen3_tts_topk_gumbel_sample_kernels::qwen3_tts_topk_gumbel_argmax_kernel<
+        kThreadsPerBlock, kMaxTopK>
+        <<<grid, block, 0, stream>>>(token_ids_out, logits_ptr, noise_ptr, vocab_size,
+                                     logits_row_stride, topk, inv_temperature);
+  }
+}
+
+}  // namespace sampler
+}  // namespace hpc

--- a/src/sampler/sampler.h
+++ b/src/sampler/sampler.h
@@ -42,6 +42,11 @@ void fused_sampler_temperature_async(int32_t* token_ids_out, const void* logits_
                                      const int64_t* draft_token_ids_ptr, int batch_size,
                                      int vocab_size, uint64_t rng_seed, cudaStream_t stream);
 
+void qwen3_tts_topk_gumbel_sample_async(int64_t* token_ids_out, const float* logits_ptr,
+                                        const float* noise_ptr, int batch_size, int vocab_size,
+                                        int logits_row_stride, int topk, float inv_temperature,
+                                        cudaStream_t stream);
+
 }  // namespace sampler
 }  // namespace hpc
 

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -9,6 +9,8 @@
    no other feature auto-dispatches to ``fused_sampler_temperature_sample``;
    it supports injected ``gumbel_noise`` (bit-exact) and a ``[B]`` int64
    ``draft_token_ids`` mask.
+3. ``hpc.qwen3_tts_topk_gumbel_sample`` — the short-vocab TTS top-k +
+   Gumbel-max sampler for codec/code logits up to 2048 vocab entries.
 """
 import os
 import sys
@@ -17,7 +19,16 @@ from typing import Optional
 
 import pytest
 
-sys.path.insert(0, os.path.realpath(list(Path(__file__).parent.glob("../build/lib.*/"))[0]))
+
+def _hpc_import_path() -> Path:
+    repo_root = Path(__file__).resolve().parent.parent
+    build_libs = list((repo_root / "build").glob("lib.*/"))
+    if build_libs:
+        return build_libs[0]
+    return repo_root
+
+
+sys.path.insert(0, os.path.realpath(_hpc_import_path()))
 
 import torch
 
@@ -623,3 +634,187 @@ def test_fused_sampler_temperature_distribution(dtype):
     # TV distance between empirical freq and true prob should be small.
     tv = 0.5 * (freq - ref_prob).abs().sum(dim=-1)
     assert (tv < 0.1).all(), f"TV distance too large: {tv.tolist()}"
+
+
+# ===========================================================================
+# (3) Qwen3-TTS short-vocab top-k Gumbel sampler.
+# ===========================================================================
+def ref_qwen3_tts_topk_gumbel_sample(
+    logits: torch.Tensor,
+    noise: torch.Tensor,
+    topk: int,
+    inv_temperature: float,
+) -> torch.Tensor:
+    vals, idx = torch.topk(logits.float(), k=topk, dim=-1, largest=True, sorted=True)
+    cand_noise = torch.gather(noise.float(), 1, idx).clamp(1.0e-20, 1.0 - 1.0e-20)
+    scores = vals * inv_temperature - torch.log(-torch.log(cand_noise))
+    best = torch.argmax(scores, dim=-1, keepdim=True)
+    return torch.gather(idx, 1, best).to(torch.int64)
+
+
+QWEN3_TTS_SAMPLER_VOCABS = [64, 128, 256, 512, 1024, 1536, 2048]
+QWEN3_TTS_SAMPLER_TOPKS = [1, 4, 16, 32, 50, 64]
+QWEN3_TTS_SAMPLER_BATCHES = [1, 4, 8, 16, 32, 64]
+QWEN3_TTS_SAMPLER_INV_TEMPS = [1.0, 1.0 / 0.8, 1.0 / 0.7, 2.0]
+
+
+def _build_qwen3_tts_sampler_cases():
+    cases = []
+    for iv, vocab_size in enumerate(QWEN3_TTS_SAMPLER_VOCABS):
+        for ik, topk in enumerate(QWEN3_TTS_SAMPLER_TOPKS):
+            if topk > vocab_size:
+                continue
+            batch_size = QWEN3_TTS_SAMPLER_BATCHES[(iv + ik) % len(QWEN3_TTS_SAMPLER_BATCHES)]
+            inv_temperature = QWEN3_TTS_SAMPLER_INV_TEMPS[
+                (iv * len(QWEN3_TTS_SAMPLER_TOPKS) + ik) % len(QWEN3_TTS_SAMPLER_INV_TEMPS)
+            ]
+            cases.append(
+                (
+                    f"vocab{vocab_size}_top{topk}_b{batch_size}",
+                    batch_size,
+                    vocab_size,
+                    topk,
+                    inv_temperature,
+                )
+            )
+    return cases
+
+
+QWEN3_TTS_SAMPLER_CASES = _build_qwen3_tts_sampler_cases()
+
+QWEN3_TTS_SAMPLER_BENCH_CASES = [
+    ("vocab64_top64_b8", 8, 64, 64, 1.0),
+    ("vocab256_top16_b8", 8, 256, 16, 1.0 / 0.8),
+    ("vocab512_top16_b1", 1, 512, 16, 1.0),
+    ("vocab512_top50_b16", 16, 512, 50, 1.0 / 0.7),
+    ("vocab1024_top32_b8", 8, 1024, 32, 1.0 / 0.8),
+    ("vocab1024_top64_b32", 32, 1024, 64, 1.0),
+    ("vocab1536_top50_b16", 16, 1536, 50, 1.0 / 0.7),
+    ("vocab2048_top16_b8", 8, 2048, 16, 1.0),
+    ("vocab2048_top50_b1", 1, 2048, 50, 1.0 / 0.7),
+    ("vocab2048_top50_b8", 8, 2048, 50, 1.0 / 0.7),
+    ("vocab2048_top50_b32", 32, 2048, 50, 1.0 / 0.7),
+    ("vocab2048_top64_b64", 64, 2048, 64, 1.0),
+]
+
+
+@pytest.mark.parametrize(
+    "case_name,batch_size,vocab_size,topk,inv_temperature",
+    QWEN3_TTS_SAMPLER_CASES,
+)
+def test_qwen3_tts_topk_gumbel_sample_golden(
+    case_name, batch_size, vocab_size, topk, inv_temperature
+):
+    del case_name
+    torch.manual_seed(0x5150 + batch_size * 17 + vocab_size + topk)
+    logits = torch.randn(batch_size, vocab_size, dtype=torch.float32, device="cuda")
+    noise = torch.rand(batch_size, vocab_size, dtype=torch.float32, device="cuda")
+
+    out = hpc.qwen3_tts_topk_gumbel_sample(logits, noise, topk, inv_temperature)
+    ref = ref_qwen3_tts_topk_gumbel_sample(logits, noise, topk, inv_temperature)
+
+    assert out.shape == (batch_size, 1)
+    assert out.dtype == torch.int64
+    assert torch.equal(out, ref), f"mismatch my={out.flatten()} ref={ref.flatten()}"
+
+
+def _cuda_event_us(fn, warmup: int, iters: int) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) * 1000.0 / iters
+
+
+@pytest.mark.skipif(
+    os.getenv("HPC_OPS_RUN_BENCHMARKS") != "1",
+    reason="set HPC_OPS_RUN_BENCHMARKS=1 to run sampler performance tests",
+)
+@pytest.mark.parametrize(
+    "case_name,batch_size,vocab_size,topk,inv_temperature",
+    QWEN3_TTS_SAMPLER_BENCH_CASES,
+)
+def test_qwen3_tts_topk_gumbel_sample_benchmark(
+    case_name, batch_size, vocab_size, topk, inv_temperature
+):
+    torch.manual_seed(0xBADC0DE + batch_size * 17 + vocab_size + topk)
+    logits = torch.randn(batch_size, vocab_size, dtype=torch.float32, device="cuda").contiguous()
+    noise = torch.rand(batch_size, vocab_size, dtype=torch.float32, device="cuda").contiguous()
+
+    out = hpc.qwen3_tts_topk_gumbel_sample(logits, noise, topk, inv_temperature)
+    ref = ref_qwen3_tts_topk_gumbel_sample(logits, noise, topk, inv_temperature)
+    assert torch.equal(out, ref), f"mismatch before benchmark my={out.flatten()} ref={ref.flatten()}"
+
+    warmup = int(os.getenv("HPC_OPS_BENCH_WARMUP", "100"))
+    iters = int(os.getenv("HPC_OPS_BENCH_ITERS", "1000"))
+
+    def hpc_call():
+        hpc.qwen3_tts_topk_gumbel_sample(logits, noise, topk, inv_temperature)
+
+    def torch_call():
+        ref_qwen3_tts_topk_gumbel_sample(logits, noise, topk, inv_temperature)
+
+    hpc_us = _cuda_event_us(hpc_call, warmup, iters)
+    torch_us = _cuda_event_us(torch_call, warmup, iters)
+    speedup = torch_us / hpc_us if hpc_us > 0 else float("nan")
+    print(
+        f"\nqwen3_tts_topk_gumbel_sample[{case_name}] "
+        f"B={batch_size} V={vocab_size} topk={topk} "
+        f"hpc={hpc_us:.3f}us torch={torch_us:.3f}us speedup={speedup:.2f}x "
+        f"warmup={warmup} iters={iters}"
+    )
+
+
+@pytest.mark.parametrize("bad_topk", [0, 65, 2049])
+def test_qwen3_tts_topk_gumbel_sample_rejects_bad_topk(bad_topk):
+    logits = torch.randn(1, 2048, dtype=torch.float32, device="cuda")
+    noise = torch.rand_like(logits)
+    with pytest.raises((RuntimeError, ValueError)):
+        hpc.qwen3_tts_topk_gumbel_sample(logits, noise, bad_topk, 1.0)
+
+
+def test_qwen3_tts_topk_gumbel_sample_rejects_unsupported_vocab():
+    logits = torch.randn(1, 2049, dtype=torch.float32, device="cuda")
+    noise = torch.rand_like(logits)
+    with pytest.raises((RuntimeError, ValueError)):
+        hpc.qwen3_tts_topk_gumbel_sample(logits, noise, 50, 1.0)
+
+
+@pytest.mark.parametrize("bad_logits_dtype", [torch.float16, torch.bfloat16])
+def test_qwen3_tts_topk_gumbel_sample_rejects_logits_dtype(bad_logits_dtype):
+    logits = torch.randn(1, 2048, dtype=bad_logits_dtype, device="cuda")
+    noise = torch.rand(1, 2048, dtype=torch.float32, device="cuda")
+    with pytest.raises((RuntimeError, ValueError)):
+        hpc.qwen3_tts_topk_gumbel_sample(logits, noise, 50, 1.0)
+
+
+def test_qwen3_tts_topk_gumbel_sample_rejects_noise_dtype():
+    logits = torch.randn(1, 2048, dtype=torch.float32, device="cuda")
+    noise = torch.rand(1, 2048, dtype=torch.bfloat16, device="cuda")
+    with pytest.raises((RuntimeError, ValueError)):
+        hpc.qwen3_tts_topk_gumbel_sample(logits, noise, 50, 1.0)
+
+
+def test_qwen3_tts_topk_gumbel_sample_rejects_noise_shape():
+    logits = torch.randn(2, 2048, dtype=torch.float32, device="cuda")
+    noise = torch.rand(1, 2048, dtype=torch.float32, device="cuda")
+    with pytest.raises((RuntimeError, ValueError)):
+        hpc.qwen3_tts_topk_gumbel_sample(logits, noise, 50, 1.0)
+
+
+@pytest.mark.parametrize("bad_tensor", ["logits", "noise"])
+def test_qwen3_tts_topk_gumbel_sample_rejects_non_contiguous(bad_tensor):
+    logits = torch.randn(2, 4096, dtype=torch.float32, device="cuda")[:, ::2]
+    noise = torch.rand(2, 4096, dtype=torch.float32, device="cuda")[:, ::2]
+    if bad_tensor == "logits":
+        noise = noise.contiguous()
+    else:
+        logits = logits.contiguous()
+    with pytest.raises((RuntimeError, ValueError)):
+        hpc.qwen3_tts_topk_gumbel_sample(logits, noise, 50, 1.0)


### PR DESCRIPTION


## Summary

This PR adds a Qwen3-TTS oriented short-vocab fused sampler operator, `qwen3_tts_topk_gumbel_sample`, for TTS/code-token sampling workloads.

The new op handles standalone logits and pre-generated uniform noise tensors:

- `logits`: `[batch_size, vocab_size]`
- `noise`: `[batch_size, vocab_size]`
- dtype: `float32`
- layout: contiguous
- supported vocab size: `vocab_size <= 2048`
- supported top-k: `1 <= topk <= 64`
- production Qwen3-TTS shape: `vocab_size=2048`, `topk=50`

It returns sampled token ids:

- output: `[batch_size, 1]`
- dtype: `int64`

It exposes:

- Python API: `hpc.qwen3_tts_topk_gumbel_sample`
- Torch op: `torch.ops.hpc.qwen3_tts_topk_gumbel_sample`
- CUDA implementation: `src/sampler/qwen3_tts_topk_gumbel_sample.cu`
- tests/benchmark: `tests/test_sampler.py`

## Motivation

Existing hpc-ops sampler kernels are designed for more general large-vocab sampling flows. The generic `fused_sampler` supports features such as repetition penalty, temperature, softmax policy, top-k, top-p, Gumbel-max sampling, and penalty-mask writeback. It is a feature-rich large-vocab path, but it is not the most direct fit for Qwen3-TTS code-token sampling.

The Qwen3-TTS code predictor path uses a much narrower sampling pattern:

```python
scaled = logits * inv_temperature
topk_vals, topk_idx = torch.topk(scaled, topk)
scores = topk_vals - torch.log(-torch.log(noise[topk_idx]))
token = topk_idx[argmax(scores)]
```

For short TTS vocabularies such as `V <= 2048`, this PyTorch expression introduces multiple CUDA launches and intermediate tensors. Reusing the generic sampler also brings machinery that this path does not need, such as large-vocab multi-block top-k, top-p, softmax policy, repetition penalty, and penalty-mask writeback.

This PR adds a dedicated short-vocab fused sampler for this TTS path.

## What changed

This PR adds a fused CUDA kernel for short-vocab TTS top-k Gumbel sampling:

- fuses top-k candidate selection, Gumbel transform, and argmax into one CUDA launch
- consumes caller-provided uniform random noise, matching the production substitution boundary
- supports vocab sizes up to `2048`
- supports `topk` up to `64`
- includes a production-specialized `topk=50` path
- uses one CUDA block per batch row
- materializes only the compact top-k candidate set
- avoids producing a full masked logits tensor
- keeps the implementation separate from the existing generic `fused_sampler`

The PR also adds minimal-build support used by focused operator validation:

- `HPC_OPS_IMPORT_MODULES=sampler` imports only sampler Python APIs
- missing `version` / `built_json` ops are tolerated only in explicit minimal-import mode
- test import path now supports both `build/lib.*` and in-place `_C.abi3.so`

## Difference from existing sampler

The existing `fused_sampler` is a general sampler for large-vocab decoding. It supports a broad feature set:

- `float32` / `bfloat16` logits
- repetition penalty
- temperature
- softmax before or after top-k
- top-k / top-p
- Gumbel-max
- penalty-mask writeback
- optional internal RNG
- large vocabulary such as `120832`

The new `qwen3_tts_topk_gumbel_sample` is intentionally narrower:

- only `float32` logits
- only external uniform noise
- no top-p
- no softmax policy
- no repetition penalty
- no penalty-mask writeback
- no internal RNG
- short vocab only, `V <= 2048`
- `topk <= 64`

This specialization lets the kernel avoid generic large-vocab sampler overhead and focus on the Qwen3-TTS code-token hot path.

## Test coverage

Correctness is covered with a general TTS short-vocab matrix:

- vocab sizes: `64`, `128`, `256`, `512`, `1024`, `1536`, `2048`
- top-k values: `1`, `4`, `16`, `32`, `50`, `64`
- batch sizes: `1`, `4`, `8`, `16`, `32`, `64`
- multiple `inv_temperature` values
- total golden correctness cases: `42`

It also covers error and boundary cases:

- invalid `topk`
- `vocab_size > 2048`
- unsupported logits dtype
- unsupported noise dtype
- noise shape mismatch
- non-contiguous logits
- non-contiguous noise

Correctness command:

```bash
HPC_OPS_IMPORT_MODULES=sampler pytest tests/test_sampler.py -q -k "qwen3_tts_topk_gumbel_sample and not benchmark"
```

Current result:

```bash
52 passed, 65 deselected
```

## Benchmark

Environment:

- GPU arch: SM90 / H20
- dtype: FP32 logits and FP32 uniform noise
- benchmark boundary: post-noise sampler chain only
- benchmark excludes random noise generation from both HPC and PyTorch paths
- benchmark command:

```bash
HPC_OPS_IMPORT_MODULES=sampler \
HPC_OPS_RUN_BENCHMARKS=1 \
HPC_OPS_BENCH_WARMUP=200 \
HPC_OPS_BENCH_ITERS=2000 \
pytest tests/test_sampler.py -q -s -k qwen3_tts_topk_gumbel_sample_benchmark
```

Benchmark result summary, excluding the removed `topk=1` micro-case:

| shape | batch | vocab | topk | torch us | hpc us | speedup |
|---|---:|---:|---:|---:|---:|---:|
| vocab64_top64 | 8 | 64 | 64 | 59.796 | 30.936 | 1.93x |
| vocab256_top16 | 8 | 256 | 16 | 63.871 | 10.229 | 6.24x |
| vocab512_top16 | 1 | 512 | 16 | 63.259 | 10.679 | 5.92x |
| vocab512_top50 | 16 | 512 | 50 | 60.008 | 16.311 | 3.68x |
| vocab1024_top32 | 8 | 1024 | 32 | 64.171 | 18.845 | 3.41x |
| vocab1024_top64 | 32 | 1024 | 64 | 60.100 | 32.887 | 1.83x |
| vocab1536_top50 | 16 | 1536 | 50 | 60.048 | 18.729 | 3.21x |
| vocab2048_top16 | 8 | 2048 | 16 | 63.633 | 14.461 | 4.40x |
| vocab2048_top50 | 1 | 2048 | 50 | 59.300 | 19.571 | 3.03x |
| vocab2048_top50 | 8 | 2048 | 50 | 60.332 | 19.879 | 3.03x |
| vocab2048_top50 | 32 | 2048 | 50 | 60.148 | 20.078 | 3.00x |
| vocab2048_top64 | 64 | 2048 | 64 | 59.966 | 35.720 | 1.68x |

Across the representative short-vocab TTS matrix, the fused op is faster than the PyTorch reference, with around `1.68x–6.24x` speedup. For the production Qwen3-TTS setting `V=2048, topk=50`, the fused op is stable around `~20us` and about `3.0x` faster than the PyTorch reference across `B=1/8/32`.

## Notes

This operator is intentionally narrower than a fully generic sampler. It currently targets:

- short-vocab TTS/code-token sampling
- `float32` logits
- external uniform noise
- `vocab_size <= 2048`
- `topk <= 64`
- Qwen3-TTS production-style `topk=50`

It does not replace the existing generic `fused_sampler`; it complements it with a specialized fast path for Qwen3-TTS short-vocab sampling.