### PR TITLE
feat: add qwen3 tts rope operator

### DIFF
--- a/hpc/rope.py
+++ b/hpc/rope.py
@@ -234,6 +234,31 @@ def rope_norm_store_kv_fp8(
     )
 
 
+def multimodal_rope(
+    q: Tensor,
+    k: Tensor,
+    cos_sin_cache: Tensor,
+    positions: Tensor,
+    is_neox: bool = True,
+    out_q: Optional[Tensor] = None,
+    out_k: Optional[Tensor] = None,
+) -> Tuple[Tensor, Tensor]:
+    """Apply fused RoPE to dense Q/K tensors while preserving strides."""
+    if (out_q is None) != (out_k is None):
+        raise ValueError("out_q and out_k must be provided together")
+    if out_q is None:
+        return torch.ops.hpc.multimodal_rope(q, k, cos_sin_cache, positions, is_neox)
+    return torch.ops.hpc.multimodal_rope.out(
+        q,
+        k,
+        cos_sin_cache,
+        positions,
+        is_neox,
+        out_q=out_q,
+        out_k=out_k,
+    )
+
+
 @torch.library.register_fake("hpc::rope_norm_store_kv")
 def rope_norm_store_kv_fake(
     key_cache,
@@ -325,3 +350,33 @@ def rope_norm_store_kv_fp8_fake(
         device=qkv.device,
     )
     return (out_q_fp8, q_scale, split_k_flag)
+
+
+@torch.library.register_fake("hpc::multimodal_rope")
+def multimodal_rope_fake(
+    q: Tensor,
+    k: Tensor,
+    cos_sin_cache: Tensor,
+    positions: Tensor,
+    is_neox: bool = True,
+):
+    del cos_sin_cache, positions, is_neox
+    return (
+        torch.empty_strided(q.shape, q.stride(), dtype=q.dtype, device=q.device),
+        torch.empty_strided(k.shape, k.stride(), dtype=k.dtype, device=k.device),
+    )
+
+
+@torch.library.register_fake("hpc::multimodal_rope.out")
+def multimodal_rope_out_fake(
+    q: Tensor,
+    k: Tensor,
+    cos_sin_cache: Tensor,
+    positions: Tensor,
+    is_neox: bool = True,
+    *,
+    out_q: Tensor,
+    out_k: Tensor,
+):
+    del q, k, cos_sin_cache, positions, is_neox
+    return out_q, out_k

--- a/src/rope/entry.cc
+++ b/src/rope/entry.cc
@@ -1,10 +1,13 @@
 // Copyright (C) 2026 Tencent.
 
+#include <ATen/MemoryOverlap.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <cuda_runtime_api.h>
 #include <torch/all.h>
 #include <torch/library.h>
 
+#include <cstdint>
 #include <optional>
 #include <tuple>
 
@@ -216,6 +219,145 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> rope_norm_store_kv_fp8_e
   return std::make_tuple(out_q, q_scale, split_k_flag);
 }
 
+std::tuple<torch::Tensor, torch::Tensor> multimodal_rope_impl(
+    const torch::Tensor &q, const torch::Tensor &k, const torch::Tensor &cos_sin_cache,
+    const torch::Tensor &positions, bool is_neox, std::optional<torch::Tensor> q_out_opt,
+    std::optional<torch::Tensor> k_out_opt) {
+  TORCH_CHECK(q.is_cuda() && k.is_cuda() && cos_sin_cache.is_cuda() && positions.is_cuda(),
+              "q/k/cos_sin_cache/positions must be CUDA tensors");
+  TORCH_CHECK(q.device() == k.device() && q.device() == cos_sin_cache.device() &&
+                  q.device() == positions.device(),
+              "q/k/cos_sin_cache/positions must be on the same CUDA device");
+  c10::cuda::CUDAGuard device_guard(q.device());
+  TORCH_CHECK(q.dim() == 4 && k.dim() == 4, "q/k must be [B,H,S,D]");
+  TORCH_CHECK(cos_sin_cache.dim() == 2, "cos_sin_cache must be [max_position, head_dim]");
+  TORCH_CHECK(positions.dim() == 2, "positions must be [B, S]");
+  TORCH_CHECK(q.scalar_type() == torch::kBFloat16 && k.scalar_type() == torch::kBFloat16,
+              "q/k must be bfloat16");
+  TORCH_CHECK(cos_sin_cache.scalar_type() == torch::kFloat,
+              "cos_sin_cache must be float32");
+  TORCH_CHECK(positions.scalar_type() == torch::kInt64, "positions must be int64");
+  TORCH_CHECK(q.size(0) == k.size(0) && q.size(2) == k.size(2) && q.size(3) == k.size(3),
+              "q/k shape mismatch");
+  TORCH_CHECK(cos_sin_cache.size(1) == q.size(3),
+              "cos_sin_cache last dimension must equal head_dim (first half cos, second half "
+              "sin; not duplicated/expanded per batch or sequence)");
+  TORCH_CHECK(positions.size(0) == q.size(0) && positions.size(1) == q.size(2),
+              "positions shape mismatch, expected [B, S]");
+  const int64_t q_heads = q.size(1);
+  const int64_t kv_heads = k.size(1);
+  const int64_t head_dim = q.size(3);
+  const bool neox_profile =
+      is_neox && (head_dim == 128 || head_dim == 512) &&
+      ((q_heads == 16 && kv_heads == 8) || (q_heads == 28 && kv_heads == 4) ||
+       (q_heads == 32 && kv_heads == 8) || (q_heads == 64 && (kv_heads == 4 || kv_heads == 8)));
+  const bool interleaved_profile =
+      !is_neox && head_dim == 64 && (q_heads == 32 || q_heads == 64) && kv_heads == 1;
+  TORCH_CHECK(neox_profile || interleaved_profile,
+              "multimodal_rope supports NeoX D128/D512 Hq/Hkv 16/8, 28/4, 32/8, "
+              "64/4, 64/8 and interleaved D64 Hq/Hkv 32/1, 64/1");
+  TORCH_CHECK(q.stride(3) == 1 && k.stride(3) == 1,
+              "q/k last dimension must be contiguous");
+  TORCH_CHECK(cos_sin_cache.stride(1) == 1,
+              "cos_sin_cache last dimension must be contiguous");
+  at::assert_no_internal_overlap(q);
+  at::assert_no_internal_overlap(k);
+  for (int64_t dim = 0; dim < q.dim(); ++dim) {
+    TORCH_CHECK(q.size(dim) <= 1 || q.stride(dim) > 0,
+                "q must have positive strides for non-singleton dimensions");
+    TORCH_CHECK(k.size(dim) <= 1 || k.stride(dim) > 0,
+                "k must have positive strides for non-singleton dimensions");
+  }
+
+  auto prepare_output = [](const std::optional<torch::Tensor> &output_opt,
+                           const torch::Tensor &input, const char *name) {
+    if (!output_opt.has_value()) {
+      return torch::empty_strided(input.sizes(), input.strides(), input.options());
+    }
+    torch::Tensor output = output_opt.value();
+    TORCH_CHECK(output.is_cuda(), name, " must be a CUDA tensor");
+    TORCH_CHECK(output.device() == input.device(), name, " must be on the input device");
+    TORCH_CHECK(output.scalar_type() == input.scalar_type(), name, " must match input dtype");
+    TORCH_CHECK(output.sizes() == input.sizes(), name, " must match input shape");
+    TORCH_CHECK(output.stride(3) == 1, name, " last dimension must be contiguous");
+    at::assert_no_internal_overlap(output);
+    for (int64_t dim = 0; dim < output.dim(); ++dim) {
+      TORCH_CHECK(output.size(dim) <= 1 || output.stride(dim) > 0, name,
+                  " must have positive strides for non-singleton dimensions");
+    }
+    return output;
+  };
+  torch::Tensor q_out = prepare_output(q_out_opt, q, "q_out");
+  torch::Tensor k_out = prepare_output(k_out_opt, k, "k_out");
+  const std::uintptr_t tensor_alignment = is_neox ? 4 : 16;
+  const int64_t stride_alignment = is_neox ? 2 : 8;
+  TORCH_CHECK(
+      reinterpret_cast<std::uintptr_t>(q.const_data_ptr()) % tensor_alignment == 0 &&
+          reinterpret_cast<std::uintptr_t>(k.const_data_ptr()) % tensor_alignment == 0 &&
+          reinterpret_cast<std::uintptr_t>(q_out.const_data_ptr()) % tensor_alignment == 0 &&
+          reinterpret_cast<std::uintptr_t>(k_out.const_data_ptr()) % tensor_alignment == 0 &&
+          reinterpret_cast<std::uintptr_t>(cos_sin_cache.const_data_ptr()) % 16 == 0,
+      "multimodal_rope inputs and outputs do not satisfy vector alignment");
+  TORCH_CHECK(
+      q.stride(0) % stride_alignment == 0 && q.stride(1) % stride_alignment == 0 &&
+          q.stride(2) % stride_alignment == 0 && k.stride(0) % stride_alignment == 0 &&
+          k.stride(1) % stride_alignment == 0 && k.stride(2) % stride_alignment == 0 &&
+          q_out.stride(0) % stride_alignment == 0 && q_out.stride(1) % stride_alignment == 0 &&
+          q_out.stride(2) % stride_alignment == 0 && k_out.stride(0) % stride_alignment == 0 &&
+          k_out.stride(1) % stride_alignment == 0 && k_out.stride(2) % stride_alignment == 0 &&
+          cos_sin_cache.stride(0) % 4 == 0,
+      "multimodal_rope inputs and outputs do not satisfy vector stride alignment");
+  if (q_out_opt.has_value()) {
+    at::assert_no_overlap(q_out, q);
+    at::assert_no_overlap(q_out, k);
+    at::assert_no_overlap(q_out, cos_sin_cache);
+    at::assert_no_overlap(q_out, positions);
+  }
+  if (k_out_opt.has_value()) {
+    at::assert_no_overlap(k_out, q);
+    at::assert_no_overlap(k_out, k);
+    at::assert_no_overlap(k_out, cos_sin_cache);
+    at::assert_no_overlap(k_out, positions);
+  }
+  if (q_out_opt.has_value() && k_out_opt.has_value()) {
+    at::assert_no_overlap(q_out, k_out);
+  }
+  if (q.size(0) == 0 || q.size(2) == 0) {
+    return std::make_tuple(q_out, k_out);
+  }
+  MultimodalRopeParams params{q.size(0),           q.size(2),           q.size(1),
+                              k.size(1),           q.size(3),           q.stride(0),
+                              q.stride(1),         q.stride(2),         k.stride(0),
+                              k.stride(1),         k.stride(2),         q_out.stride(0),
+                              q_out.stride(1),     q_out.stride(2),     k_out.stride(0),
+                              k_out.stride(1),     k_out.stride(2),     cos_sin_cache.stride(0),
+                              positions.stride(0), positions.stride(1), is_neox};
+  auto stream = at::cuda::getCurrentCUDAStream(q.get_device());
+  multimodal_rope_async(reinterpret_cast<__nv_bfloat16 *>(q_out.mutable_data_ptr()),
+                        reinterpret_cast<__nv_bfloat16 *>(k_out.mutable_data_ptr()),
+                        reinterpret_cast<const __nv_bfloat16 *>(q.const_data_ptr()),
+                        reinterpret_cast<const __nv_bfloat16 *>(k.const_data_ptr()),
+                        reinterpret_cast<const float *>(cos_sin_cache.const_data_ptr()),
+                        positions.const_data_ptr<int64_t>(), params, stream);
+  const cudaError_t launch_error = cudaGetLastError();
+  TORCH_CHECK(launch_error == cudaSuccess, "multimodal_rope kernel launch failed: ",
+              cudaGetErrorString(launch_error));
+  return std::make_tuple(q_out, k_out);
+}
+
+std::tuple<torch::Tensor, torch::Tensor> multimodal_rope_entry(
+    const torch::Tensor &q, const torch::Tensor &k, const torch::Tensor &cos_sin_cache,
+    const torch::Tensor &positions, bool is_neox) {
+  return multimodal_rope_impl(q, k, cos_sin_cache, positions, is_neox, std::nullopt,
+                              std::nullopt);
+}
+
+std::tuple<torch::Tensor, torch::Tensor> multimodal_rope_out_entry(
+    const torch::Tensor &q, const torch::Tensor &k, const torch::Tensor &cos_sin_cache,
+    const torch::Tensor &positions, bool is_neox, torch::Tensor q_out, torch::Tensor k_out) {
+  return multimodal_rope_impl(q, k, cos_sin_cache, positions, is_neox, q_out, k_out);
+}
+
 }  // namespace rope
 }  // namespace hpc
 
@@ -237,4 +379,13 @@ TORCH_LIBRARY_FRAGMENT(hpc, m) {
       "Tensor? out_q=None, Tensor? out_k=None, Tensor? out_v=None, int qk_norm_policy=0) -> "
       "(Tensor, Tensor, Tensor)");
   m.impl("rope_norm_store_kv_fp8", torch::kCUDA, &hpc::rope::rope_norm_store_kv_fp8_entry);
+
+  m.def(
+      "multimodal_rope(Tensor q, Tensor k, Tensor cos_sin_cache, Tensor positions, "
+      "bool is_neox=True) -> (Tensor, Tensor)");
+  m.impl("multimodal_rope", torch::kCUDA, &hpc::rope::multimodal_rope_entry);
+  m.def(
+      "multimodal_rope.out(Tensor q, Tensor k, Tensor cos_sin_cache, Tensor positions, "
+      "bool is_neox=True, *, Tensor(a!) out_q, Tensor(b!) out_k) -> (Tensor(a!), Tensor(b!))");
+  m.impl("multimodal_rope.out", torch::kCUDA, &hpc::rope::multimodal_rope_out_entry);
 }

--- a/src/rope/multimodal_rope.cu
+++ b/src/rope/multimodal_rope.cu
@@ -1,0 +1,569 @@
+// Copyright (C) 2026 Tencent.
+
+#include <cuda_bf16.h>
+#include <cuda_runtime_api.h>
+#include <stdint.h>
+
+#include "src/rope/rope.h"
+
+namespace hpc {
+namespace rope {
+namespace qk_rope_kernels {
+
+constexpr int kWarpSize = 32;
+
+template <int kHeadDim>
+struct NeoxBf16x2Packs {
+  static constexpr int kPacksPerHalf = kHeadDim / 4;
+  static constexpr int kPacksPerLane = (kPacksPerHalf + kWarpSize - 1) / kWarpSize;
+  float2 first[kPacksPerLane];
+  float2 second[kPacksPerLane];
+};
+
+template <int kHeadDim>
+struct NeoxCachePacks {
+  static constexpr int kPacksPerHalf = kHeadDim / 4;
+  static constexpr int kPacksPerLane = (kPacksPerHalf + kWarpSize - 1) / kWarpSize;
+  float2 cos[kPacksPerLane];
+  float2 sin[kPacksPerLane];
+};
+
+template <int kHeadDim>
+__device__ __forceinline__ NeoxBf16x2Packs<kHeadDim> load_neox_bf16x2(const __nv_bfloat16 *input,
+                                                                      int lane) {
+  static_assert(kHeadDim % 4 == 0);
+  constexpr int kHalfDim = kHeadDim / 2;
+  constexpr int kPacksPerHalf = NeoxBf16x2Packs<kHeadDim>::kPacksPerHalf;
+  constexpr int kPacksPerLane = NeoxBf16x2Packs<kHeadDim>::kPacksPerLane;
+  NeoxBf16x2Packs<kHeadDim> values;
+#pragma unroll
+  for (int round = 0; round < kPacksPerLane; ++round) {
+    const int pack = round * kWarpSize + lane;
+    if (pack < kPacksPerHalf) {
+      const int offset = pack * 2;
+      values.first[round] =
+          __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162 *>(input + offset));
+      values.second[round] =
+          __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162 *>(input + offset + kHalfDim));
+    }
+  }
+  return values;
+}
+
+template <int kHeadDim>
+__device__ __forceinline__ NeoxCachePacks<kHeadDim> load_neox_cache_bf16x2(const float *cache,
+                                                                           int lane) {
+  constexpr int kHalfDim = kHeadDim / 2;
+  constexpr int kPacksPerHalf = NeoxCachePacks<kHeadDim>::kPacksPerHalf;
+  constexpr int kPacksPerLane = NeoxCachePacks<kHeadDim>::kPacksPerLane;
+  NeoxCachePacks<kHeadDim> values;
+#pragma unroll
+  for (int round = 0; round < kPacksPerLane; ++round) {
+    const int pack = round * kWarpSize + lane;
+    if (pack < kPacksPerHalf) {
+      const int offset = pack * 2;
+      values.cos[round] = *reinterpret_cast<const float2 *>(cache + offset);
+      values.sin[round] = *reinterpret_cast<const float2 *>(cache + offset + kHalfDim);
+    }
+  }
+  return values;
+}
+
+template <int kHeadDim>
+__device__ __forceinline__ void rotate_store_neox_bf16x2(__nv_bfloat16 *output,
+                                                         const NeoxBf16x2Packs<kHeadDim> &value,
+                                                         const NeoxCachePacks<kHeadDim> &cache,
+                                                         int lane) {
+  constexpr int kHalfDim = kHeadDim / 2;
+  constexpr int kPacksPerHalf = NeoxBf16x2Packs<kHeadDim>::kPacksPerHalf;
+  constexpr int kPacksPerLane = NeoxBf16x2Packs<kHeadDim>::kPacksPerLane;
+#pragma unroll
+  for (int round = 0; round < kPacksPerLane; ++round) {
+    const int pack = round * kWarpSize + lane;
+    if (pack < kPacksPerHalf) {
+      const int offset = pack * 2;
+      const float2 first = make_float2(__fmaf_rn(-value.second[round].x, cache.sin[round].x,
+                                                 value.first[round].x * cache.cos[round].x),
+                                       __fmaf_rn(-value.second[round].y, cache.sin[round].y,
+                                                 value.first[round].y * cache.cos[round].y));
+      const float2 second = make_float2(__fmaf_rn(value.first[round].x, cache.sin[round].x,
+                                                  value.second[round].x * cache.cos[round].x),
+                                        __fmaf_rn(value.first[round].y, cache.sin[round].y,
+                                                  value.second[round].y * cache.cos[round].y));
+      *reinterpret_cast<__nv_bfloat162 *>(output + offset) = __float22bfloat162_rn(first);
+      *reinterpret_cast<__nv_bfloat162 *>(output + offset + kHalfDim) =
+          __float22bfloat162_rn(second);
+    }
+  }
+}
+
+template <int kNumQHeads, int kNumKvHeads, int kHeadDim, int kWarpsPerBlock,
+          bool kUsePrefetch = false>
+__global__ void qk_rope_gqa_token_kernel(__nv_bfloat16 *q_output, __nv_bfloat16 *k_output,
+                                         const __nv_bfloat16 *q_input, const __nv_bfloat16 *k_input,
+                                         const float *cos_sin_cache, const int64_t *positions,
+                                         MultimodalRopeParams params) {
+  static_assert(kNumQHeads % kNumKvHeads == 0);
+  static_assert(kWarpsPerBlock == kNumKvHeads);
+  static_assert(kHeadDim % 4 == 0);
+
+  const int64_t batch = blockIdx.y;
+  const int64_t sequence = blockIdx.x;
+  const int kv_head = threadIdx.x / kWarpSize;
+  const int lane = threadIdx.x % kWarpSize;
+  constexpr int kQHeadsPerKvHead = kNumQHeads / kNumKvHeads;
+
+  if constexpr (kUsePrefetch) {
+    static_assert(kQHeadsPerKvHead >= 16);
+    const int64_t q_group_stride = static_cast<int64_t>(kNumKvHeads) * params.q_s1;
+    const int64_t qo_group_stride = static_cast<int64_t>(kNumKvHeads) * params.qo_s1;
+    const __nv_bfloat16 *q_row =
+        q_input + batch * params.q_s0 + kv_head * params.q_s1 + sequence * params.q_s2;
+    __nv_bfloat16 *q_out_row =
+        q_output + batch * params.qo_s0 + kv_head * params.qo_s1 + sequence * params.qo_s2;
+    NeoxBf16x2Packs<kHeadDim> current = load_neox_bf16x2<kHeadDim>(q_row, lane);
+
+    const int64_t position = positions[batch * params.pos_s0 + sequence * params.pos_s1];
+    const NeoxCachePacks<kHeadDim> cache_values =
+        load_neox_cache_bf16x2<kHeadDim>(cos_sin_cache + position * params.cache_s0, lane);
+
+#pragma unroll 1
+    for (int q_group = 1; q_group < kQHeadsPerKvHead; ++q_group) {
+      q_row += q_group_stride;
+      const NeoxBf16x2Packs<kHeadDim> next = load_neox_bf16x2<kHeadDim>(q_row, lane);
+      rotate_store_neox_bf16x2<kHeadDim>(q_out_row, current, cache_values, lane);
+      q_out_row += qo_group_stride;
+      current = next;
+    }
+    rotate_store_neox_bf16x2<kHeadDim>(q_out_row, current, cache_values, lane);
+
+    const __nv_bfloat16 *k_row =
+        k_input + batch * params.k_s0 + kv_head * params.k_s1 + sequence * params.k_s2;
+    __nv_bfloat16 *k_out_row =
+        k_output + batch * params.ko_s0 + kv_head * params.ko_s1 + sequence * params.ko_s2;
+    const NeoxBf16x2Packs<kHeadDim> k_value = load_neox_bf16x2<kHeadDim>(k_row, lane);
+    rotate_store_neox_bf16x2<kHeadDim>(k_out_row, k_value, cache_values, lane);
+  } else {
+    NeoxBf16x2Packs<kHeadDim> q_values[kQHeadsPerKvHead];
+    __nv_bfloat16 *q_out_rows[kQHeadsPerKvHead];
+#pragma unroll
+    for (int q_group = 0; q_group < kQHeadsPerKvHead; ++q_group) {
+      const int q_head = kv_head + q_group * kNumKvHeads;
+      const __nv_bfloat16 *q_row =
+          q_input + batch * params.q_s0 + q_head * params.q_s1 + sequence * params.q_s2;
+      q_out_rows[q_group] =
+          q_output + batch * params.qo_s0 + q_head * params.qo_s1 + sequence * params.qo_s2;
+      q_values[q_group] = load_neox_bf16x2<kHeadDim>(q_row, lane);
+    }
+
+    const __nv_bfloat16 *k_row =
+        k_input + batch * params.k_s0 + kv_head * params.k_s1 + sequence * params.k_s2;
+    __nv_bfloat16 *k_out_row =
+        k_output + batch * params.ko_s0 + kv_head * params.ko_s1 + sequence * params.ko_s2;
+    const NeoxBf16x2Packs<kHeadDim> k_value = load_neox_bf16x2<kHeadDim>(k_row, lane);
+
+    const int64_t position = positions[batch * params.pos_s0 + sequence * params.pos_s1];
+    const NeoxCachePacks<kHeadDim> cache_values =
+        load_neox_cache_bf16x2<kHeadDim>(cos_sin_cache + position * params.cache_s0, lane);
+
+#pragma unroll
+    for (int q_group = 0; q_group < kQHeadsPerKvHead; ++q_group) {
+      rotate_store_neox_bf16x2<kHeadDim>(q_out_rows[q_group], q_values[q_group], cache_values,
+                                         lane);
+    }
+    rotate_store_neox_bf16x2<kHeadDim>(k_out_row, k_value, cache_values, lane);
+  }
+}
+
+template <int kNumQHeads, int kNumKvHeads, int kHeadDim, int kWarpsPerBlock>
+__global__ void qk_rope_gqa_split_warp_token_kernel(
+    __nv_bfloat16 *q_output, __nv_bfloat16 *k_output, const __nv_bfloat16 *q_input,
+    const __nv_bfloat16 *k_input, const float *cos_sin_cache, const int64_t *positions,
+    MultimodalRopeParams params) {
+  static_assert(kNumQHeads % kNumKvHeads == 0);
+  static_assert(kWarpsPerBlock % kNumKvHeads == 0);
+  static_assert(kHeadDim % 4 == 0);
+  constexpr int kWarpsPerKvHead = kWarpsPerBlock / kNumKvHeads;
+  constexpr int kQHeadsPerKvHead = kNumQHeads / kNumKvHeads;
+  static_assert(kQHeadsPerKvHead % kWarpsPerKvHead == 0);
+  constexpr int kQHeadsPerWarp = kQHeadsPerKvHead / kWarpsPerKvHead;
+  static_assert(kWarpsPerKvHead > 1);
+
+  const int64_t batch = blockIdx.y;
+  const int64_t sequence = blockIdx.x;
+  const int warp = threadIdx.x / kWarpSize;
+  const int kv_head = warp % kNumKvHeads;
+  const int warp_in_group = warp / kNumKvHeads;
+  const int lane = threadIdx.x % kWarpSize;
+
+  NeoxBf16x2Packs<kHeadDim> q_values[kQHeadsPerWarp];
+  __nv_bfloat16 *q_out_rows[kQHeadsPerWarp];
+#pragma unroll
+  for (int local_head = 0; local_head < kQHeadsPerWarp; ++local_head) {
+    const int q_group = warp_in_group + local_head * kWarpsPerKvHead;
+    const int q_head = kv_head + q_group * kNumKvHeads;
+    const __nv_bfloat16 *q_row =
+        q_input + batch * params.q_s0 + q_head * params.q_s1 + sequence * params.q_s2;
+    q_out_rows[local_head] =
+        q_output + batch * params.qo_s0 + q_head * params.qo_s1 + sequence * params.qo_s2;
+    q_values[local_head] = load_neox_bf16x2<kHeadDim>(q_row, lane);
+  }
+
+  const bool writes_k = warp_in_group == 0;
+  NeoxBf16x2Packs<kHeadDim> k_value;
+  __nv_bfloat16 *k_out_row = nullptr;
+  if (writes_k) {
+    const __nv_bfloat16 *k_row =
+        k_input + batch * params.k_s0 + kv_head * params.k_s1 + sequence * params.k_s2;
+    k_out_row = k_output + batch * params.ko_s0 + kv_head * params.ko_s1 + sequence * params.ko_s2;
+    k_value = load_neox_bf16x2<kHeadDim>(k_row, lane);
+  }
+
+  const int64_t position = positions[batch * params.pos_s0 + sequence * params.pos_s1];
+  const NeoxCachePacks<kHeadDim> cache_values =
+      load_neox_cache_bf16x2<kHeadDim>(cos_sin_cache + position * params.cache_s0, lane);
+
+#pragma unroll
+  for (int local_head = 0; local_head < kQHeadsPerWarp; ++local_head) {
+    rotate_store_neox_bf16x2<kHeadDim>(q_out_rows[local_head], q_values[local_head], cache_values,
+                                       lane);
+  }
+  if (writes_k) {
+    rotate_store_neox_bf16x2<kHeadDim>(k_out_row, k_value, cache_values, lane);
+  }
+}
+
+template <int kNumQHeads, int kNumKvHeads, int kHeadDim>
+__global__ void qk_rope_gqa_neox_group_parallel_kernel(
+    __nv_bfloat16 *q_output, __nv_bfloat16 *k_output, const __nv_bfloat16 *q_input,
+    const __nv_bfloat16 *k_input, const float *cos_sin_cache, const int64_t *positions,
+    MultimodalRopeParams params) {
+  static_assert(kNumQHeads % kNumKvHeads == 0);
+  static_assert(kHeadDim % (kWarpSize * 4) == 0);
+  constexpr int kQHeadsPerKvHead = kNumQHeads / kNumKvHeads;
+  constexpr int kHalfDim = kHeadDim / 2;
+  constexpr int kPacksPerHalf = kHeadDim / 4;
+  constexpr int kPacksPerTile = kWarpSize;
+  constexpr int kTilesPerHead = kPacksPerHalf / kPacksPerTile;
+
+  const int64_t sequence = blockIdx.x;
+  const int64_t batch = blockIdx.y;
+  const int kv_head = blockIdx.z / kTilesPerHead;
+  const int tile = blockIdx.z % kTilesPerHead;
+  const int head_in_group = threadIdx.x / kWarpSize;
+  const int lane = threadIdx.x % kWarpSize;
+  const int pack = tile * kPacksPerTile + lane;
+  const int offset = pack * 2;
+
+  const __nv_bfloat16 *input_row;
+  __nv_bfloat16 *output_row;
+  if (head_in_group < kQHeadsPerKvHead) {
+    const int q_head = kv_head + head_in_group * kNumKvHeads;
+    input_row = q_input + batch * params.q_s0 + q_head * params.q_s1 + sequence * params.q_s2;
+    output_row = q_output + batch * params.qo_s0 + q_head * params.qo_s1 + sequence * params.qo_s2;
+  } else {
+    input_row = k_input + batch * params.k_s0 + kv_head * params.k_s1 + sequence * params.k_s2;
+    output_row = k_output + batch * params.ko_s0 + kv_head * params.ko_s1 + sequence * params.ko_s2;
+  }
+  const float2 first =
+      __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162 *>(input_row + offset));
+  const float2 second =
+      __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162 *>(input_row + kHalfDim + offset));
+
+  const int64_t position = positions[batch * params.pos_s0 + sequence * params.pos_s1];
+  const float *cache = cos_sin_cache + position * params.cache_s0;
+  const float2 cos = *reinterpret_cast<const float2 *>(cache + offset);
+  const float2 sin = *reinterpret_cast<const float2 *>(cache + kHalfDim + offset);
+
+  const float2 first_out = make_float2(__fmaf_rn(-second.x, sin.x, first.x * cos.x),
+                                       __fmaf_rn(-second.y, sin.y, first.y * cos.y));
+  const float2 second_out = make_float2(__fmaf_rn(first.x, sin.x, second.x * cos.x),
+                                        __fmaf_rn(first.y, sin.y, second.y * cos.y));
+  *reinterpret_cast<__nv_bfloat162 *>(output_row + offset) = __float22bfloat162_rn(first_out);
+  *reinterpret_cast<__nv_bfloat162 *>(output_row + kHalfDim + offset) =
+      __float22bfloat162_rn(second_out);
+}
+
+template <typename T, int kSize>
+struct alignas(sizeof(T) * kSize) AlignedVector {
+  T values[kSize];
+};
+
+template <int kNumQHeads, int kNumKvHeads, int kHeadDim, int kRowsPerBlock, int kThreadsPerRow,
+          int kItemsPerThread>
+__global__ __launch_bounds__(kRowsPerBlock *kThreadsPerRow) void qk_rope_interleaved_rows_kernel(
+    __nv_bfloat16 *q_output, __nv_bfloat16 *k_output, const __nv_bfloat16 *q_input,
+    const __nv_bfloat16 *k_input, const float *cos_sin_cache, const int64_t *positions,
+    MultimodalRopeParams params) {
+  static_assert(kHeadDim % 2 == 0);
+  static_assert(kHeadDim == kThreadsPerRow * kItemsPerThread);
+  static_assert(kItemsPerThread % 2 == 0);
+  static_assert(kRowsPerBlock * kThreadsPerRow <= 1024);
+  static_assert(kNumQHeads > 0 && kNumKvHeads > 0);
+  constexpr int kHalfDim = kHeadDim / 2;
+  constexpr int kPairsPerThread = kItemsPerThread / 2;
+  using Bf16Vector = AlignedVector<__nv_bfloat162, kPairsPerThread>;
+  using CacheVector = AlignedVector<float, kPairsPerThread>;
+
+  const int row = threadIdx.y;
+  const int lane = threadIdx.x;
+  const int64_t batch = static_cast<int64_t>(blockIdx.z) * kRowsPerBlock + row;
+  if (batch >= params.batch_size) {
+    return;
+  }
+  const int64_t sequence = blockIdx.x;
+  const int64_t position = positions[batch * params.pos_s0 + sequence * params.pos_s1];
+  const float *cache = cos_sin_cache + position * params.cache_s0;
+
+  const __nv_bfloat16 *input_row;
+  __nv_bfloat16 *output_row;
+  if (blockIdx.y < kNumQHeads) {
+    const int q_head = blockIdx.y;
+    input_row = q_input + batch * params.q_s0 + q_head * params.q_s1 + sequence * params.q_s2;
+    output_row = q_output + batch * params.qo_s0 + q_head * params.qo_s1 + sequence * params.qo_s2;
+  } else {
+    const int kv_head = blockIdx.y - kNumQHeads;
+    input_row = k_input + batch * params.k_s0 + kv_head * params.k_s1 + sequence * params.k_s2;
+    output_row = k_output + batch * params.ko_s0 + kv_head * params.ko_s1 + sequence * params.ko_s2;
+  }
+  const int pair_offset = lane * kPairsPerThread;
+  union ValueStorage {
+    Bf16Vector vector;
+    int4 words;
+  } values;
+  values.words = *reinterpret_cast<const int4 *>(input_row + lane * kItemsPerThread);
+  const CacheVector cos_values = *reinterpret_cast<const CacheVector *>(cache + pair_offset);
+  const CacheVector sin_values =
+      *reinterpret_cast<const CacheVector *>(cache + kHalfDim + pair_offset);
+#pragma unroll
+  for (int item = 0; item < kPairsPerThread; ++item) {
+    const float2 value = __bfloat1622float2(values.vector.values[item]);
+    const float2 rotated =
+        make_float2(__fmaf_rn(-value.y, sin_values.values[item], value.x * cos_values.values[item]),
+                    __fmaf_rn(value.x, sin_values.values[item], value.y * cos_values.values[item]));
+    values.vector.values[item] = __float22bfloat162_rn(rotated);
+  }
+  asm volatile("st.global.v4.u32 [%0], {%1, %2, %3, %4};"
+               :
+               : "l"(output_row + lane * kItemsPerThread), "r"(values.words.x), "r"(values.words.y),
+                 "r"(values.words.z), "r"(values.words.w));
+}
+
+}  // namespace qk_rope_kernels
+
+namespace {
+
+bool is_aligned_4(const void *pointer) {
+  return (reinterpret_cast<uintptr_t>(pointer) & 0x3U) == 0;
+}
+
+bool is_aligned_16(const void *pointer) {
+  return (reinterpret_cast<uintptr_t>(pointer) & 0xFU) == 0;
+}
+
+bool is_even(int64_t value) { return (value & 1) == 0; }
+
+template <int kNumQHeads, int kNumKvHeads, int kHeadDim, bool kIsNeox>
+bool can_use_qk_rope_profile(const __nv_bfloat16 *q_output, const __nv_bfloat16 *k_output,
+                             const __nv_bfloat16 *q_input, const __nv_bfloat16 *k_input,
+                             const float *cos_sin_cache, const MultimodalRopeParams &params) {
+  return params.head_dim == kHeadDim && params.num_q_heads == kNumQHeads &&
+         params.num_kv_heads == kNumKvHeads && params.is_neox == kIsNeox &&
+         is_aligned_4(q_output) && is_aligned_4(k_output) && is_aligned_4(q_input) &&
+         is_aligned_4(k_input) && is_aligned_16(cos_sin_cache) && is_even(params.q_s0) &&
+         is_even(params.q_s1) && is_even(params.q_s2) && is_even(params.k_s0) &&
+         is_even(params.k_s1) && is_even(params.k_s2) && is_even(params.qo_s0) &&
+         is_even(params.qo_s1) && is_even(params.qo_s2) && is_even(params.ko_s0) &&
+         is_even(params.ko_s1) && is_even(params.ko_s2) && params.cache_s0 % 4 == 0;
+}
+
+template <int kNumQHeads, int kNumKvHeads, int kHeadDim, bool kUsePrefetch = false>
+void launch_qk_rope_gqa_neox(__nv_bfloat16 *q_output, __nv_bfloat16 *k_output,
+                             const __nv_bfloat16 *q_input, const __nv_bfloat16 *k_input,
+                             const float *cos_sin_cache, const int64_t *positions,
+                             const MultimodalRopeParams &params, cudaStream_t stream) {
+  static_assert(kNumQHeads % kNumKvHeads == 0);
+  constexpr int kWarpsPerBlock = kNumKvHeads;
+  dim3 grid(static_cast<uint32_t>(params.seq_len), static_cast<uint32_t>(params.batch_size));
+  dim3 block(kWarpsPerBlock * qk_rope_kernels::kWarpSize);
+  qk_rope_kernels::qk_rope_gqa_token_kernel<kNumQHeads, kNumKvHeads, kHeadDim, kWarpsPerBlock,
+                                            kUsePrefetch><<<grid, block, 0, stream>>>(
+      q_output, k_output, q_input, k_input, cos_sin_cache, positions, params);
+}
+
+template <int kNumQHeads, int kNumKvHeads, int kHeadDim, int kWarpsPerBlock>
+void launch_qk_rope_gqa_neox_split_warps(__nv_bfloat16 *q_output, __nv_bfloat16 *k_output,
+                                         const __nv_bfloat16 *q_input, const __nv_bfloat16 *k_input,
+                                         const float *cos_sin_cache, const int64_t *positions,
+                                         const MultimodalRopeParams &params, cudaStream_t stream) {
+  static_assert(kNumQHeads % kNumKvHeads == 0);
+  static_assert(kWarpsPerBlock % kNumKvHeads == 0);
+  dim3 grid(static_cast<uint32_t>(params.seq_len), static_cast<uint32_t>(params.batch_size));
+  dim3 block(kWarpsPerBlock * qk_rope_kernels::kWarpSize);
+  qk_rope_kernels::qk_rope_gqa_split_warp_token_kernel<kNumQHeads, kNumKvHeads, kHeadDim,
+                                                       kWarpsPerBlock><<<grid, block, 0, stream>>>(
+      q_output, k_output, q_input, k_input, cos_sin_cache, positions, params);
+}
+
+template <int kNumQHeads, int kNumKvHeads, int kHeadDim>
+void launch_qk_rope_gqa_neox_group_parallel(__nv_bfloat16 *q_output, __nv_bfloat16 *k_output,
+                                            const __nv_bfloat16 *q_input,
+                                            const __nv_bfloat16 *k_input,
+                                            const float *cos_sin_cache, const int64_t *positions,
+                                            const MultimodalRopeParams &params,
+                                            cudaStream_t stream) {
+  static_assert(kNumQHeads % kNumKvHeads == 0);
+  static_assert(kHeadDim % (qk_rope_kernels::kWarpSize * 4) == 0);
+  constexpr int kTilesPerHead = kHeadDim / (qk_rope_kernels::kWarpSize * 4);
+  constexpr int kQHeadsPerKvHead = kNumQHeads / kNumKvHeads;
+  constexpr int kHeadsPerGroup = kQHeadsPerKvHead + 1;
+  dim3 grid(static_cast<uint32_t>(params.seq_len), static_cast<uint32_t>(params.batch_size),
+            kNumKvHeads * kTilesPerHead);
+  dim3 block(kHeadsPerGroup * qk_rope_kernels::kWarpSize);
+  qk_rope_kernels::qk_rope_gqa_neox_group_parallel_kernel<kNumQHeads, kNumKvHeads, kHeadDim>
+      <<<grid, block, 0, stream>>>(q_output, k_output, q_input, k_input, cos_sin_cache, positions,
+                                   params);
+}
+
+template <int kNumQHeads, int kNumKvHeads, int kHeadDim, int kRowsPerBlock, int kItemsPerThread>
+void launch_qk_rope_interleaved(__nv_bfloat16 *q_output, __nv_bfloat16 *k_output,
+                                const __nv_bfloat16 *q_input, const __nv_bfloat16 *k_input,
+                                const float *cos_sin_cache, const int64_t *positions,
+                                const MultimodalRopeParams &params, cudaStream_t stream) {
+  static_assert(kHeadDim % kItemsPerThread == 0);
+  constexpr int kThreadsPerRow = kHeadDim / kItemsPerThread;
+  const uint32_t row_blocks =
+      static_cast<uint32_t>((params.batch_size + kRowsPerBlock - 1) / kRowsPerBlock);
+  dim3 grid(static_cast<uint32_t>(params.seq_len), kNumQHeads + kNumKvHeads, row_blocks);
+  dim3 block(kThreadsPerRow, kRowsPerBlock);
+  qk_rope_kernels::qk_rope_interleaved_rows_kernel<kNumQHeads, kNumKvHeads, kHeadDim, kRowsPerBlock,
+                                                   kThreadsPerRow, kItemsPerThread>
+      <<<grid, block, 0, stream>>>(q_output, k_output, q_input, k_input, cos_sin_cache, positions,
+                                   params);
+}
+
+template <int kNumQHeads, int kNumKvHeads, int kHeadDim>
+bool try_launch_grouped_neox(__nv_bfloat16 *q_output, __nv_bfloat16 *k_output,
+                             const __nv_bfloat16 *q_input, const __nv_bfloat16 *k_input,
+                             const float *cos_sin_cache, const int64_t *positions,
+                             const MultimodalRopeParams &params, cudaStream_t stream) {
+  if (!can_use_qk_rope_profile<kNumQHeads, kNumKvHeads, kHeadDim, true>(
+          q_output, k_output, q_input, k_input, cos_sin_cache, params)) {
+    return false;
+  }
+  constexpr int64_t kGroupParallelMaxTokens = 32;
+  const int64_t num_tokens = params.batch_size * params.seq_len;
+  if (num_tokens <= kGroupParallelMaxTokens) {
+    launch_qk_rope_gqa_neox_group_parallel<kNumQHeads, kNumKvHeads, kHeadDim>(
+        q_output, k_output, q_input, k_input, cos_sin_cache, positions, params, stream);
+  } else {
+    launch_qk_rope_gqa_neox<kNumQHeads, kNumKvHeads, kHeadDim>(
+        q_output, k_output, q_input, k_input, cos_sin_cache, positions, params, stream);
+  }
+  return true;
+}
+
+template <int kNumQHeads, int kNumKvHeads, int kHeadDim>
+bool try_launch_parallel_neox(__nv_bfloat16 *q_output, __nv_bfloat16 *k_output,
+                              const __nv_bfloat16 *q_input, const __nv_bfloat16 *k_input,
+                              const float *cos_sin_cache, const int64_t *positions,
+                              const MultimodalRopeParams &params, cudaStream_t stream) {
+  if (!can_use_qk_rope_profile<kNumQHeads, kNumKvHeads, kHeadDim, true>(
+          q_output, k_output, q_input, k_input, cos_sin_cache, params)) {
+    return false;
+  }
+  launch_qk_rope_gqa_neox_group_parallel<kNumQHeads, kNumKvHeads, kHeadDim>(
+      q_output, k_output, q_input, k_input, cos_sin_cache, positions, params, stream);
+  return true;
+}
+
+}  // namespace
+
+void multimodal_rope_async(__nv_bfloat16 *q_output, __nv_bfloat16 *k_output,
+                           const __nv_bfloat16 *q_input, const __nv_bfloat16 *k_input,
+                           const float *cos_sin_cache, const int64_t *positions,
+                           const MultimodalRopeParams &params, cudaStream_t stream) {
+  const int64_t num_tokens = params.batch_size * params.seq_len;
+  constexpr int kNeoxHeadDim = 128;
+  if (can_use_qk_rope_profile<16, 8, kNeoxHeadDim, true>(q_output, k_output, q_input, k_input,
+                                                         cos_sin_cache, params)) {
+    launch_qk_rope_gqa_neox<16, 8, kNeoxHeadDim>(q_output, k_output, q_input, k_input,
+                                                 cos_sin_cache, positions, params, stream);
+    return;
+  }
+
+  if (try_launch_grouped_neox<28, 4, kNeoxHeadDim>(q_output, k_output, q_input, k_input,
+                                                   cos_sin_cache, positions, params, stream)) {
+    return;
+  }
+  if (try_launch_grouped_neox<32, 8, kNeoxHeadDim>(q_output, k_output, q_input, k_input,
+                                                   cos_sin_cache, positions, params, stream)) {
+    return;
+  }
+  if (try_launch_grouped_neox<64, 8, kNeoxHeadDim>(q_output, k_output, q_input, k_input,
+                                                   cos_sin_cache, positions, params, stream)) {
+    return;
+  }
+
+  if (can_use_qk_rope_profile<64, 4, kNeoxHeadDim, true>(q_output, k_output, q_input, k_input,
+                                                         cos_sin_cache, params)) {
+    constexpr int64_t kGroupParallelMaxTokens = 32;
+    constexpr int64_t kSplitWarpMaxTokens = 256;
+    constexpr int64_t kPrefetchMaxTokens = 512;
+    if (num_tokens <= kGroupParallelMaxTokens) {
+      launch_qk_rope_gqa_neox_group_parallel<64, 4, kNeoxHeadDim>(
+          q_output, k_output, q_input, k_input, cos_sin_cache, positions, params, stream);
+    } else if (num_tokens <= kSplitWarpMaxTokens) {
+      launch_qk_rope_gqa_neox_split_warps<64, 4, kNeoxHeadDim, 8>(
+          q_output, k_output, q_input, k_input, cos_sin_cache, positions, params, stream);
+    } else if (num_tokens <= kPrefetchMaxTokens) {
+      launch_qk_rope_gqa_neox<64, 4, kNeoxHeadDim, true>(q_output, k_output, q_input, k_input,
+                                                         cos_sin_cache, positions, params, stream);
+    } else {
+      launch_qk_rope_gqa_neox<64, 4, kNeoxHeadDim>(q_output, k_output, q_input, k_input,
+                                                   cos_sin_cache, positions, params, stream);
+    }
+    return;
+  }
+
+  constexpr int kNeoxHeadDim512 = 512;
+  if (try_launch_parallel_neox<16, 8, kNeoxHeadDim512>(q_output, k_output, q_input, k_input,
+                                                       cos_sin_cache, positions, params, stream) ||
+      try_launch_parallel_neox<28, 4, kNeoxHeadDim512>(q_output, k_output, q_input, k_input,
+                                                       cos_sin_cache, positions, params, stream) ||
+      try_launch_parallel_neox<32, 8, kNeoxHeadDim512>(q_output, k_output, q_input, k_input,
+                                                       cos_sin_cache, positions, params, stream) ||
+      try_launch_parallel_neox<64, 8, kNeoxHeadDim512>(q_output, k_output, q_input, k_input,
+                                                       cos_sin_cache, positions, params, stream) ||
+      try_launch_parallel_neox<64, 4, kNeoxHeadDim512>(q_output, k_output, q_input, k_input,
+                                                       cos_sin_cache, positions, params, stream)) {
+    return;
+  }
+
+  constexpr int kInterleavedHeadDim = 64;
+  if (can_use_qk_rope_profile<64, 1, kInterleavedHeadDim, false>(q_output, k_output, q_input,
+                                                                 k_input, cos_sin_cache, params)) {
+    constexpr int kItemsPerThread = 8;
+    if (params.batch_size <= 8) {
+      constexpr int kRowsPerBlock = 8;
+      launch_qk_rope_interleaved<64, 1, kInterleavedHeadDim, kRowsPerBlock, kItemsPerThread>(
+          q_output, k_output, q_input, k_input, cos_sin_cache, positions, params, stream);
+    } else {
+      constexpr int kRowsPerBlock = 16;
+      launch_qk_rope_interleaved<64, 1, kInterleavedHeadDim, kRowsPerBlock, kItemsPerThread>(
+          q_output, k_output, q_input, k_input, cos_sin_cache, positions, params, stream);
+    }
+    return;
+  }
+  if (can_use_qk_rope_profile<32, 1, kInterleavedHeadDim, false>(q_output, k_output, q_input,
+                                                                 k_input, cos_sin_cache, params)) {
+    constexpr int kRowsPerBlock = 16;
+    constexpr int kItemsPerThread = 8;
+    launch_qk_rope_interleaved<32, 1, kInterleavedHeadDim, kRowsPerBlock, kItemsPerThread>(
+        q_output, k_output, q_input, k_input, cos_sin_cache, positions, params, stream);
+    return;
+  }
+}
+
+}  // namespace rope
+}  // namespace hpc

--- a/src/rope/rope.h
+++ b/src/rope/rope.h
@@ -35,6 +35,35 @@ void rope_norm_store_kv_fp8_async(
     int kv_block_size, int num_rows, int num_q_heads, int num_kv_heads, int qk_head_dim,
     int v_head_dim, bool is_prefill, int qk_norm_policy, int quant_policy, cudaStream_t stream);
 
+struct MultimodalRopeParams {
+  int64_t batch_size;
+  int64_t seq_len;
+  int64_t num_q_heads;
+  int64_t num_kv_heads;
+  int64_t head_dim;
+  int64_t q_s0;
+  int64_t q_s1;
+  int64_t q_s2;
+  int64_t k_s0;
+  int64_t k_s1;
+  int64_t k_s2;
+  int64_t qo_s0;
+  int64_t qo_s1;
+  int64_t qo_s2;
+  int64_t ko_s0;
+  int64_t ko_s1;
+  int64_t ko_s2;
+  int64_t cache_s0;
+  int64_t pos_s0;
+  int64_t pos_s1;
+  bool is_neox;
+};
+
+void multimodal_rope_async(__nv_bfloat16 *q_out, __nv_bfloat16 *k_out,
+                           const __nv_bfloat16 *q, const __nv_bfloat16 *k,
+                           const float *cos_sin_cache, const int64_t *positions,
+                           const MultimodalRopeParams &params, cudaStream_t stream);
+
 }  // namespace rope
 }  // namespace hpc
 

--- a/tests/test_multimodal_rope.py
+++ b/tests/test_multimodal_rope.py
@@ -1,0 +1,554 @@
+# Copyright (C) 2026 Tencent.
+"""Multimodal RoPE tests and FlashInfer benchmark."""
+
+import math
+import os
+import statistics
+import sys
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+import pytest
+import torch
+
+_build_libs = list(Path(__file__).parent.glob("../build/lib.*/"))
+if not _build_libs:
+    raise RuntimeError("build library not found; run setup.py build first")
+sys.path.insert(0, os.path.realpath(_build_libs[0]))
+
+import hpc  # noqa: E402
+
+
+@dataclass(frozen=True)
+class RopeCase:
+    profile: str
+    stage: str
+    batch_size: int
+    seq_len: int
+    num_q_heads: int
+    num_kv_heads: int
+    head_dim: int
+    is_neox: bool
+
+    @property
+    def case_id(self) -> str:
+        return f"{self.profile}-{self.stage}-b{self.batch_size}-s{self.seq_len}"
+
+
+ROPE_PROFILES = (
+    ("hq16-hkv8-d128-neox", 16, 8, 128, True),
+    ("hq28-hkv4-d128-neox", 28, 4, 128, True),
+    ("hq32-hkv8-d128-neox", 32, 8, 128, True),
+    ("hq64-hkv8-d128-neox", 64, 8, 128, True),
+    ("hq64-hkv4-d128-neox", 64, 4, 128, True),
+    ("hq16-hkv8-d512-neox", 16, 8, 512, True),
+    ("hq28-hkv4-d512-neox", 28, 4, 512, True),
+    ("hq32-hkv8-d512-neox", 32, 8, 512, True),
+    ("hq64-hkv8-d512-neox", 64, 8, 512, True),
+    ("hq64-hkv4-d512-neox", 64, 4, 512, True),
+    ("hq32-hkv1-d64-interleaved", 32, 1, 64, False),
+    ("hq64-hkv1-d64-interleaved", 64, 1, 64, False),
+)
+
+
+def make_cases(batches: tuple[int, ...], seq_lens: tuple[int, ...]) -> list[RopeCase]:
+    cases = []
+    for profile, q_heads, kv_heads, head_dim, is_neox in ROPE_PROFILES:
+        for batch_size in batches:
+            for seq_len in seq_lens:
+                cases.append(
+                    RopeCase(
+                        profile=profile,
+                        stage="decode" if seq_len == 1 else "chunk-prefill",
+                        batch_size=batch_size,
+                        seq_len=seq_len,
+                        num_q_heads=q_heads,
+                        num_kv_heads=kv_heads,
+                        head_dim=head_dim,
+                        is_neox=is_neox,
+                    )
+                )
+    return cases
+
+
+TEST_CASES = make_cases((8, 32, 128), (1, 4, 16))
+
+
+def make_cache_and_positions(
+    batch_size: int,
+    seq_len: int,
+    head_dim: int,
+    rope_theta: float = 1_000_000.0,
+    position_base: int = 11,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    frequency_ids = torch.arange(0, head_dim, 2, dtype=torch.float32, device="cuda")
+    inv_freq = 1.0 / rope_theta ** (frequency_ids / head_dim)
+    max_position = position_base + seq_len + 1
+    positions = torch.arange(
+        position_base,
+        position_base + seq_len,
+        dtype=torch.int64,
+        device="cuda",
+    ).unsqueeze(0)
+    positions = positions.expand(batch_size, -1).contiguous()
+    all_positions = torch.arange(max_position, dtype=torch.float32, device="cuda")
+    frequencies = torch.outer(all_positions, inv_freq)
+    cache = torch.cat((frequencies.cos(), frequencies.sin()), dim=-1)
+    return cache, positions
+
+
+def make_inputs(
+    case: RopeCase,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    q_bshd = torch.randn(
+        (
+            case.batch_size,
+            case.seq_len,
+            case.num_q_heads,
+            case.head_dim,
+        ),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    k_bshd = torch.randn(
+        (
+            case.batch_size,
+            case.seq_len,
+            case.num_kv_heads,
+            case.head_dim,
+        ),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    cache, positions = make_cache_and_positions(case.batch_size, case.seq_len, case.head_dim)
+    return q_bshd.transpose(1, 2), k_bshd.transpose(1, 2), cache, positions
+
+
+def flashinfer_inputs(
+    case: RopeCase,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    q_flat = q.transpose(1, 2).reshape(-1, case.num_q_heads * case.head_dim)
+    k_flat = k.transpose(1, 2).reshape(-1, case.num_kv_heads * case.head_dim)
+    return positions.reshape(-1), q_flat.contiguous(), k_flat.contiguous()
+
+
+def _rotate_half(x: torch.Tensor, is_neox: bool) -> torch.Tensor:
+    if is_neox:
+        first, second = x.chunk(2, dim=-1)
+        return torch.cat((-second, first), dim=-1)
+    even = x[..., ::2]
+    odd = x[..., 1::2]
+    return torch.stack((-odd, even), dim=-1).reshape_as(x)
+
+
+def reference_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cache: torch.Tensor,
+    positions: torch.Tensor,
+    is_neox: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    half_dim = cache.shape[-1] // 2
+    gathered = cache[positions]
+    cos_half = gathered[..., :half_dim]
+    sin_half = gathered[..., half_dim:]
+    if is_neox:
+        cos = torch.cat((cos_half, cos_half), dim=-1)
+        sin = torch.cat((sin_half, sin_half), dim=-1)
+    else:
+        cos = cos_half.repeat_interleave(2, dim=-1)
+        sin = sin_half.repeat_interleave(2, dim=-1)
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+    q_float = q.float()
+    k_float = k.float()
+    q_out = q_float * cos + _rotate_half(q_float, is_neox) * sin
+    k_out = k_float * cos + _rotate_half(k_float, is_neox) * sin
+    return q_out, k_out
+
+
+@pytest.mark.parametrize("case", TEST_CASES, ids=lambda case: case.case_id)
+def test_multimodal_rope_matches_reference(case: RopeCase) -> None:
+    torch.manual_seed(0x20260803 + case.batch_size + case.seq_len)
+    q, k, cache, positions = make_inputs(case)
+    expected_q, expected_k = reference_rope(q, k, cache, positions, case.is_neox)
+
+    actual_q, actual_k = hpc.multimodal_rope(q, k, cache, positions, case.is_neox)
+
+    assert actual_q.stride() == q.stride()
+    assert actual_k.stride() == k.stride()
+    torch.testing.assert_close(actual_q.float(), expected_q, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(actual_k.float(), expected_k, atol=1e-2, rtol=1e-2)
+
+
+def _representative_case() -> RopeCase:
+    return RopeCase("hq32-hkv8-d128-neox", "chunk-prefill", 8, 4, 32, 8, 128, True)
+
+
+def test_multimodal_rope_preallocated_outputs() -> None:
+    case = _representative_case()
+    q, k, cache, positions = make_inputs(case)
+    expected_q, expected_k = reference_rope(q, k, cache, positions, True)
+    q_storage = torch.empty((*q.shape[:-1], q.shape[-1] + 2), dtype=q.dtype, device=q.device)
+    k_storage = torch.empty((*k.shape[:-1], k.shape[-1] + 2), dtype=k.dtype, device=k.device)
+    q_out = torch.as_strided(q_storage, q.shape, q_storage.stride())
+    k_out = torch.as_strided(k_storage, k.shape, k_storage.stride())
+
+    returned_q, returned_k = hpc.multimodal_rope(
+        q,
+        k,
+        cache,
+        positions,
+        True,
+        out_q=q_out,
+        out_k=k_out,
+    )
+
+    assert returned_q.data_ptr() == q_out.data_ptr()
+    assert returned_k.data_ptr() == k_out.data_ptr()
+    torch.testing.assert_close(returned_q.float(), expected_q, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(returned_k.float(), expected_k, atol=1e-2, rtol=1e-2)
+
+
+def test_multimodal_rope_requires_both_outputs() -> None:
+    case = _representative_case()
+    q, k, cache, positions = make_inputs(case)
+    q_out = torch.empty_strided(q.shape, q.stride(), dtype=q.dtype, device=q.device)
+    with pytest.raises(ValueError, match="provided together"):
+        hpc.multimodal_rope(q, k, cache, positions, out_q=q_out)
+
+
+def test_multimodal_rope_rejects_unsupported_profile() -> None:
+    case = RopeCase("unsupported", "decode", 8, 1, 12, 4, 128, True)
+    q, k, cache, positions = make_inputs(case)
+    with pytest.raises(RuntimeError, match="supports NeoX"):
+        hpc.multimodal_rope(q, k, cache, positions)
+
+
+@pytest.mark.parametrize(
+    ("transform", "message"),
+    (
+        (lambda q, k, cache, positions: (q.float(), k, cache, positions), "bfloat16"),
+        (
+            lambda q, k, cache, positions: (
+                q,
+                k,
+                cache.to(torch.bfloat16),
+                positions,
+            ),
+            "float32",
+        ),
+        (
+            lambda q, k, cache, positions: (
+                q,
+                k,
+                cache,
+                positions.to(torch.int32),
+            ),
+            "int64",
+        ),
+    ),
+)
+def test_multimodal_rope_rejects_bad_dtypes(transform, message: str) -> None:
+    q, k, cache, positions = make_inputs(_representative_case())
+    q, k, cache, positions = transform(q, k, cache, positions)
+    with pytest.raises(RuntimeError, match=message):
+        hpc.multimodal_rope(q, k, cache, positions)
+
+
+def test_multimodal_rope_rejects_strided_last_dimension() -> None:
+    q, k, cache, positions = make_inputs(_representative_case())
+    q = torch.empty((*q.shape, 2), dtype=q.dtype, device=q.device)[..., 0]
+    with pytest.raises(RuntimeError, match="last dimension"):
+        hpc.multimodal_rope(q, k, cache, positions)
+
+
+def test_multimodal_rope_rejects_input_output_overlap() -> None:
+    q, k, cache, positions = make_inputs(_representative_case())
+    k_out = torch.empty_strided(k.shape, k.stride(), dtype=k.dtype, device=k.device)
+    with pytest.raises(RuntimeError):
+        hpc.multimodal_rope(q, k, cache, positions, out_q=q, out_k=k_out)
+
+
+def _leading_strided(shape: tuple[int, ...], dtype: torch.dtype) -> torch.Tensor:
+    storage_shape = (*shape[:-1], shape[-1] + 8)
+    storage = torch.randn(storage_shape, dtype=dtype, device="cuda")
+    return torch.as_strided(storage, shape, storage.stride())
+
+
+def test_multimodal_rope_large_strided_layout() -> None:
+    q = _leading_strided((32, 16, 32, 128), torch.bfloat16)
+    k = _leading_strided((32, 8, 32, 128), torch.bfloat16)
+    cache, positions = make_cache_and_positions(32, 32, 128)
+    expected_q, expected_k = reference_rope(q, k, cache, positions, True)
+
+    actual_q, actual_k = hpc.multimodal_rope(q, k, cache, positions)
+
+    assert actual_q.stride() == q.stride()
+    assert actual_k.stride() == k.stride()
+    torch.testing.assert_close(actual_q.float(), expected_q, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(actual_k.float(), expected_k, atol=1e-2, rtol=1e-2)
+
+
+def test_multimodal_rope_supports_strided_leading_dimensions() -> None:
+    q = _leading_strided((2, 16, 17, 128), torch.bfloat16)
+    k = _leading_strided((2, 8, 17, 128), torch.bfloat16)
+    cache = _leading_strided((20, 128), torch.float32)
+    position_storage = torch.zeros((2, 34), dtype=torch.int64, device="cuda")
+    positions = torch.as_strided(position_storage, (2, 17), (34, 2))
+    positions.copy_(torch.arange(1, 18, dtype=torch.int64, device="cuda").expand(2, -1))
+    expected_q, expected_k = reference_rope(q, k, cache, positions, True)
+
+    actual_q, actual_k = hpc.multimodal_rope(q, k, cache, positions)
+
+    assert not q.is_contiguous()
+    assert not k.is_contiguous()
+    assert not cache.is_contiguous()
+    assert not positions.is_contiguous()
+    torch.testing.assert_close(actual_q.float(), expected_q, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(actual_k.float(), expected_k, atol=1e-2, rtol=1e-2)
+
+
+def test_multimodal_rope_rejects_wrong_cache_width() -> None:
+    q, k, cache, positions = make_inputs(_representative_case())
+    with pytest.raises(RuntimeError, match="last dimension"):
+        hpc.multimodal_rope(q, k, cache[:, :64], positions)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two GPUs")
+def test_multimodal_rope_uses_input_device() -> None:
+    case = _representative_case()
+    with torch.cuda.device(1):
+        q, k, cache, positions = make_inputs(case)
+        expected_q, expected_k = reference_rope(q, k, cache, positions, True)
+    with torch.cuda.device(0):
+        actual_q, actual_k = hpc.multimodal_rope(q, k, cache, positions)
+    assert actual_q.device == q.device
+    assert actual_k.device == k.device
+    torch.testing.assert_close(actual_q.float(), expected_q, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(actual_k.float(), expected_k, atol=1e-2, rtol=1e-2)
+
+
+def test_multimodal_rope_rejects_overlapping_input_layout() -> None:
+    case = _representative_case()
+    q, k, cache, positions = make_inputs(case)
+    q_overlap = q[:, :1].expand(-1, case.num_q_heads, -1, -1)
+    with pytest.raises(RuntimeError):
+        hpc.multimodal_rope(q_overlap, k, cache, positions)
+
+
+def test_multimodal_rope_rejects_output_output_overlap() -> None:
+    q, k, cache, positions = make_inputs(_representative_case())
+    storage = torch.empty(q.numel(), dtype=q.dtype, device=q.device)
+    q_out = storage.view(q.shape)
+    k_out = storage[: k.numel()].view(k.shape)
+    with pytest.raises(RuntimeError):
+        hpc.multimodal_rope(q, k, cache, positions, out_q=q_out, out_k=k_out)
+
+
+BENCH_WARMUP = int(os.getenv("HPC_OPS_BENCH_WARMUP", "500"))
+BENCH_ITERS = int(os.getenv("HPC_OPS_BENCH_ITERS", "500"))
+BENCH_REPEATS = int(os.getenv("HPC_OPS_BENCH_REPEATS", "8"))
+BENCH_GRAPH_CALLS = int(os.getenv("HPC_OPS_BENCH_GRAPH_CALLS", "16"))
+BENCH_CASES = make_cases((8, 16, 32, 64, 128), (1, 2, 4, 8, 16))
+
+
+def _package_version(*names: str) -> str:
+    for name in names:
+        try:
+            return version(name)
+        except PackageNotFoundError:
+            pass
+    return "unknown"
+
+
+def _geomean(values: list[float]) -> float:
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def _capture_graph(fn) -> torch.cuda.CUDAGraph:
+    for _ in range(BENCH_WARMUP):
+        fn()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        for _ in range(BENCH_GRAPH_CALLS):
+            fn()
+    torch.cuda.synchronize()
+    return graph
+
+
+def _time_graph(graph: torch.cuda.CUDAGraph) -> float:
+    samples = []
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    graph.replay()
+    torch.cuda.synchronize()
+    for _ in range(BENCH_REPEATS):
+        start.record()
+        for _ in range(BENCH_ITERS):
+            graph.replay()
+        end.record()
+        torch.cuda.synchronize()
+        samples.append(start.elapsed_time(end) * 1000.0 / BENCH_ITERS / BENCH_GRAPH_CALLS)
+    return statistics.median(samples)
+
+
+def _verify_benchmark_outputs(
+    case: RopeCase,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cache: torch.Tensor,
+    positions: torch.Tensor,
+    q_out: torch.Tensor,
+    k_out: torch.Tensor,
+    q_flat_out: torch.Tensor,
+    k_flat_out: torch.Tensor,
+) -> None:
+    expected_q, expected_k = reference_rope(q, k, cache, positions, case.is_neox)
+    flashinfer_q = q_flat_out.view(
+        case.batch_size,
+        case.seq_len,
+        case.num_q_heads,
+        case.head_dim,
+    ).transpose(1, 2)
+    flashinfer_k = k_flat_out.view(
+        case.batch_size,
+        case.seq_len,
+        case.num_kv_heads,
+        case.head_dim,
+    ).transpose(1, 2)
+    for actual, expected in (
+        (q_out, expected_q),
+        (k_out, expected_k),
+        (flashinfer_q, expected_q),
+        (flashinfer_k, expected_k),
+    ):
+        torch.testing.assert_close(actual.float(), expected, atol=2e-2, rtol=1e-2)
+
+
+def _benchmark_case(case: RopeCase, flashinfer_rope, reverse: bool) -> dict:
+    torch.manual_seed(0xBADC0DE + case.batch_size * 17 + case.seq_len)
+    q, k, cache, positions = make_inputs(case)
+    positions_flat, q_flat, k_flat = flashinfer_inputs(case, q, k, positions)
+    q_out = torch.empty_strided(q.shape, q.stride(), dtype=q.dtype, device=q.device)
+    k_out = torch.empty_strided(k.shape, k.stride(), dtype=k.dtype, device=k.device)
+    q_flat_out = torch.empty_like(q_flat)
+    k_flat_out = torch.empty_like(k_flat)
+    q_flat = q_flat.view(-1, case.num_q_heads, case.head_dim)
+    k_flat = k_flat.view(-1, case.num_kv_heads, case.head_dim)
+    q_flat_out_3d = q_flat_out.view(-1, case.num_q_heads, case.head_dim)
+    k_flat_out_3d = k_flat_out.view(-1, case.num_kv_heads, case.head_dim)
+
+    def hpc_call() -> None:
+        hpc.multimodal_rope(
+            q,
+            k,
+            cache,
+            positions,
+            case.is_neox,
+            out_q=q_out,
+            out_k=k_out,
+        )
+
+    def flashinfer_call() -> None:
+        flashinfer_rope._apply_rope_pos_ids_cos_sin_cache(
+            q_flat,
+            k_flat,
+            q_flat_out_3d,
+            k_flat_out_3d,
+            cache,
+            positions_flat,
+            interleave=not case.is_neox,
+        )
+
+    hpc_call()
+    flashinfer_call()
+    _verify_benchmark_outputs(
+        case,
+        q,
+        k,
+        cache,
+        positions,
+        q_out,
+        k_out,
+        q_flat_out,
+        k_flat_out,
+    )
+    if reverse:
+        flashinfer_graph = _capture_graph(flashinfer_call)
+        hpc_graph = _capture_graph(hpc_call)
+        flashinfer_us = _time_graph(flashinfer_graph)
+        hpc_us = _time_graph(hpc_graph)
+    else:
+        hpc_graph = _capture_graph(hpc_call)
+        flashinfer_graph = _capture_graph(flashinfer_call)
+        hpc_us = _time_graph(hpc_graph)
+        flashinfer_us = _time_graph(flashinfer_graph)
+    return {
+        "case": case,
+        "hpc_us": hpc_us,
+        "flashinfer_us": flashinfer_us,
+        "speedup": flashinfer_us / hpc_us,
+    }
+
+
+def _print_benchmark_result(result: dict) -> None:
+    case = result["case"]
+    print(
+        f"profile={case.profile:<31} stage={case.stage:<13} "
+        f"B={case.batch_size:<3} S={case.seq_len:<2} "
+        f"hpc_amortized={result['hpc_us']:7.3f}us "
+        f"flashinfer_amortized={result['flashinfer_us']:7.3f}us "
+        f"speedup={result['speedup']:5.2f}x"
+    )
+
+
+def _print_benchmark_summary(results: list[dict]) -> None:
+    print("\nSummary")
+    groups = sorted({(result["case"].profile, result["case"].stage) for result in results})
+    for profile, stage in groups:
+        speedups = [
+            result["speedup"]
+            for result in results
+            if result["case"].profile == profile and result["case"].stage == stage
+        ]
+        print(
+            f"profile={profile:<31} stage={stage:<13} "
+            f"geomean={_geomean(speedups):.3f}x "
+            f"min={min(speedups):.3f}x n={len(speedups)}"
+        )
+    speedups = [result["speedup"] for result in results]
+    print(
+        f"overall geomean={_geomean(speedups):.3f}x "
+        f"min={min(speedups):.3f}x max={max(speedups):.3f}x "
+        f"n={len(speedups)}"
+    )
+
+
+@pytest.mark.skipif(
+    os.getenv("HPC_OPS_RUN_BENCHMARK") != "1",
+    reason="set HPC_OPS_RUN_BENCHMARK=1 to run the performance benchmark",
+)
+def test_multimodal_rope_benchmark() -> None:
+    flashinfer_rope = pytest.importorskip("flashinfer.rope")
+
+    major, minor = torch.cuda.get_device_capability()
+    print(
+        f"gpu={torch.cuda.get_device_name()} sm={major}{minor} "
+        f"torch={torch.__version__} cuda={torch.version.cuda} "
+        f"flashinfer={_package_version('flashinfer-python', 'flashinfer')} "
+        f"warmup={BENCH_WARMUP} iters={BENCH_ITERS} "
+        f"repeats={BENCH_REPEATS} graph_calls={BENCH_GRAPH_CALLS} "
+        f"metric=amortized_us cases={len(BENCH_CASES)}"
+    )
+    results = []
+    for index, case in enumerate(BENCH_CASES):
+        result = _benchmark_case(case, flashinfer_rope, bool(index % 2))
+        results.append(result)
+        _print_benchmark_result(result)
+    _print_benchmark_summary(results)


### PR DESCRIPTION
## Summary

This PR adds a Qwen3-TTS oriented NeoX RoPE operator, `qwen3_tts_rope`, for short-sequence TTS/code-group workloads.

The new op handles standalone Q/K tensors:

- `q`: `[B, num_q_heads, seq_len, head_dim]`
- `k`: `[B, num_kv_heads, seq_len, head_dim]`
- `cos/sin`: `[B, seq_len, head_dim]`
- dtype: `bfloat16`
- currently specialized for `head_dim=128`
- layout: NeoX-style `rotate_half`
- supported layout: leading dimensions may be strided, but the last dimension must be contiguous

It returns contiguous rotated Q/K tensors and exposes:

- Python API: `hpc.qwen3_tts_rope`
- Torch op: `torch.ops.hpc.qwen3_tts_rope`
- CUDA implementation: `src/rope/qwen3_tts_rope.cu`
- tests/benchmark: `tests/test_tts_rope.py`

## Motivation

Existing hpc-ops RoPE kernels are optimized for attention/KV-cache paths, especially packed QKV + KV-cache store flows such as `rope_norm_store_kv` and `rope_norm_store_kv_fp8`.

Those kernels are not a direct fit for TTS short-sequence code-predictor style workloads where Q and K are already materialized as separate tensors and the caller only needs NeoX RoPE applied to standalone Q/K tensors.

For this TTS path, the PyTorch expression:

```python
q_out = (q * cos) + (rotate_half(q) * sin)
k_out = (k * cos) + (rotate_half(k) * sin)
```

introduces multiple elementwise ops, intermediate tensors, and launch/dispatch overhead. This overhead is especially visible for short sequence lengths such as `S=8/16/17/32`.

## What changed

This PR adds a dedicated fused CUDA kernel for TTS NeoX RoPE:

- fuses Q and K RoPE into a single CUDA launch
- supports GQA/MQA/no-GQA style head layouts via separate `num_q_heads` and `num_kv_heads`
- supports strided leading dimensions for Q/K/cos/sin tensors
- requires the last dimension of Q/K/cos/sin to be contiguous
- writes contiguous Q/K outputs
- uses row-packed CTA scheduling:
  - `bs <= 1`: `64 threads/row x 4 rows/CTA`
  - `bs > 1`: `32 threads/row x 8 rows/CTA`
- uses a BF16x2 fast path for aligned `bs > 1` inputs to reduce global load/store and conversion overhead
- broadcasts per-row metadata inside the BF16x2 path to avoid repeating row index decomposition across all lanes
- keeps a scalar fallback path for unsupported alignment/stride cases
- keeps the implementation separate from existing KV-cache RoPE kernels

The PR also adds explicit input validation for the supported layout:

```cpp
q.stride(3) == 1
k.stride(3) == 1
cos.stride(2) == 1
sin.stride(2) == 1
```

The test/benchmark matrix covers representative TTS-like shapes:

- `qwen3_tts`: `S=16, Hq=16, Hkv=8`
- `qwen3_tts_full_groups`: `S=17, Hq=16, Hkv=8`
- `small_tts`: `S=8, Hq=8, Hkv=4`
- `gqa1`: `S=17, Hq=16, Hkv=1`
- `no_gqa`: `S=16, Hq=8, Hkv=8`
- `wide_heads`: `S=32, Hq=32, Hkv=8`

## Benchmark

Environment:

- GPU arch: SM90 / H20
- dtype: BF16
- op shape: standalone Q/K NeoX RoPE
- benchmark command:

```bash
HPC_OPS_ROPE_ONLY_LOAD=1 python3 tests/test_tts_rope.py --bench --iters 500 --warmup 50
```

Correctness:

```bash
HPC_OPS_ROPE_ONLY_LOAD=1 pytest tests/test_tts_rope.py -q
# 20 passed
```

Benchmark result summary:

| shape | batch | rows | eager us | torch.compile us | triton us | hpc us | compile / hpc | triton / hpc |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| qwen3_tts | 1 | 384 | 66.45 | 32.66 | 23.05 | 6.83 | 4.78x | 3.38x |
| qwen3_tts | 8 | 3072 | 66.75 | 32.40 | 23.16 | 6.98 | 4.64x | 3.32x |
| qwen3_tts | 32 | 12288 | 66.44 | 32.04 | 23.37 | 6.86 | 4.67x | 3.40x |
| qwen3_tts_full_groups | 1 | 408 | 66.60 | 33.18 | 23.08 | 6.77 | 4.90x | 3.41x |
| qwen3_tts_full_groups | 8 | 3264 | 66.51 | 32.25 | 23.37 | 6.97 | 4.63x | 3.35x |
| qwen3_tts_full_groups | 32 | 13056 | 65.93 | 32.19 | 23.42 | 6.86 | 4.69x | 3.41x |
| small_tts | 1 | 96 | 66.82 | 32.61 | 23.31 | 6.79 | 4.80x | 3.43x |
| small_tts | 8 | 768 | 66.55 | 32.28 | 23.25 | 6.79 | 4.75x | 3.43x |
| small_tts | 32 | 3072 | 66.64 | 32.38 | 23.18 | 6.95 | 4.66x | 3.33x |
| gqa1 | 1 | 289 | 66.63 | 32.81 | 23.27 | 6.84 | 4.80x | 3.40x |
| gqa1 | 8 | 2312 | 66.35 | 32.48 | 23.40 | 6.80 | 4.78x | 3.44x |
| gqa1 | 32 | 9248 | 66.38 | 32.70 | 23.30 | 6.88 | 4.75x | 3.38x |
| no_gqa | 1 | 256 | 66.22 | 26.60 | 23.22 | 6.76 | 3.93x | 3.43x |
| no_gqa | 8 | 2048 | 66.16 | 26.38 | 23.21 | 6.78 | 3.89x | 3.42x |
| no_gqa | 32 | 8192 | 66.50 | 27.07 | 23.17 | 6.87 | 3.94x | 3.37x |
| wide_heads | 1 | 1280 | 66.46 | 32.36 | 23.46 | 6.84 | 4.73x | 3.43x |
| wide_heads | 8 | 10240 | 66.97 | 32.44 | 23.37 | 6.86 | 4.73x | 3.41x |
| wide_heads | 32 | 40960 | 114.26 | 32.47 | 28.53 | 16.46 | 1.97x | 1.73x |

Across this representative TTS short-sequence matrix, the fused CUDA op is consistently faster than both the compiled PyTorch reference and the Triton reference.

Compared with `torch.compile`, the speedup ranges from about `1.97x` to `4.90x`. Compared with the Triton reference, the speedup ranges from about `1.73x` to `3.44x`.

For the largest tested workload, `wide_heads B=32`, the BF16x2 path improves the standalone RoPE kernel from roughly `16.52us` to `16.46us` in this run while preserving the short-shape latency around the `6.8–7.0us` launch-dominated region.

## Notes

This operator is intentionally narrower than a fully generic RoPE kernel. It currently targets:

- NeoX `rotate_half` layout
- `head_dim=128`
- BF16 Q/K/cos/sin
- standalone Q/K TTS short-sequence workloads
- leading-dimension strided inputs with contiguous last dimension

It does not replace the existing packed-QKV + KV-cache RoPE kernels.