### PR TITLE
perf: add small-batch route MMA for MoE

### DIFF
--- a/src/fuse_moe/entry.cc
+++ b/src/fuse_moe/entry.cc
@@ -5,10 +5,12 @@
 #include <torch/all.h>
 #include <torch/library.h>
 
+#include <algorithm>
 #include <tuple>
 
 #include "src/fuse_moe/cp_async/fuse_moe_cp_async.h"
 #include "src/fuse_moe/fuse_moe.h"
+#include "src/fuse_moe/small_batch_route_mma.h"
 #include "src/utils/utils.h"
 
 namespace hpc {
@@ -223,7 +225,12 @@ torch::Tensor fuse_moe_cp_async_entry(
   constexpr int kGemmTileN = 64;
   int gate_up_num_tile_n = (intermediate_size + kGemmTileN - 1) / kGemmTileN;
   int down_num_tile_n = (hidden_size + kGemmTileN - 1) / kGemmTileN;
-  int max_tile_m = total_num_seq / kMinTileM + num_expert_local;
+  // If A groups are non-empty, sum(ceil(c_i / kMinTileM)) is at most
+  // A + floor((total_routes - A) / kMinTileM). The expression increases with
+  // A, whose upper bound is min(total_routes, local_experts).
+  const int max_nonempty_groups = std::min(total_num_seq, num_expert_local);
+  const int max_tile_m = max_nonempty_groups +
+                         (total_num_seq - max_nonempty_groups) / kMinTileM;
   int gateup_task_map_len = max_tile_m * gate_up_num_tile_n;
   int down_task_map_len = max_tile_m * down_num_tile_n;
 
@@ -287,6 +294,7 @@ torch::Tensor fuse_moe_entry(const torch::Tensor &x, const torch::Tensor &gate_u
               "gate_up_scale, down_scale, act_and_mul_scale and topk_scale dtype must be float32");
   TORCH_CHECK(x.device().is_cuda(), "x tensor must be cuda");
   TORCH_CHECK(gate_up_weight.device().is_cuda(), "gate_up_weight tensor must be cuda");
+  TORCH_CHECK(down_weight.device().is_cuda(), "down_weight tensor must be cuda");
   TORCH_CHECK(gate_up_scale.device().is_cuda(), "gate_up_scale tensor must be cuda");
   TORCH_CHECK(down_scale.device().is_cuda(), "down_scale tensor must be cuda");
   TORCH_CHECK(act_and_mul_scale.device().is_cuda(), "act_and_mul_scale tensor must be cuda");
@@ -332,24 +340,76 @@ torch::Tensor fuse_moe_entry(const torch::Tensor &x, const torch::Tensor &gate_u
   int num_tokens_per_group_avg = num_seq * num_topk / num_expert_total;
   TORCH_CHECK(num_topk <= 128, "num_topk must less than or equal to 128");
 
-  if (intermediate_size / 2 <= 512 && (intermediate_size / 2) % 64 == 0 && hidden_size % 64 == 0) {
-    return fuse_moe_cp_async_entry(x, gate_up_weight, down_weight, gate_up_scale, down_scale,
-                                   act_and_mul_scale, topk_ids, topk_scale, shared_output, rank_ep,
-                                   num_expert_total, use_bf16_mul, output);
-  }
-
   auto options = x.options();
   torch::Tensor y;
-  void *y_ptr = nullptr;
   if (output.has_value()) {
-    TORCH_CHECK(output.value().size(0) == num_seq && output.value().size(1) == hidden_size,
+    y = output.value();
+    TORCH_CHECK(y.size(0) == num_seq && y.size(1) == hidden_size,
                 "output shape must be [num_tokens, hidden_size]");
-    TORCH_CHECK(output.value().dtype() == torch::kBFloat16, "output dtype must be bfloat16");
-    TORCH_CHECK(output.value().device().is_cuda(), "output must be cuda tensor");
-    y_ptr = output.value().mutable_data_ptr();
+    TORCH_CHECK(y.dtype() == torch::kBFloat16, "output dtype must be bfloat16");
+    TORCH_CHECK(y.device().is_cuda(), "output must be cuda tensor");
+    TORCH_CHECK(y.is_contiguous(), "output must be contiguous");
   } else {
     y = torch::empty({num_seq, hidden_size}, options.dtype(torch::kBFloat16));
-    y_ptr = y.mutable_data_ptr();
+  }
+  void *y_ptr = y.mutable_data_ptr();
+
+  TORCH_CHECK(intermediate_size % 2 == 0,
+              "gate_up_weight output dimension must be even");
+  const int actual_intermediate_size = intermediate_size / 2;
+  TORCH_CHECK(down_weight.size(1) == hidden_size &&
+                  down_weight.size(2) == actual_intermediate_size,
+              "down_weight shape must be [num_expert, hidden_size, intermediate_size]");
+  const bool use_small_batch_route_mma =
+      num_seq > 0 && num_seq <= 4 && num_topk == 8 &&
+      actual_intermediate_size > 0 && actual_intermediate_size <= 512 &&
+      actual_intermediate_size % 64 == 0 && hidden_size % 64 == 0;
+  if (use_small_batch_route_mma) {
+    // Route-direct work stays close to the number of active experts for B<=4.
+    // Split the long Gate/Up K dimension only when more CTAs are needed to
+    // provide roughly four waves of work; all other shapes use the normal path.
+    const int64_t num_routes = static_cast<int64_t>(num_seq) * num_topk;
+    int num_splits = 1;
+    if (hidden_size > 2048) {
+      const int gate_tile_k = hidden_size % 128 == 0 ? 128 : 64;
+      const int num_k_tiles = hidden_size / gate_tile_k;
+      const int gate_tasks_without_split =
+          static_cast<int>(num_routes) * (intermediate_size / 64);
+      const int target_gate_tasks = get_sm_count() * 4;
+      const int desired_splits =
+          (target_gate_tasks + gate_tasks_without_split - 1) /
+          gate_tasks_without_split;
+      for (int candidate : {1, 2, 4, 8}) {
+        if (candidate >= desired_splits && num_k_tiles % candidate == 0) {
+          num_splits = candidate;
+          break;
+        }
+        if (num_k_tiles % candidate == 0) {
+          num_splits = candidate;
+        }
+      }
+    }
+    const int64_t workspace_bytes =
+        num_routes * num_splits * intermediate_size * sizeof(at::BFloat16) +
+        num_routes * actual_intermediate_size +
+        num_routes * hidden_size * sizeof(at::BFloat16);
+    torch::Tensor workspace =
+        torch::empty({workspace_bytes}, options.dtype(torch::kUInt8));
+    fuse_moe_small_batch_route_mma_async(
+        y_ptr, x.const_data_ptr(), workspace.mutable_data_ptr(),
+        gate_up_weight.const_data_ptr(), gate_up_scale.const_data_ptr(),
+        act_and_mul_scale.const_data_ptr(), down_weight.const_data_ptr(),
+        down_scale.const_data_ptr(), topk_ids.const_data_ptr(), topk_scale.const_data_ptr(),
+        shared_output_ptr, num_seq, hidden_size, actual_intermediate_size, num_topk,
+        num_splits, num_expert, rank_ep, use_bf16_mul, stream);
+    return y;
+  }
+
+  if (actual_intermediate_size <= 512 && actual_intermediate_size % 64 == 0 &&
+      hidden_size % 64 == 0) {
+    return fuse_moe_cp_async_entry(x, gate_up_weight, down_weight, gate_up_scale, down_scale,
+                                   act_and_mul_scale, topk_ids, topk_scale, shared_output, rank_ep,
+                                   num_expert_total, use_bf16_mul, y);
   }
 
   torch::Tensor gate_up_input = torch::empty({num_seq * num_topk, hidden_size}, options);
@@ -435,11 +495,7 @@ torch::Tensor fuse_moe_entry(const torch::Tensor &x, const torch::Tensor &gate_u
                  shared_output_ptr, gateup_task_map_ptr, down_task_map_ptr, num_gateup_waves,
                  num_down_waves, num_seq, hidden_size, intermediate_size, num_topk,
                  num_expert_total, num_expert, rank_ep, use_bf16_mul, stream);
-  if (output.has_value()) {
-    return output.value();
-  } else {
-    return y;
-  }
+  return y;
 }
 
 torch::Tensor fuse_moe_blockwise_entry(
@@ -455,10 +511,11 @@ torch::Tensor fuse_moe_blockwise_entry(
                   down_weight.dtype() == torch::kFloat8_e4m3fn,
               "x, gate_up_weight and down_weight dtype must be fp8_e4m3");
   TORCH_CHECK(topk_ids.dtype() == torch::kInt32, "topk_ids dtype must be int32");
-  TORCH_CHECK(gate_up_weight_scale.dtype() == torch::kFloat32 &&
+  TORCH_CHECK(x_scale.dtype() == torch::kFloat32 &&
+                  gate_up_weight_scale.dtype() == torch::kFloat32 &&
                   down_weight_scale.dtype() == torch::kFloat32 &&
                   topk_scale.dtype() == torch::kFloat32,
-              "gate_up_scale, down_scale, act_and_mul_scale and topk_scale dtype must be float32");
+              "x_scale, gate_up_scale, down_scale and topk_scale dtype must be float32");
   TORCH_CHECK(x.device().is_cuda(), "x tensor must be cuda");
   TORCH_CHECK(x_scale.device().is_cuda(), "x_scale tensor must be cuda");
   TORCH_CHECK(gate_up_weight.device().is_cuda(), "gate_up_weight tensor must be cuda");
@@ -522,6 +579,80 @@ torch::Tensor fuse_moe_blockwise_entry(
 
   TORCH_CHECK(num_topk <= 128, "num_topk must less than or equal to 128");
 
+  // Small decode batches do not have enough rows per expert to amortize routing
+  // and task-map construction. The route-direct path applies each 128-element
+  // activation/weight scale while accumulating FP8 WGMMA results.
+  TORCH_CHECK(intermediate_size % 2 == 0,
+              "gate_up_weight output dimension must be even");
+  const int actual_intermediate_size = intermediate_size / 2;
+  TORCH_CHECK(actual_intermediate_size > 0,
+              "intermediate_size must be positive");
+  TORCH_CHECK(down_weight.size(1) == hidden_size &&
+                  down_weight.size(2) == actual_intermediate_size,
+              "down_weight shape must be [num_expert, hidden_size, intermediate_size]");
+  const bool use_small_batch_route_mma =
+      num_tokens > 0 && num_tokens <= 4 && num_topk == 8 && hidden_size <= 4096 &&
+      actual_intermediate_size >= 128 && actual_intermediate_size <= 768 &&
+      hidden_size % 128 == 0 &&
+      actual_intermediate_size % 64 == 0;
+
+  auto options = x.options();
+  torch::Tensor y;
+  if (output.has_value()) {
+    y = output.value();
+    TORCH_CHECK(y.size(0) == num_tokens && y.size(1) == hidden_size,
+                "output shape must be [num_tokens, hidden_size]");
+    TORCH_CHECK(y.dtype() == torch::kBFloat16, "output dtype must be bfloat16");
+    TORCH_CHECK(y.device().is_cuda(), "output must be cuda tensor");
+    TORCH_CHECK(y.is_contiguous(), "output must be contiguous");
+  } else {
+    y = torch::empty({num_tokens, hidden_size}, options.dtype(torch::kBFloat16));
+  }
+  void *y_ptr = y.mutable_data_ptr();
+
+  if (use_small_batch_route_mma) {
+    const int64_t num_routes = static_cast<int64_t>(num_tokens) * num_topk;
+    int num_splits = 1;
+    if (hidden_size > 2048) {
+      const int num_k_tiles = hidden_size / 128;
+      const int gate_tasks_without_split =
+          static_cast<int>(num_routes) * (intermediate_size / 64);
+      const int target_gate_tasks = get_sm_count() * 4;
+      const int desired_splits =
+          (target_gate_tasks + gate_tasks_without_split - 1) /
+          gate_tasks_without_split;
+      for (int candidate : {1, 2, 4, 8}) {
+        if (candidate >= desired_splits && num_k_tiles % candidate == 0) {
+          num_splits = candidate;
+          break;
+        }
+        if (num_k_tiles % candidate == 0) {
+          num_splits = candidate;
+        }
+      }
+    }
+    const int64_t num_intermediate_blocks =
+        (actual_intermediate_size + 127) / 128;
+    const int64_t workspace_bytes =
+        num_routes * num_splits * 2 * actual_intermediate_size *
+            sizeof(at::BFloat16) +
+        num_routes * actual_intermediate_size +
+        num_routes * num_intermediate_blocks * sizeof(float) +
+        num_routes * hidden_size * sizeof(at::BFloat16);
+    torch::Tensor workspace =
+        torch::empty({workspace_bytes}, options.dtype(torch::kUInt8));
+    fuse_moe_blockwise_small_batch_route_mma_async(
+        y_ptr, x.const_data_ptr(), x_scale.const_data_ptr(),
+        workspace.mutable_data_ptr(), gate_up_weight.const_data_ptr(),
+        gate_up_weight_scale.const_data_ptr(), down_weight.const_data_ptr(),
+        down_weight_scale.const_data_ptr(), topk_ids.const_data_ptr(),
+        topk_scale.const_data_ptr(), shared_output_ptr, num_tokens, hidden_size,
+        actual_intermediate_size, num_topk, num_splits, num_experts,
+        gate_up_weight_scale_lastdim_pad4, down_weight_scale_lastdim_pad4, rank_ep,
+        stream);
+    return y;
+  }
+
   if (num_tokens_per_group_avg <= 8) {
     aligned_size = 8;
   } else if (num_tokens_per_group_avg <= 16) {
@@ -545,19 +676,6 @@ torch::Tensor fuse_moe_blockwise_entry(
       (num_tokens * num_topk + num_expert_total * aligned_size + aligned_size - 1) / aligned_size *
       aligned_size;
 
-  auto options = x.options();
-  torch::Tensor y;
-  void *y_ptr = nullptr;
-  if (output.has_value()) {
-    TORCH_CHECK(output.value().size(0) == num_tokens && output.value().size(1) == hidden_size,
-                "output shape must be [num_tokens, hidden_size]");
-    TORCH_CHECK(output.value().dtype() == torch::kBFloat16, "output dtype must be bfloat16");
-    TORCH_CHECK(output.value().device().is_cuda(), "output must be cuda tensor");
-    y_ptr = output.value().mutable_data_ptr();
-  } else {
-    y = torch::empty({num_tokens, hidden_size}, options.dtype(torch::kBFloat16));
-    y_ptr = y.mutable_data_ptr();
-  }
   torch::Tensor gate_up_input =
       torch::empty({num_tokens * num_topk, hidden_size}, options.dtype(torch::kFloat8_e4m3fn));
   torch::Tensor gate_up_input_scale =
@@ -631,11 +749,7 @@ torch::Tensor fuse_moe_blockwise_entry(
       down_task_map_ptr, num_gateup_waves, num_down_waves, num_tokens, num_padded_tokens,
       hidden_size, intermediate_size, num_topk, num_expert_total, num_experts,
       gate_up_weight_scale_lastdim_pad4, down_weight_scale_lastdim_pad4, rank_ep, stream);
-  if (output.has_value()) {
-    return output.value();
-  } else {
-    return y;
-  }
+  return y;
 }
 
 }  // namespace fuse_moe

--- a/src/fuse_moe/entry.cc
+++ b/src/fuse_moe/entry.cc
@@ -365,9 +365,6 @@ torch::Tensor fuse_moe_entry(const torch::Tensor &x, const torch::Tensor &gate_u
       actual_intermediate_size > 0 && actual_intermediate_size <= 512 &&
       actual_intermediate_size % 64 == 0 && hidden_size % 64 == 0;
   if (use_small_batch_route_mma) {
-    // Route-direct work stays close to the number of active experts for B<=4.
-    // Split the long Gate/Up K dimension only when more CTAs are needed to
-    // provide roughly four waves of work; all other shapes use the normal path.
     const int64_t num_routes = static_cast<int64_t>(num_seq) * num_topk;
     int num_splits = 1;
     if (hidden_size > 2048) {
@@ -551,8 +548,6 @@ torch::Tensor fuse_moe_blockwise_entry(
               "gate_up_weight must be per 128 blockwise quant and must be aligned to 4");
   TORCH_CHECK(down_weight_scale.size(1) == down_weight.size(1) / 128,
               "down_weight must be per 128 blockwise quant");
-  TORCH_CHECK(down_weight_scale.size(2) == (down_weight.size(2) / 128 + 3) / 4 * 4,
-              "down_weight must be per 128 blockwise quant and must be aligned to 4");
 
   const void *shared_output_ptr = nullptr;
   if (shared_output.has_value()) {
@@ -579,22 +574,18 @@ torch::Tensor fuse_moe_blockwise_entry(
 
   TORCH_CHECK(num_topk <= 128, "num_topk must less than or equal to 128");
 
-  // Small decode batches do not have enough rows per expert to amortize routing
-  // and task-map construction. The route-direct path applies each 128-element
-  // activation/weight scale while accumulating FP8 WGMMA results.
-  TORCH_CHECK(intermediate_size % 2 == 0,
-              "gate_up_weight output dimension must be even");
   const int actual_intermediate_size = intermediate_size / 2;
-  TORCH_CHECK(actual_intermediate_size > 0,
-              "intermediate_size must be positive");
-  TORCH_CHECK(down_weight.size(1) == hidden_size &&
-                  down_weight.size(2) == actual_intermediate_size,
-              "down_weight shape must be [num_expert, hidden_size, intermediate_size]");
   const bool use_small_batch_route_mma =
       num_tokens > 0 && num_tokens <= 4 && num_topk == 8 && hidden_size <= 4096 &&
       actual_intermediate_size >= 128 && actual_intermediate_size <= 768 &&
       hidden_size % 128 == 0 &&
       actual_intermediate_size % 64 == 0;
+  const int down_weight_scale_num_blocks =
+      use_small_batch_route_mma ? (actual_intermediate_size + 127) / 128
+                                : actual_intermediate_size / 128;
+  TORCH_CHECK(down_weight_scale.size(2) ==
+                  (down_weight_scale_num_blocks + 3) / 4 * 4,
+              "down_weight must be per 128 blockwise quant and must be aligned to 4");
 
   auto options = x.options();
   torch::Tensor y;

--- a/src/fuse_moe/reduce.cu
+++ b/src/fuse_moe/reduce.cu
@@ -38,7 +38,8 @@ __global__ void reduce_kernel(T *y_ptr, const T *x_ptr, const int *topk_pos_ptr,
   }
 #pragma unroll 1
   for (int i = idx; i < num_topk; i += blockDim.x) {
-    pos_shm[i] = topk_pos_ptr[irow * num_topk + i];
+    pos_shm[i] = topk_pos_ptr ? topk_pos_ptr[irow * num_topk + i]
+                              : irow * num_topk + i;
     scale_shm[i] = topk_scale_ptr[irow * num_topk + i];
   }
   __syncthreads();

--- a/src/fuse_moe/small_batch_route_mma.cu
+++ b/src/fuse_moe/small_batch_route_mma.cu
@@ -1,0 +1,280 @@
+// Copyright (C) 2026 Tencent.
+
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#include <type_traits>
+
+#include "src/fuse_moe/fuse_moe.h"
+#include "src/fuse_moe/small_batch_route_mma.h"
+#include "src/group_gemm/cp_async/group_gemm.h"
+#include "src/utils/utils.cuh"
+
+namespace hpc {
+namespace fuse_moe {
+namespace kernels {
+
+template <bool kUseBFloat16PrecisionMultiply>
+__global__ void split_partial_act_quant_kernel(
+    __nv_fp8_e4m3 *__restrict__ output_ptr,
+    const __nv_bfloat16 *__restrict__ partial_ptr,
+    const float *__restrict__ scale_ptr, int num_routes, int num_splits,
+    int intermediate_size) {
+  cudaGridDependencySynchronize();
+
+  constexpr int kVectorSize = 8;
+  const int num_vectors = num_routes * intermediate_size / kVectorSize;
+  for (int vector_idx = blockIdx.x * blockDim.x + threadIdx.x;
+       vector_idx < num_vectors; vector_idx += blockDim.x * gridDim.x) {
+    const int element_idx = vector_idx * kVectorSize;
+    const int route = element_idx / intermediate_size;
+    const int col = element_idx - route * intermediate_size;
+    float gate[kVectorSize] = {};
+    float up[kVectorSize] = {};
+
+#pragma unroll 1
+    for (int split = 0; split < num_splits; ++split) {
+      const uint64_t base =
+          (static_cast<uint64_t>(route) * num_splits + split) *
+          (2 * intermediate_size);
+#pragma unroll
+      for (int i = 0; i < kVectorSize; ++i) {
+        gate[i] += __bfloat162float(partial_ptr[base + col + i]);
+        up[i] += __bfloat162float(
+            partial_ptr[base + intermediate_size + col + i]);
+      }
+    }
+
+    float activated[kVectorSize];
+#pragma unroll
+    for (int i = 0; i < kVectorSize; ++i) {
+      gate[i] = __bfloat162float(__float2bfloat16_rn(gate[i]));
+      up[i] = __bfloat162float(__float2bfloat16_rn(up[i]));
+      if constexpr (kUseBFloat16PrecisionMultiply) {
+        auto silu_bf16 = __float2bfloat16_rn(silu(gate[i]));
+        auto up_bf16 = __float2bfloat16_rn(up[i]);
+        activated[i] = __bfloat162float(silu_bf16 * up_bf16) * scale_ptr[0];
+      } else {
+        activated[i] = silu(gate[i]) * up[i] * scale_ptr[0];
+      }
+    }
+    auto *output = output_ptr + element_idx;
+    *reinterpret_cast<__nv_fp8x4_e4m3 *>(output) =
+        __nv_fp8x4_e4m3(*reinterpret_cast<float4 *>(&activated[0]));
+    *reinterpret_cast<__nv_fp8x4_e4m3 *>(output + 4) =
+        __nv_fp8x4_e4m3(*reinterpret_cast<float4 *>(&activated[4]));
+  }
+
+  // Some threads can have no vector to write. Let natural CTA completion
+  // satisfy PDL instead of allowing an idle thread to trigger it early.
+}
+
+}  // namespace kernels
+
+void split_partial_act_quant_async(
+    void *output_ptr, const void *partial_ptr, const void *scale_ptr,
+    int num_routes, int num_splits, int intermediate_size,
+    bool use_bf16_mul, cudaStream_t stream) {
+  constexpr int kThreads = 256;
+  constexpr int kVectorSize = 8;
+  const int num_vectors = num_routes * intermediate_size / kVectorSize;
+  const int grid = (num_vectors + kThreads - 1) / kThreads;
+
+  auto launch = [&](auto bf16_mul_tag) {
+    constexpr bool kUseBFloat16PrecisionMultiply = decltype(bf16_mul_tag)::value;
+    auto kernel =
+        kernels::split_partial_act_quant_kernel<kUseBFloat16PrecisionMultiply>;
+    cudaLaunchAttribute attr[1];
+    attr[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attr[0].val.programmaticStreamSerializationAllowed = 1;
+    cudaLaunchConfig_t cfg{};
+    cfg.gridDim = dim3(grid);
+    cfg.blockDim = dim3(kThreads);
+    cfg.stream = stream;
+    cfg.attrs = attr;
+    cfg.numAttrs = 1;
+    cudaLaunchKernelEx(
+        &cfg, kernel, static_cast<__nv_fp8_e4m3 *>(output_ptr),
+        static_cast<const __nv_bfloat16 *>(partial_ptr),
+        static_cast<const float *>(scale_ptr), num_routes, num_splits,
+        intermediate_size);
+  };
+  if (use_bf16_mul) {
+    launch(std::true_type{});
+  } else {
+    launch(std::false_type{});
+  }
+}
+
+void fuse_moe_small_batch_route_mma_async(
+    void *output_ptr, const void *input_ptr, void *intermediate_ptr,
+    const void *gate_up_weight_ptr, const void *gate_up_scale_ptr,
+    const void *act_and_mul_scale_ptr, const void *down_weight_ptr,
+    const void *down_scale_ptr, const void *topk_ids_ptr, const void *topk_scale_ptr,
+    const void *shared_output_ptr, int num_seq, int hidden_size, int intermediate_size,
+    int num_topk, int num_splits, int num_expert_local, int rank_ep, bool use_bf16_mul,
+    cudaStream_t stream) {
+  const int num_routes = num_seq * num_topk;
+  auto *workspace = static_cast<uint8_t *>(intermediate_ptr);
+  auto *gate_up_partials = reinterpret_cast<__nv_bfloat16 *>(workspace);
+  workspace += static_cast<size_t>(num_routes) * num_splits * 2 * intermediate_size *
+               sizeof(__nv_bfloat16);
+  auto *down_input = reinterpret_cast<__nv_fp8_e4m3 *>(workspace);
+  workspace += static_cast<size_t>(num_routes) * intermediate_size *
+               sizeof(__nv_fp8_e4m3);
+  auto *down_output = reinterpret_cast<__nv_bfloat16 *>(workspace);
+
+  group_gemm_cp_async::group_gemm_fp8_route_splitk_async(
+      gate_up_partials, input_ptr, gate_up_weight_ptr, gate_up_scale_ptr,
+      topk_ids_ptr, num_routes, num_topk, 2 * intermediate_size, hidden_size,
+      num_splits, num_expert_local, rank_ep, stream);
+
+  split_partial_act_quant_async(
+      down_input, gate_up_partials, act_and_mul_scale_ptr, num_routes,
+      num_splits, intermediate_size, use_bf16_mul, stream);
+
+  group_gemm_cp_async::group_gemm_fp8_route_async(
+      down_output, down_input, down_weight_ptr, down_scale_ptr, topk_ids_ptr,
+      num_routes, num_topk, hidden_size, intermediate_size, num_expert_local,
+      rank_ep, /*input_is_token=*/false, stream);
+
+  reduce_async(output_ptr, down_output, /*topk_pos_ptr=*/nullptr, topk_scale_ptr,
+               shared_output_ptr, num_routes, num_seq, hidden_size, num_topk,
+               /*use_pdl=*/true, stream);
+}
+
+namespace kernels {
+
+constexpr int kBlockwiseQuantSize = 128;
+
+__global__ void blockwise_act_quant_kernel(
+    __nv_fp8_e4m3 *__restrict__ output_ptr,
+    float *__restrict__ output_scale_ptr,
+    const __nv_bfloat16 *__restrict__ gate_up_ptr, int num_splits,
+    int intermediate_size) {
+  cudaGridDependencySynchronize();
+
+  const int route = blockIdx.y;
+  const int block = blockIdx.x;
+  const int col = block * kBlockwiseQuantSize + threadIdx.x;
+  float activated = 0.0f;
+  if (col < intermediate_size) {
+    float gate = 0.0f;
+    float up = 0.0f;
+#pragma unroll 1
+    for (int split = 0; split < num_splits; ++split) {
+      const uint64_t base =
+          (static_cast<uint64_t>(route) * num_splits + split) *
+          2 * intermediate_size;
+      gate += __bfloat162float(gate_up_ptr[base + col]);
+      up += __bfloat162float(
+          gate_up_ptr[base + intermediate_size + col]);
+    }
+    gate = __bfloat162float(__float2bfloat16_rn(gate));
+    up = __bfloat162float(__float2bfloat16_rn(up));
+    activated = silu(gate) * up;
+  }
+
+  float max_value = warp_reduce_max_xor(fabsf(activated));
+  __shared__ float warp_max[4];
+  if ((threadIdx.x & 31) == 0) {
+    warp_max[threadIdx.x / 32] = max_value;
+  }
+  __syncthreads();
+  if (threadIdx.x < 32) {
+    max_value = threadIdx.x < 4 ? warp_max[threadIdx.x] : 0.0f;
+    max_value = warp_reduce_max_xor(max_value);
+  }
+
+  __shared__ float inverse_scale;
+  const int num_blocks =
+      (intermediate_size + kBlockwiseQuantSize - 1) /
+      kBlockwiseQuantSize;
+  if (threadIdx.x == 0) {
+    const float scale = max_value / 448.0f;
+    output_scale_ptr[static_cast<uint64_t>(route) * num_blocks + block] =
+        scale;
+    inverse_scale = 1.0f / (scale + 1e-8f);
+  }
+  __syncthreads();
+  if (col < intermediate_size) {
+    output_ptr[static_cast<uint64_t>(route) * intermediate_size + col] =
+        __nv_fp8_e4m3(activated * inverse_scale);
+  }
+}
+
+}  // namespace kernels
+
+void blockwise_act_quant_async(
+    void *output_ptr, void *output_scale_ptr, const void *gate_up_ptr,
+    int num_routes, int num_splits, int intermediate_size,
+    cudaStream_t stream) {
+  constexpr int kThreads = kernels::kBlockwiseQuantSize;
+  const int num_blocks =
+      (intermediate_size + kernels::kBlockwiseQuantSize - 1) /
+      kernels::kBlockwiseQuantSize;
+  auto kernel = kernels::blockwise_act_quant_kernel;
+  cudaLaunchAttribute attr[1];
+  attr[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attr[0].val.programmaticStreamSerializationAllowed = 1;
+  cudaLaunchConfig_t cfg{};
+  cfg.gridDim = dim3(num_blocks, num_routes);
+  cfg.blockDim = dim3(kThreads);
+  cfg.stream = stream;
+  cfg.attrs = attr;
+  cfg.numAttrs = 1;
+  cudaLaunchKernelEx(
+      &cfg, kernel, static_cast<__nv_fp8_e4m3 *>(output_ptr),
+      static_cast<float *>(output_scale_ptr),
+      static_cast<const __nv_bfloat16 *>(gate_up_ptr), num_splits,
+      intermediate_size);
+}
+
+void fuse_moe_blockwise_small_batch_route_mma_async(
+    void *output_ptr, const void *input_ptr, const void *input_scale_ptr,
+    void *workspace_ptr, const void *gate_up_weight_ptr,
+    const void *gate_up_weight_scale_ptr, const void *down_weight_ptr,
+    const void *down_weight_scale_ptr, const void *topk_ids_ptr,
+    const void *topk_scale_ptr, const void *shared_output_ptr, int num_tokens,
+    int hidden_size, int intermediate_size, int num_topk, int num_splits,
+    int num_expert_local, int gate_up_weight_scale_lastdim_pad4,
+    int down_weight_scale_lastdim_pad4, int rank_ep, cudaStream_t stream) {
+  const int num_routes = num_tokens * num_topk;
+  const int num_intermediate_blocks =
+      (intermediate_size + kernels::kBlockwiseQuantSize - 1) /
+      kernels::kBlockwiseQuantSize;
+  auto *workspace = static_cast<uint8_t *>(workspace_ptr);
+  auto *gate_up_partials = reinterpret_cast<__nv_bfloat16 *>(workspace);
+  workspace += static_cast<size_t>(num_routes) * num_splits *
+               2 * intermediate_size *
+               sizeof(__nv_bfloat16);
+  auto *down_input = reinterpret_cast<__nv_fp8_e4m3 *>(workspace);
+  workspace += static_cast<size_t>(num_routes) * intermediate_size;
+  auto *down_input_scale = reinterpret_cast<float *>(workspace);
+  workspace += static_cast<size_t>(num_routes) * num_intermediate_blocks *
+               sizeof(float);
+  auto *down_output = reinterpret_cast<__nv_bfloat16 *>(workspace);
+
+  group_gemm_cp_async::group_gemm_fp8_route_blockwise_async(
+      gate_up_partials, input_ptr, input_scale_ptr, gate_up_weight_ptr,
+      gate_up_weight_scale_ptr, topk_ids_ptr, num_routes, num_topk,
+      2 * intermediate_size, hidden_size, num_splits, num_expert_local, rank_ep,
+      /*input_is_token=*/true, gate_up_weight_scale_lastdim_pad4, stream);
+
+  blockwise_act_quant_async(down_input, down_input_scale, gate_up_partials,
+                            num_routes, num_splits, intermediate_size, stream);
+
+  group_gemm_cp_async::group_gemm_fp8_route_blockwise_async(
+      down_output, down_input, down_input_scale, down_weight_ptr,
+      down_weight_scale_ptr, topk_ids_ptr, num_routes, num_topk, hidden_size,
+      intermediate_size, /*num_splits=*/1, num_expert_local, rank_ep,
+      /*input_is_token=*/false, down_weight_scale_lastdim_pad4, stream);
+
+  reduce_async(output_ptr, down_output, /*topk_pos_ptr=*/nullptr, topk_scale_ptr,
+               shared_output_ptr, num_routes, num_tokens, hidden_size, num_topk,
+               /*use_pdl=*/true, stream);
+}
+
+}  // namespace fuse_moe
+}  // namespace hpc

--- a/src/fuse_moe/small_batch_route_mma.h
+++ b/src/fuse_moe/small_batch_route_mma.h
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Tencent.
+
+#ifndef SRC_FUSE_MOE_SMALL_BATCH_ROUTE_MMA_H_
+#define SRC_FUSE_MOE_SMALL_BATCH_ROUTE_MMA_H_
+
+#include <cuda_runtime_api.h>
+
+namespace hpc {
+namespace fuse_moe {
+
+// SM90 route-direct implementation: Gate/Up WGMMA can split K for small-batch
+// occupancy, then one kernel reduces the partials, applies SwiGLU, and
+// requantizes for route-direct Down WGMMA. intermediate_ptr is a byte workspace
+// containing BF16 Gate/Up partials, FP8 Down input, and BF16 route output.
+void fuse_moe_small_batch_route_mma_async(
+    void *output_ptr, const void *input_ptr, void *intermediate_ptr,
+    const void *gate_up_weight_ptr, const void *gate_up_scale_ptr,
+    const void *act_and_mul_scale_ptr, const void *down_weight_ptr,
+    const void *down_scale_ptr, const void *topk_ids_ptr, const void *topk_scale_ptr,
+    const void *shared_output_ptr, int num_seq, int hidden_size, int intermediate_size,
+    int num_topk, int num_splits, int num_expert_local, int rank_ep, bool use_bf16_mul,
+    cudaStream_t stream);
+
+void fuse_moe_blockwise_small_batch_route_mma_async(
+    void *output_ptr, const void *input_ptr, const void *input_scale_ptr,
+    void *workspace_ptr, const void *gate_up_weight_ptr,
+    const void *gate_up_weight_scale_ptr, const void *down_weight_ptr,
+    const void *down_weight_scale_ptr, const void *topk_ids_ptr,
+    const void *topk_scale_ptr, const void *shared_output_ptr, int num_tokens,
+    int hidden_size, int intermediate_size, int num_topk, int num_splits,
+    int num_expert_local, int gate_up_weight_scale_lastdim_pad4,
+    int down_weight_scale_lastdim_pad4, int rank_ep, cudaStream_t stream);
+
+}  // namespace fuse_moe
+}  // namespace hpc
+
+#endif  // SRC_FUSE_MOE_SMALL_BATCH_ROUTE_MMA_H_

--- a/src/group_gemm/cp_async/group_gemm.h
+++ b/src/group_gemm/cp_async/group_gemm.h
@@ -15,6 +15,34 @@ void group_gemm_fp8_multistage_async(void *y_ptr, const void *x_ptr, const void 
                                      int task_map_len, int m, int n, int k, int num_group,
                                      int num_seq_per_group_avg, bool use_pdl, cudaStream_t stream);
 
+// Route-direct small-M GEMM. Each logical row selects its expert from topk_ids;
+// no expert sorting, prefix sum, or task map is required. When input_is_token
+// is true, route r reads input row r / num_topk (Gate/Up); otherwise it reads
+// route row r directly (Down).
+void group_gemm_fp8_route_async(void *y_ptr, const void *x_ptr, const void *w_ptr,
+                                const void *y_scale_ptr, const void *topk_ids_ptr,
+                                int num_routes, int num_topk, int n, int k,
+                                int num_expert_local, int rank_ep, bool input_is_token,
+                                cudaStream_t stream);
+
+// Route-direct blockwise-scaled GEMM. Input and weight scales describe
+// 128-element K blocks; weight_scale_stride is the padded K-block dimension.
+void group_gemm_fp8_route_blockwise_async(
+    void *y_ptr, const void *x_ptr, const void *x_scale_ptr,
+    const void *w_ptr, const void *w_scale_ptr, const void *topk_ids_ptr,
+    int num_routes, int num_topk, int n, int k, int num_splits,
+    int num_expert_local, int rank_ep, bool input_is_token, int weight_scale_stride,
+    cudaStream_t stream);
+
+// Route-direct Gate/Up projection split along K. Output is BF16 with layout
+// [num_routes, num_splits, n], consumed by the activation kernel.
+void group_gemm_fp8_route_splitk_async(void *partial_ptr, const void *x_ptr,
+                                       const void *w_ptr, const void *y_scale_ptr,
+                                       const void *topk_ids_ptr, int num_routes,
+                                       int num_topk, int n, int k, int num_splits,
+                                       int num_expert_local, int rank_ep,
+                                       cudaStream_t stream);
+
 void group_gemm_fp8_scatter_async(void *y_ptr, const void *x_ptr, const void *w_ptr,
                                   const void *y_scale_ptr, const void *row_indices_ptr,
                                   const void *seqlens_ptr, const void *cu_seqlens_ptr,

--- a/src/group_gemm/cp_async/group_gemm_fp8.cu
+++ b/src/group_gemm/cp_async/group_gemm_fp8.cu
@@ -3,6 +3,7 @@
 #include <cuda.h>
 
 #include <cassert>
+#include <type_traits>
 
 #include "cute/tensor.hpp"
 #include "src/group_gemm/cp_async/common.cuh"
@@ -223,6 +224,235 @@ __global__ void __launch_bounds__(128, kMinBlocks)
   }
 }
 
+template <typename Config, typename TsACopy>
+__device__ __forceinline__ void route_load_A_tile(
+    TsACopy &tsA_copy, const typename Config::Tin *__restrict__ input_ptr,
+    int input_row, int k_col_base, int k, int ismem) {
+  constexpr int kTileM = Config::kTileM;
+  constexpr int kTileK = Config::kTileK;
+  constexpr int kElemsPerAtom = 16;
+  constexpr int kThreadsPerRow = kTileK / kElemsPerAtom;
+  constexpr int kRowsPerIter = 128 / kThreadsPerRow;
+  constexpr int kNumIters = (kTileM + kRowsPerIter - 1) / kRowsPerIter;
+
+#pragma unroll
+  for (int row_iter = 0; row_iter < kNumIters; ++row_iter) {
+    const int local_row = row_iter * kRowsPerIter + threadIdx.x / kThreadsPerRow;
+    if (local_row < kTileM) {
+      const int k_thread = threadIdx.x % kThreadsPerRow;
+      const int k_col = k_col_base + k_thread * kElemsPerAtom;
+      void *smem_ptr =
+          (void *)&tsA_copy(cute::Int<0>{}, row_iter, cute::Int<0>{}, ismem);
+      const void *gmem_ptr =
+          (const void *)(input_ptr + static_cast<uint64_t>(input_row) * k + k_col);
+      const int src_size = local_row == 0 ? 16 : 0;
+      asm volatile("cp.async.cg.shared.global.L2::128B [%0], [%1], %2, %3;\n" : :
+                   "r"(static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr))),
+                   "l"(gmem_ptr), "n"(16), "r"(src_size));
+    }
+  }
+}
+
+// One logical route per WGMMA M tile. SM90 WGMMA has an M=8 minimum here, so
+// row 0 carries the route and rows 1..7 are zero-filled by cp.async. This is
+// deliberately route-major: the expert is read directly from topk_ids and no
+// sorting metadata is needed.
+template <typename Config, bool kInputIsToken, bool kBlockwiseScale>
+__global__ void __launch_bounds__(128, 5) group_gemm_fp8_route_kernel(
+    void *Cptr, const void *Aptr, const void *Bptr, const float *y_scale_ptr,
+    const float *input_scale_ptr, const float *weight_scale_ptr,
+    const int *topk_ids_ptr, int num_routes, int num_topk, int n, int k,
+    int num_expert_local, int start_expert, int num_splits, int tiles_per_split,
+    int input_scale_stride, int weight_scale_stride,
+    cutlass::FastDivmod flat_divider, cutlass::FastDivmod split_divider,
+    cutlass::FastDivmod topk_divider) {
+  using namespace cute;  // NOLINT
+
+  using Tin = typename Config::Tin;
+  using Tout = typename Config::Tout;
+  using SmemLayoutA = typename Config::SmemLayoutA;
+  using SmemLayoutB = typename Config::SmemLayoutB;
+  using SmemLayoutCT = typename Config::SmemLayoutCT;
+  using G2SCopyA = typename Config::G2SCopyA;
+  using G2SCopyB = typename Config::G2SCopyB;
+  using S2GCopyC = typename Config::S2GCopyC;
+  using TiledMMA = typename Config::TiledMMA;
+
+  constexpr int kTileM = Config::kTileM;
+  constexpr int kTileN = Config::kTileN;
+  constexpr int kTileK = Config::kTileK;
+  constexpr int kStage = Config::kStage;
+  static_assert(kTileM == 8, "route-direct kernel requires the SM90 M=8 tile");
+
+  extern __shared__ Tin shm_data[];
+  Tin *Ashm = shm_data;
+  Tin *Bshm = Ashm + cosize(SmemLayoutA{});
+  Tout *Cshm = reinterpret_cast<Tout *>(shm_data);
+
+  cudaGridDependencySynchronize();
+
+  const int num_tile_n = n / kTileN;
+  const int num_tasks = num_routes * num_splits * num_tile_n;
+  for (int task_idx = blockIdx.x; task_idx < num_tasks; task_idx += gridDim.x) {
+    int route_split, itile_n;
+    flat_divider(route_split, itile_n, task_idx);
+    int route, split;
+    split_divider(route, split, route_split);
+    const int local_expert = topk_ids_ptr[route] - start_expert;
+    const uint64_t output_row = static_cast<uint64_t>(route) * num_splits + split;
+
+    if (local_expert < 0 || local_expert >= num_expert_local) {
+      if (threadIdx.x < kTileN) {
+        reinterpret_cast<Tout *>(Cptr)[output_row * n +
+                                       itile_n * kTileN + threadIdx.x] = Tout{};
+      }
+      continue;
+    }
+
+    int input_row = route;
+    if constexpr (kInputIsToken) {
+      int topk_slot;
+      topk_divider(input_row, topk_slot, route);
+    }
+
+    Tensor B = make_tensor(
+        make_gmem_ptr((Tin *)Bptr + static_cast<uint64_t>(local_expert) * n * k),
+        make_shape(n, k), make_stride(k, Int<1>{}));
+    Tensor C = make_tensor(make_gmem_ptr((Tout *)Cptr + output_row * n),
+                           make_shape(n, 1), make_stride(Int<1>{}, n));
+    Tensor gB = local_tile(B, make_tile(Int<kTileN>{}, Int<kTileK>{}),
+                           make_coord(itile_n, _));
+    Tensor gCT = local_tile(C, make_tile(Int<kTileN>{}, Int<kTileM>{}),
+                            make_coord(itile_n, 0));
+
+    auto sA = make_tensor(make_smem_ptr(Ashm), SmemLayoutA{});
+    auto sB = make_tensor(make_smem_ptr(Bshm), SmemLayoutB{});
+    auto sCT = make_tensor(make_smem_ptr(Cshm), SmemLayoutCT{});
+
+    G2SCopyA g2s_tiled_copy_a;
+    auto g2s_thr_copy_a = g2s_tiled_copy_a.get_slice(threadIdx.x);
+    auto tsA_copy = g2s_thr_copy_a.partition_D(sA);
+
+    G2SCopyB g2s_tiled_copy_b;
+    auto g2s_thr_copy_b = g2s_tiled_copy_b.get_slice(threadIdx.x);
+    auto tgB_copy = g2s_thr_copy_b.partition_S(gB);
+    auto tsB_copy = g2s_thr_copy_b.partition_D(sB);
+
+    S2GCopyC s2g_tiled_copy_c;
+    auto s2g_thr_copy_c = s2g_tiled_copy_c.get_slice(threadIdx.x);
+    auto tCs2g = s2g_thr_copy_c.partition_S(sCT);
+    auto tCg2s = s2g_thr_copy_c.partition_D(gCT);
+
+    TiledMMA tiled_mma;
+    auto thr_mma = tiled_mma.get_slice(threadIdx.x);
+    auto tBr = thr_mma.make_fragment_A(thr_mma.partition_A(sB));
+    auto tAr = thr_mma.make_fragment_B(thr_mma.partition_B(sA));
+    auto tCr = thr_mma.partition_fragment_C(gCT);
+
+    auto tIC = s2g_thr_copy_c.partition_S(
+        make_identity_tensor(make_shape(Int<kTileN>{}, Int<kTileM>{})));
+    auto pred_c = make_tensor<bool>(shape(tIC));
+#pragma unroll
+    for (int i = 0; i < size(tIC); ++i) {
+      pred_c(i) = get<1>(tIC(i)) == 0;
+    }
+
+    const int ntile = tiles_per_split;
+    const int first_k_tile = split * tiles_per_split;
+    int itile_to_read = 0;
+    int ismem_write = 0;
+#pragma unroll
+    for (int stage = 0; stage < kStage - 1; ++stage) {
+      if (stage < ntile) {
+        route_load_A_tile<Config>(tsA_copy, static_cast<const Tin *>(Aptr), input_row,
+                                  (first_k_tile + stage) * kTileK, k, stage);
+        cute::copy(g2s_tiled_copy_b, tgB_copy(_, _, _, first_k_tile + stage),
+                   tsB_copy(_, _, _, stage));
+      }
+      cp_async_fence();
+      ++itile_to_read;
+      ++ismem_write;
+    }
+
+    auto tDr = make_tensor_like(tCr);
+    clear(tDr);
+    constexpr int kScaleBlock = 128;
+    const float *input_scale_row = nullptr;
+    const float *weight_scale_row = nullptr;
+    float tensor_scale = 0.0f;
+    if constexpr (kBlockwiseScale) {
+      const int n_block = itile_n * kTileN / kScaleBlock;
+      const int num_n_blocks = (n + kScaleBlock - 1) / kScaleBlock;
+      input_scale_row = input_scale_ptr +
+                        static_cast<uint64_t>(input_row) * input_scale_stride;
+      weight_scale_row = weight_scale_ptr +
+                         (static_cast<uint64_t>(local_expert) * num_n_blocks +
+                          n_block) *
+                             weight_scale_stride;
+    } else {
+      tensor_scale = y_scale_ptr[local_expert];
+    }
+    for (int itile = 0; itile < ntile; ++itile) {
+      if (itile_to_read < ntile) {
+        route_load_A_tile<Config>(tsA_copy, static_cast<const Tin *>(Aptr), input_row,
+                                  (first_k_tile + itile_to_read) * kTileK, k, ismem_write);
+        cute::copy(g2s_tiled_copy_b, tgB_copy(_, _, _, first_k_tile + itile_to_read),
+                   tsB_copy(_, _, _, ismem_write));
+        ++itile_to_read;
+        ismem_write = (ismem_write + 1) % kStage;
+      }
+      cp_async_fence();
+
+      float scale;
+      if constexpr (kBlockwiseScale) {
+        const int global_k_tile = first_k_tile + itile;
+        const int k_block = global_k_tile * kTileK / kScaleBlock;
+        scale = input_scale_row[k_block] * weight_scale_row[k_block];
+      } else {
+        scale = tensor_scale;
+      }
+
+      cp_async_wait<kStage - 1>();
+      __syncthreads();
+
+      tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
+      warpgroup_fence_operand(tCr);
+      warpgroup_arrive();
+#pragma unroll
+      for (int ik = 0; ik < size<2>(tBr); ++ik) {
+        cute::gemm(tiled_mma, tBr(_, _, ik, itile % kStage),
+                   tAr(_, _, ik, itile % kStage), tCr);
+        tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+      }
+      warpgroup_commit_batch();
+      warpgroup_wait<0>();
+      warpgroup_fence_operand(tCr);
+#pragma unroll
+      for (int i = 0; i < size(tCr); ++i) {
+        tDr(i) = tCr(i) * scale + tDr(i);
+      }
+    }
+
+    auto tCrh = make_tensor_like<Tout>(tCr);
+#pragma unroll
+    for (int i = 0; i < size(tCr); ++i) {
+      tCrh(i) = Tout(tDr(i));
+    }
+    using R2SCopyAtomC = typename Config::R2SCopyAtomC;
+    auto tiled_copy_c = make_tiled_copy_C(R2SCopyAtomC{}, tiled_mma);
+    auto thr_copy_c = tiled_copy_c.get_slice(threadIdx.x);
+    auto tCr4s = thr_copy_c.retile_S(tCrh);
+    auto tCs4r = thr_copy_c.partition_D(sCT);
+    cute::copy(tiled_copy_c, tCr4s, tCs4r);
+    __syncthreads();
+    cute::copy_if(s2g_tiled_copy_c, pred_c, tCs2g, tCg2s);
+    __syncthreads();
+  }
+
+  // Do not trigger PDL early: route branches can leave different warps at the
+  // tail at different times. Natural CTA completion preserves the dependency.
+}
+
 }  // namespace kernels
 
 // Multistage launch policy. kStage is selected in the dispatcher below
@@ -350,6 +580,221 @@ void group_gemm_fp8_multistage_async(void *y_ptr, const void *x_ptr, const void 
     dispatch_k_stage(Int<48>{});
   } else {
     dispatch_k_stage(Int<64>{});
+  }
+}
+
+void group_gemm_fp8_route_async(void *y_ptr, const void *x_ptr, const void *w_ptr,
+                                const void *y_scale_ptr, const void *topk_ids_ptr,
+                                int num_routes, int num_topk, int n, int k,
+                                int num_expert_local, int rank_ep, bool input_is_token,
+                                cudaStream_t stream) {
+  using namespace cute;  // NOLINT
+  using Tin = cute::float_e4m3_t;
+  using Tout = cute::bfloat16_t;
+
+  assert(n % 64 == 0 && "group_gemm_fp8_route_async: n must be a multiple of 64");
+  assert(k % 64 == 0 && "group_gemm_fp8_route_async: k must be a multiple of 64");
+
+  constexpr int kTileM = 8;
+  constexpr int kTileN = 64;
+  const int num_tile_n = n / kTileN;
+  const int num_tasks = num_routes * num_tile_n;
+  if (num_tasks == 0) {
+    return;
+  }
+  cutlass::FastDivmod flat_divider(num_tile_n);
+  cutlass::FastDivmod split_divider(1);
+  cutlass::FastDivmod topk_divider(num_topk);
+  const int start_expert = rank_ep * num_expert_local;
+
+  auto launch = [&](auto tile_k_tag, auto stage_tag, auto input_is_token_tag) {
+    constexpr int kTileK = decltype(tile_k_tag)::value;
+    constexpr int kStage = decltype(stage_tag)::value;
+    constexpr bool kInputIsToken = decltype(input_is_token_tag)::value;
+    using GemmConfig = config::FP8GemmConfig<Tin, Tout, kTileM, kTileN, kTileK, kStage>;
+    GemmConfig gemm_config;
+    const int shm_size = gemm_config.kShmSize;
+    auto kernel =
+        kernels::group_gemm_fp8_route_kernel<GemmConfig, kInputIsToken, false>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shm_size);
+
+    cudaLaunchAttribute attr[1];
+    attr[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attr[0].val.programmaticStreamSerializationAllowed = 1;
+    cudaLaunchConfig_t cfg{};
+    const int max_grid = get_sm_count() * grid_multiplier(kTileM);
+    cfg.gridDim = dim3(num_tasks < max_grid ? num_tasks : max_grid);
+    cfg.blockDim = dim3(128);
+    cfg.dynamicSmemBytes = shm_size;
+    cfg.stream = stream;
+    cfg.attrs = attr;
+    cfg.numAttrs = 1;
+    cudaLaunchKernelEx(&cfg, kernel, y_ptr, x_ptr, w_ptr,
+                       static_cast<const float *>(y_scale_ptr), nullptr, nullptr,
+                       static_cast<const int *>(topk_ids_ptr), num_routes, num_topk, n, k,
+                       num_expert_local, start_expert, 1, k / kTileK, 0, 0,
+                       flat_divider, split_divider, topk_divider);
+  };
+
+  auto dispatch_input = [&](auto tile_k_tag, auto stage_tag) {
+    if (input_is_token) {
+      launch(tile_k_tag, stage_tag, std::true_type{});
+    } else {
+      launch(tile_k_tag, stage_tag, std::false_type{});
+    }
+  };
+  if (k % 128 == 0) {
+    dispatch_input(Int<128>{}, Int<2>{});
+  } else {
+    dispatch_input(Int<64>{}, Int<3>{});
+  }
+}
+
+void group_gemm_fp8_route_blockwise_async(
+    void *y_ptr, const void *x_ptr, const void *x_scale_ptr,
+    const void *w_ptr, const void *w_scale_ptr, const void *topk_ids_ptr,
+    int num_routes, int num_topk, int n, int k, int num_splits,
+    int num_expert_local, int rank_ep, bool input_is_token, int weight_scale_stride,
+    cudaStream_t stream) {
+  using namespace cute;  // NOLINT
+  using Tin = cute::float_e4m3_t;
+  using Tout = cute::bfloat16_t;
+
+  assert(n % 64 == 0 &&
+         "group_gemm_fp8_route_blockwise_async: n must be a multiple of 64");
+  assert(k % 64 == 0 &&
+         "group_gemm_fp8_route_blockwise_async: k must be a multiple of 64");
+  assert(num_splits > 0 &&
+         "group_gemm_fp8_route_blockwise_async: num_splits must be positive");
+
+  constexpr int kTileM = 8;
+  constexpr int kTileN = 64;
+  constexpr int kScaleBlock = 128;
+  const int num_tile_n = n / kTileN;
+  const int num_tasks = num_routes * num_splits * num_tile_n;
+  if (num_tasks == 0) {
+    return;
+  }
+  cutlass::FastDivmod flat_divider(num_tile_n);
+  cutlass::FastDivmod split_divider(num_splits);
+  cutlass::FastDivmod topk_divider(num_topk);
+  const int start_expert = rank_ep * num_expert_local;
+  const int input_scale_stride = (k + kScaleBlock - 1) / kScaleBlock;
+
+  auto launch = [&](auto tile_k_tag, auto stage_tag,
+                    auto input_is_token_tag) {
+    constexpr int kTileK = decltype(tile_k_tag)::value;
+    constexpr int kStage = decltype(stage_tag)::value;
+    constexpr bool kInputIsToken = decltype(input_is_token_tag)::value;
+    assert((k / kTileK) % num_splits == 0 &&
+           "group_gemm_fp8_route_blockwise_async: split must divide K tiles");
+    const int tiles_per_split = (k / kTileK) / num_splits;
+    using GemmConfig =
+        config::FP8GemmConfig<Tin, Tout, kTileM, kTileN, kTileK, kStage>;
+    GemmConfig gemm_config;
+    const int shm_size = gemm_config.kShmSize;
+    auto kernel =
+        kernels::group_gemm_fp8_route_kernel<GemmConfig, kInputIsToken, true>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                         shm_size);
+
+    cudaLaunchAttribute attr[1];
+    attr[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attr[0].val.programmaticStreamSerializationAllowed = 1;
+    cudaLaunchConfig_t cfg{};
+    const int max_grid = get_sm_count() * grid_multiplier(kTileM);
+    cfg.gridDim = dim3(num_tasks < max_grid ? num_tasks : max_grid);
+    cfg.blockDim = dim3(128);
+    cfg.dynamicSmemBytes = shm_size;
+    cfg.stream = stream;
+    cfg.attrs = attr;
+    cfg.numAttrs = 1;
+    cudaLaunchKernelEx(
+        &cfg, kernel, y_ptr, x_ptr, w_ptr, nullptr,
+        static_cast<const float *>(x_scale_ptr),
+        static_cast<const float *>(w_scale_ptr),
+        static_cast<const int *>(topk_ids_ptr), num_routes, num_topk, n, k,
+        num_expert_local, start_expert, num_splits, tiles_per_split, input_scale_stride,
+        weight_scale_stride, flat_divider, split_divider, topk_divider);
+  };
+
+  auto dispatch_input = [&](auto tile_k_tag, auto stage_tag) {
+    if (input_is_token) {
+      launch(tile_k_tag, stage_tag, std::true_type{});
+    } else {
+      launch(tile_k_tag, stage_tag, std::false_type{});
+    }
+  };
+  if (k % 128 == 0 && (k / 128) % num_splits == 0) {
+    dispatch_input(Int<128>{}, Int<2>{});
+  } else {
+    assert((k / 64) % num_splits == 0 &&
+           "group_gemm_fp8_route_blockwise_async: split must divide K tiles");
+    dispatch_input(Int<64>{}, Int<3>{});
+  }
+}
+
+void group_gemm_fp8_route_splitk_async(void *partial_ptr, const void *x_ptr,
+                                       const void *w_ptr, const void *y_scale_ptr,
+                                       const void *topk_ids_ptr, int num_routes,
+                                       int num_topk, int n, int k, int num_splits,
+                                       int num_expert_local, int rank_ep,
+                                       cudaStream_t stream) {
+  using namespace cute;  // NOLINT
+  using Tin = cute::float_e4m3_t;
+  using Tout = cute::bfloat16_t;
+
+  assert(n % 64 == 0 && "group_gemm_fp8_route_splitk_async: n must be a multiple of 64");
+  assert(k % 64 == 0 && "group_gemm_fp8_route_splitk_async: k must be a multiple of 64");
+  assert(num_splits > 0 && "group_gemm_fp8_route_splitk_async: num_splits must be positive");
+
+  constexpr int kTileM = 8;
+  constexpr int kTileN = 64;
+  const int num_tile_n = n / kTileN;
+  const int num_tasks = num_routes * num_splits * num_tile_n;
+  if (num_tasks == 0) {
+    return;
+  }
+  cutlass::FastDivmod flat_divider(num_tile_n);
+  cutlass::FastDivmod split_divider(num_splits);
+  cutlass::FastDivmod topk_divider(num_topk);
+  const int start_expert = rank_ep * num_expert_local;
+
+  auto launch = [&](auto tile_k_tag, auto stage_tag) {
+    constexpr int kTileK = decltype(tile_k_tag)::value;
+    constexpr int kStage = decltype(stage_tag)::value;
+    assert((k / kTileK) % num_splits == 0 &&
+           "group_gemm_fp8_route_splitk_async: split must divide K tiles");
+    const int tiles_per_split = (k / kTileK) / num_splits;
+
+    using GemmConfig = config::FP8GemmConfig<Tin, Tout, kTileM, kTileN, kTileK, kStage>;
+    GemmConfig gemm_config;
+    const int shm_size = gemm_config.kShmSize;
+    auto kernel = kernels::group_gemm_fp8_route_kernel<GemmConfig, true, false>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shm_size);
+
+    const int max_grid = get_sm_count() * grid_multiplier(kTileM);
+    cudaLaunchAttribute attr[1];
+    attr[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attr[0].val.programmaticStreamSerializationAllowed = 1;
+    cudaLaunchConfig_t cfg{};
+    cfg.gridDim = dim3(num_tasks < max_grid ? num_tasks : max_grid);
+    cfg.blockDim = dim3(128);
+    cfg.dynamicSmemBytes = shm_size;
+    cfg.stream = stream;
+    cfg.attrs = attr;
+    cfg.numAttrs = 1;
+    cudaLaunchKernelEx(&cfg, kernel, partial_ptr, x_ptr, w_ptr,
+                       static_cast<const float *>(y_scale_ptr), nullptr, nullptr,
+                       static_cast<const int *>(topk_ids_ptr), num_routes, num_topk, n, k,
+                       num_expert_local, start_expert, num_splits, tiles_per_split,
+                       0, 0, flat_divider, split_divider, topk_divider);
+  };
+
+  if (k % 128 == 0 && (k / 128) % num_splits == 0) {
+    launch(Int<128>{}, Int<2>{});
+  } else {
+    launch(Int<64>{}, Int<3>{});
   }
 }
 

--- a/tests/test_fuse_moe_blockwise.py
+++ b/tests/test_fuse_moe_blockwise.py
@@ -99,31 +99,29 @@ def naive_group_gemm(x, w, num_tokens_per_expert, cu_num_tokens_per_expert, xsca
 
         x_scale_group = xscale[start_idx:end_idx]  # (m, k / 128)
         w_scale_group = wscale[i]  # (n/128, 64)
-        w_scale_group = w_scale_group[:, : k // 128]
+        w_scale_group = w_scale_group[:, : (k + 127) // 128]
 
         assert x_group.size(1) == w_group.size(1)
         assert w_scale_group.size(0) == w_group.size(0) // 128
-        assert w_scale_group.size(1) == w_group.size(1) // 128
+        assert w_scale_group.size(1) == (w_group.size(1) + 127) // 128
 
         output = torch.zeros((m, n), dtype=torch.float32, device=x_group.device)
 
         num_tile_n = n // 128
-        num_tile_k = k // 128
-
-        x_chunks = torch.chunk(x_group, num_tile_k, dim=1)
-        w_chunks = torch.chunk(w_group, num_tile_k, dim=1)
+        num_tile_k = (k + 127) // 128
 
         for n in range(num_tile_n):
             tmp = torch.zeros((m, 128), dtype=torch.float32, device=x_group.device)
             for k in range(num_tile_k):
-                x_i = x_chunks[k]  # （m, 128)
+                start_k = k * 128
+                end_k = min(start_k + 128, x_group.size(1))
+                x_i = x_group[:, start_k:end_k]
                 x_scale_i = x_scale_group[:, k]  # (m, 1)
                 w_scale_i = w_scale_group[n, k]  # (1)
                 assert x_scale_i.size(0) == x_i.size(0)
                 assert w_scale_i.numel() == 1
 
-                w_chunk = w_chunks[k]  # (n, 128)
-                w_i = w_chunk[n * 128 : (n + 1) * 128].t()  # (128, 128)
+                w_i = w_group[n * 128 : (n + 1) * 128, start_k:end_k].t()
 
                 scale_a = torch.tensor([1.0], dtype=torch.float32, device="cuda")
                 scale_b = torch.tensor([1.0], dtype=torch.float32, device="cuda")
@@ -348,3 +346,116 @@ def test_fuse_moe_blockwise_fp8(
     torch.cuda.synchronize()
 
     assert allclose(gt.to(torch.float32), my.to(torch.float32), rtol=0.01, atol=0.01)
+
+
+@pytest.mark.parametrize(
+    "num_tokens,hidden_size,intermediate_size",
+    [(num_tokens, 256, 256) for num_tokens in [1, 2, 3, 4, 8, 16]]
+    # Intermediate tails are covered only inside the B<=4 route-MMA range.
+    # Tail support in the legacy fallback path is a separate change.
+    + [(num_tokens, 256, 192) for num_tokens in [1, 2, 3, 4]]
+    + [
+        (1, 2048, 768),
+        (2, 4096, 192),
+        (4, 4096, 512),
+    ],
+)
+@pytest.mark.parametrize("size_ep", [1, 2])
+@pytest.mark.parametrize("has_shared_output", [False, True])
+def test_fuse_moe_blockwise_fp8_small_batch_route_mma(
+    num_tokens, hidden_size, intermediate_size, size_ep, has_shared_output
+):
+    dtype = torch.float8_e4m3fn
+    num_expert = 16
+    rank_ep = 0 if size_ep == 1 else 1
+    num_topk = 8
+
+    topk_ids = torch.multinomial(
+        torch.ones((num_tokens, num_expert), dtype=torch.float, device="cuda"),
+        num_topk,
+        replacement=False,
+    ).to(torch.int32)
+    topk_ids, _ = torch.sort(topk_ids, dim=1)
+    topk_scale = torch.rand((num_tokens, num_topk), dtype=torch.float, device="cuda")
+    topk_scale /= topk_scale.sum(dim=1, keepdim=True)
+    x = (torch.randn((num_tokens, hidden_size), device="cuda") / 100).to(dtype)
+
+    def make_scale(shape):
+        # Dequantization scales are positive in production checkpoints. Keep
+        # the original signed stress distribution for the legacy small shapes.
+        if hidden_size > 256:
+            return torch.rand(shape, device="cuda") * 0.02
+        return torch.randn(shape, device="cuda")
+
+    x_scale = make_scale((num_tokens, hidden_size // 128))
+    gate_up_weight = torch.randn(
+        (num_expert // size_ep, intermediate_size * 2, hidden_size), device="cuda"
+    ).to(dtype)
+    gate_up_weight_scale = make_scale(
+        (
+            num_expert // size_ep,
+            intermediate_size * 2 // 128,
+            (hidden_size // 128 + 3) // 4 * 4,
+        )
+    )
+    down_weight = torch.randn(
+        (num_expert // size_ep, hidden_size, intermediate_size), device="cuda"
+    ).to(dtype)
+    down_weight_scale = make_scale(
+        (
+            num_expert // size_ep,
+            hidden_size // 128,
+            ((intermediate_size + 127) // 128 + 3) // 4 * 4,
+        )
+    )
+    shared_output = (
+        torch.randn((num_tokens, hidden_size), dtype=torch.bfloat16, device="cuda")
+        if has_shared_output
+        else None
+    )
+
+    if hidden_size > 256:
+        output = torch.empty((num_tokens, hidden_size), dtype=torch.bfloat16, device="cuda")
+        my = hpc.fuse_moe_blockwise(
+            x,
+            x_scale,
+            gate_up_weight,
+            gate_up_weight_scale,
+            down_weight,
+            down_weight_scale,
+            topk_ids,
+            topk_scale,
+            rank_ep,
+            num_expert,
+            shared_output,
+            output,
+        )
+        assert my.data_ptr() == output.data_ptr()
+    else:
+        my = hpc.fuse_moe_blockwise_fp8(
+            x,
+            x_scale,
+            gate_up_weight,
+            gate_up_weight_scale,
+            down_weight,
+            down_weight_scale,
+            topk_ids,
+            topk_scale,
+            rank_ep,
+            num_expert,
+            shared_output,
+        )
+    gt = naive_fuse_moe_blockwise_fp8(
+        x,
+        x_scale,
+        gate_up_weight,
+        gate_up_weight_scale,
+        down_weight,
+        down_weight_scale,
+        topk_ids,
+        topk_scale,
+        rank_ep,
+        num_expert,
+        shared_output,
+    )
+    assert allclose(gt.float(), my.float(), rtol=0.01, atol=0.01)

--- a/tests/test_fuse_moe_cp_async.py
+++ b/tests/test_fuse_moe_cp_async.py
@@ -144,7 +144,7 @@ def naive_fuse_moe_pertensor_fp8(
 
 
 # hunyuan-v3 TP=8 EP=1 shape: E=192, topk=8, H=4096, I=192 (= 1536/8)
-@pytest.mark.parametrize("num_seq", [128])
+@pytest.mark.parametrize("num_seq", [1, 2, 3, 4, 8, 128])
 @pytest.mark.parametrize("num_topk", [8])
 @pytest.mark.parametrize("hidden_size", [4096])
 @pytest.mark.parametrize("intermediate_size", [192])


### PR DESCRIPTION
## perf(moe): add a route-direct WGMMA path for small-batch FP8 MoE

## Summary

This PR adds an SM90a route-direct WGMMA path for small-batch FP8 MoE decode, covering both per-tensor and 128x128 blockwise quantization.

For the production dispatch range (batch 1-4, top-k 8), the new path reduces single-op CUDA Graph latency by **9.25%-38.57%** (**1.10x-1.63x**) on the three H20 workloads measured below.

The fast path:

- reads the expert directly from each token/top-k route;
- bypasses expert sorting, input gathering, prefix sums, and task-map construction;
- uses route-direct FP8 WGMMA for both Gate/Up and Down projections;
- optionally splits the long Gate/Up K dimension to expose enough parallel work;
- combines split reduction, SwiGLU, and Down-input quantization;
- preserves EP routing, shared output, preallocated output, and CUDA Graph capture.

Shapes outside the selected range continue to use the existing implementation.

## Motivation

The existing MoE path is designed around grouping rows by expert:

`count/sort -> gather -> prefix/task map -> Gate/Up grouped GEMM -> activation/quantization -> Down grouped GEMM -> scatter/top-k reduction`

This is efficient once each expert receives enough rows. During decode, however, `B * top_k` can be much smaller than the expert count. For example, batch 1 with top-k 8 creates only eight routes across 128 or 192 experts. Most experts receive zero rows, so sorting, padding, gathering, metadata construction, and intermediate traffic dominate the useful matrix multiplication.

The new path keeps data in route order:

`topk routes -> route Gate/Up WGMMA -> split reduction + SwiGLU + FP8 quantization -> route Down WGMMA -> contiguous top-k reduction`

Each logical route is assigned to one SM90 M=8 WGMMA tile. Row 0 carries the route and rows 1-7 are zero-filled. Although this intentionally under-utilizes the M dimension, it avoids the larger fixed cost of expert grouping for very small batches.

## Code changes

- Added `src/fuse_moe/small_batch_route_mma.{h,cu}` to orchestrate the per-tensor and blockwise route pipelines.
- Added route-direct and split-K launchers to `src/group_gemm/cp_async/group_gemm.{h,cu}`.
- Added small-batch dispatch, split selection, contiguous workspace allocation, output validation, and preallocated-output support in `src/fuse_moe/entry.cc`.
- Tightened the existing per-tensor cp.async task-map bound to the actual non-empty workload and added missing input/output shape, dtype, device, and contiguity validation.
- Updated `src/fuse_moe/reduce.cu` to reduce contiguous route-order outputs without a `topk_pos` map.

## Dispatch

The production dispatch remains deliberately conservative.

### Per-tensor FP8

- `1 <= batch <= 4`
- `top_k == 8`
- `0 < I <= 512`
- `H % 64 == 0`
- `I % 64 == 0`

### Blockwise FP8

- `1 <= batch <= 4`
- `top_k == 8`
- `H <= 4096`
- `128 <= I <= 768`
- `H % 128 == 0`
- `I % 64 == 0`

All other shapes use the existing path. The forced B=5-8 measurements below characterize the profitability boundary only; this PR does not enable those batches in production dispatch.

## Correctness

### Regression and targeted validation

| Check | Result |
|---|---:|
| Full pytest regression | 452 passed in 183.76 s |
| Additional targeted cases | 14/14 passed |
| CUDA Graph replay | Bitwise equal to eager output |

Reference-comparison metrics:

| Quantization | Worst relative L2 | Minimum cosine similarity |
|---|---:|---:|
| Blockwise | 1.61% | 0.999873 |
| Per-tensor | 1.47% | 0.999892 |

## Performance

### Methodology

- GPU: NVIDIA H20 96 GB (SM90)
- Driver: 535.161.08
- CUDA: 13.0
- PyTorch: 2.11.0+cu130
- `top_k=8`
- Single-op CUDA Graph capture with preallocated output

To isolate the fast path, both binaries were built from the same clean `bc97d55` source:

- **Same-source fallback:** route-MMA dispatch disabled.
- **Forced route-MMA:** batch 1-8 forced through route-MMA while retaining all other shape constraints.

`Speedup = fallback latency / route-MMA latency`.

### Per-tensor Hunyuan-V3 TP8: E=192, H=4096, I=192

| Batch | Same-source fallback (us) | Forced route-MMA (us) | Speedup | Latency reduction |
|---:|---:|---:|---:|---:|
| 1 | 20.767 | 13.243 | 1.568x | 36.23% |
| 2 | 27.400 | 16.833 | 1.628x | 38.57% |
| 3 | 33.864 | 22.773 | 1.487x | 32.75% |
| 4 | 41.668 | 30.663 | 1.359x | 26.41% |
| 5 | 45.830 | 35.983 | 1.274x | 21.49% |
| 6 | 49.833 | 41.554 | 1.199x | 16.61% |
| 7 | 53.052 | 47.259 | 1.123x | 10.92% |
| 8 | 56.848 | 54.124 | 1.050x | 4.79% |

This shape remains profitable through B=8. A future shape-aware dispatch could extend its range independently of the blockwise paths.


### Blockwise Qwen3: E=128, H=2048, I=768

| Batch | Same-source fallback (us) | Forced route-MMA (us) | Speedup | Latency reduction |
|---:|---:|---:|---:|---:|
| 1 | 24.725 | 17.349 | 1.425x | 29.83% |
| 2 | 41.528 | 29.863 | 1.391x | 28.09% |
| 3 | 50.437 | 40.708 | 1.239x | 19.29% |
| 4 | 58.109 | 52.732 | 1.102x | 9.25% |
| 5 | 67.782 | 62.510 | 1.084x | 7.78% |
| 6 | 75.988 | 73.040 | 1.040x | 3.88% |
| 7 | 83.356 | 84.419 | 0.987x | -1.28% |
| 8 | 89.050 | 94.352 | 0.944x | -5.95% |

Route-MMA remains profitable through B=6 for this measured shape and crosses over between B=6 and B=7.

### Blockwise: E=128, H=4096, I=512

| Batch | Same-source fallback (us) | Forced route-MMA (us) | Speedup | Latency reduction |
|---:|---:|---:|---:|---:|
| 1 | 29.845 | 19.779 | 1.509x | 33.73% |
| 2 | 50.389 | 37.585 | 1.341x | 25.41% |
| 3 | 64.916 | 52.295 | 1.241x | 19.44% |
| 4 | 73.862 | 63.833 | 1.157x | 13.58% |
| 5 | 86.072 | 85.218 | 1.010x | 0.99% |
| 6 | 98.718 | 98.465 | 1.003x | 0.26% |
| 7 | 107.532 | 111.362 | 0.966x | -3.56% |
| 8 | 117.451 | 121.922 | 0.963x | -3.81% |

B=5-6 are effectively at the noise boundary, while B=7-8 regress. The conservative B<=4 production threshold is appropriate for this shape.


## Conclusions

Within the current B=1-4 production range, route-MMA improves all three measured workloads by **1.10x-1.63x**.

