### PR TITLE
[ROCm] Add ROCm support and norm op.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,49 +1,117 @@
 cmake_minimum_required(VERSION 3.18)
-project(hpc_ops LANGUAGES CXX CUDA)
 
-enable_language(CUDA)
+# ROCm/HIP support is opt-in via -DUSE_ROCM=ON (or the USE_ROCM env var). When
+# off, the build is byte-for-byte the original NVIDIA CUDA path. When on, only
+# the already-ported operators under src/amd/ are compiled for AMD GPUs; the
+# CUDA-only kernels (attention/moe/gemm/... which depend on CUTLASS/CuTe/Hopper
+# TMA) are excluded because they do not build on AMD.
+option(USE_ROCM "Build the ROCm/HIP backend instead of CUDA" OFF)
+if(NOT USE_ROCM AND DEFINED ENV{USE_ROCM})
+  set(USE_ROCM $ENV{USE_ROCM})
+endif()
+
+if(USE_ROCM)
+  # Default to gfx950 (MI350X), but let PYTORCH_ROCM_ARCH override it. Must be
+  # set before enable_language(HIP) so the HIP compiler picks up the target.
+  if(NOT DEFINED CMAKE_HIP_ARCHITECTURES)
+    if(DEFINED ENV{PYTORCH_ROCM_ARCH})
+      set(CMAKE_HIP_ARCHITECTURES $ENV{PYTORCH_ROCM_ARCH})
+    else()
+      set(CMAKE_HIP_ARCHITECTURES gfx950)
+    endif()
+  endif()
+  project(hpc_ops LANGUAGES CXX HIP)
+  enable_language(HIP)
+  find_package(hip REQUIRED)
+else()
+  project(hpc_ops LANGUAGES CXX CUDA)
+  enable_language(CUDA)
+  find_package(CUDAToolkit REQUIRED)
+endif()
+
 set(CMAKE_BUILD_TYPE "Release")
 
-find_package(CUDAToolkit REQUIRED)
 find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
 
-file(GLOB_RECURSE SOURCES "src/*/*.cu" "src/*/*.cc")
-file(GLOB CP_ASYNC_SOURCES "src/fuse_moe/cp_async/*.cu" "src/group_gemm/cp_async/*.cu"
-                           "src/group_gemm/cp_async/*.cc")
-list(APPEND SOURCES ${CP_ASYNC_SOURCES})
-list(FILTER SOURCES EXCLUDE REGEX ".*test.*")
+if(USE_ROCM)
+  # ROCm: explicit allowlist of ported sources only. Do NOT glob src/*, that
+  # would pull in the CUDA-only kernels. Keep paths free of the substring
+  # "test" (the CUDA glob below filters it, and we mirror that convention).
+  set(SOURCES
+      ${CMAKE_SOURCE_DIR}/src/C/C.cc
+      ${CMAKE_SOURCE_DIR}/src/C/version.cc
+      ${CMAKE_SOURCE_DIR}/src/amd/C/built_json.cc
+      ${CMAKE_SOURCE_DIR}/src/amd/normalization/entry.cc
+      ${CMAKE_SOURCE_DIR}/src/amd/normalization/fused_rmsnorm_with_scale.cu)
+  # Treat .cu files as HIP so hipcc compiles them.
+  set_source_files_properties(
+    ${CMAKE_SOURCE_DIR}/src/amd/normalization/fused_rmsnorm_with_scale.cu
+    PROPERTIES LANGUAGE HIP)
+else()
+  file(GLOB_RECURSE SOURCES "src/*/*.cu" "src/*/*.cc")
+  file(GLOB CP_ASYNC_SOURCES "src/fuse_moe/cp_async/*.cu" "src/group_gemm/cp_async/*.cu"
+                             "src/group_gemm/cp_async/*.cc")
+  list(APPEND SOURCES ${CP_ASYNC_SOURCES})
+  list(FILTER SOURCES EXCLUDE REGEX ".*test.*")
+  # Exclude the ROCm-only tree from the CUDA build.
+  list(FILTER SOURCES EXCLUDE REGEX ".*/src/amd/.*")
+endif()
 
 
 add_library(_C MODULE ${SOURCES})
 
-set_target_properties(
-  _C PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/
+if(USE_ROCM)
+  set_target_properties(
+    _C PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/
 
-  OUTPUT_NAME "_C"
-  PREFIX ""
-  SUFFIX ".abi3.so"
-  CUDA_RUNTIME_LIBRARY "Shared"
+    OUTPUT_NAME "_C"
+    PREFIX ""
+    SUFFIX ".abi3.so"
 
-  CUDA_SEPARABLE_COMPILATION OFF
-  CUDA_RESOLVE_DEVICE_SYMBOLS ON
-  SKIP_BUILD_RPATH TRUE
+    SKIP_BUILD_RPATH TRUE
 
-  C_VISIBILITY_PRESET "hidden"
-  CXX_VISIBILITY_PRESET "hidden"
-  VISIBILITY_INLINES_HIDDEN ON
-  CUDA_VISIBILITY_PRESET "hidden"
+    C_VISIBILITY_PRESET "hidden"
+    CXX_VISIBILITY_PRESET "hidden"
+    VISIBILITY_INLINES_HIDDEN ON
+    HIP_VISIBILITY_PRESET "hidden"
 
-  CXX_STANDARD 17
-  CXX_STANDARD_REQUIRED ON
-  CXX_EXTENSIONS OFF
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
 
-  CUDA_STANDARD 17
-  CUDA_STANDARD_REQUIRED ON
-  CUDA_EXTENSIONS OFF
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+    HIP_EXTENSIONS OFF)
+else()
+  set_target_properties(
+    _C PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/
 
-  CUDA_ARCHITECTURES "90a"
-)
+    OUTPUT_NAME "_C"
+    PREFIX ""
+    SUFFIX ".abi3.so"
+    CUDA_RUNTIME_LIBRARY "Shared"
+
+    CUDA_SEPARABLE_COMPILATION OFF
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    SKIP_BUILD_RPATH TRUE
+
+    C_VISIBILITY_PRESET "hidden"
+    CXX_VISIBILITY_PRESET "hidden"
+    VISIBILITY_INLINES_HIDDEN ON
+    CUDA_VISIBILITY_PRESET "hidden"
+
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+
+    CUDA_STANDARD 17
+    CUDA_STANDARD_REQUIRED ON
+    CUDA_EXTENSIONS OFF
+
+    CUDA_ARCHITECTURES "90a")
+endif()
 
 target_compile_definitions(
   _C PRIVATE
@@ -70,48 +138,97 @@ print(';'.join(library_paths()), end='')
 )
 
 
-target_include_directories(
-  _C PRIVATE
-  ./
-  3rd/cutlass/include
-  ${CUDAToolkit_INCLUDE_DIRS}
-  ${TORCH_INCLUDE_PATHS}
-)
+if(USE_ROCM)
+  target_include_directories(
+    _C PRIVATE
+    ./
+    ${TORCH_INCLUDE_PATHS}
+    $ENV{ROCM_PATH}/include
+    /opt/rocm/include
+  )
+else()
+  target_include_directories(
+    _C PRIVATE
+    ./
+    3rd/cutlass/include
+    ${CUDAToolkit_INCLUDE_DIRS}
+    ${TORCH_INCLUDE_PATHS}
+  )
+endif()
 
 target_link_directories(
   _C PRIVATE
   ${TORCH_LIBRARY_PATHS}
 )
 
-target_link_libraries(
-  _C PRIVATE
-  cuda
-  c10
-  torch
-  torch_cpu
-  cudart
-  c10_cuda
-  torch_cuda
-)
+if(USE_ROCM)
+  target_link_libraries(
+    _C PRIVATE
+    hip::host
+    c10
+    torch
+    torch_cpu
+    c10_hip
+    torch_hip
+  )
+else()
+  target_link_libraries(
+    _C PRIVATE
+    cuda
+    c10
+    torch
+    torch_cpu
+    cudart
+    c10_cuda
+    torch_cuda
+  )
+endif()
 
-target_compile_options(
-  _C PRIVATE
-  $<$<COMPILE_LANGUAGE:CUDA>:
-    -Werror=all-warnings
-    -lineinfo
-    --expt-relaxed-constexpr
-    -std=c++17
-    -DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED
-    -DNDEBUG
-    -Xptxas=-warn-double-usage,-v
-  >
-  $<$<COMPILE_LANGUAGE:CXX>:
-    -Wno-unused-result
-    -Wsign-compare
-    -g
-    -fwrapv
-    -Wall
-    -DTORCH_API_INCLUDE_EXTENSION_H
-    -DTORCH_EXTENSION_NAME=_C
-  >
-)
+if(USE_ROCM)
+  # ROCm PyTorch requires these macros so the CUDA-named ATen/torch headers
+  # resolve to their HIP backing (same set torch's cpp_extension injects).
+  target_compile_definitions(
+    _C PRIVATE
+    __HIP_PLATFORM_AMD__=1
+    USE_ROCM=1
+    HIPBLAS_V2
+  )
+  target_compile_options(
+    _C PRIVATE
+    $<$<COMPILE_LANGUAGE:HIP>:
+      -std=c++17
+      -DNDEBUG
+    >
+    $<$<COMPILE_LANGUAGE:CXX>:
+      -Wno-unused-result
+      -Wsign-compare
+      -g
+      -fwrapv
+      -Wall
+      -DTORCH_API_INCLUDE_EXTENSION_H
+      -DTORCH_EXTENSION_NAME=_C
+    >
+  )
+else()
+  target_compile_options(
+    _C PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:
+      -Werror=all-warnings
+      -lineinfo
+      --expt-relaxed-constexpr
+      -std=c++17
+      -DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED
+      -DNDEBUG
+      -Xptxas=-warn-double-usage,-v
+    >
+    $<$<COMPILE_LANGUAGE:CXX>:
+      -Wno-unused-result
+      -Wsign-compare
+      -g
+      -fwrapv
+      -Wall
+      -DTORCH_API_INCLUDE_EXTENSION_H
+      -DTORCH_EXTENSION_NAME=_C
+    >
+  )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,12 @@ if(USE_ROCM)
     $<$<COMPILE_LANGUAGE:HIP>:
       -std=c++17
       -DNDEBUG
+      # Preload kernel arguments into SGPRs so each wave skips the per-launch
+      # s_load + s_waitcnt of the kernarg segment. Matches what Triton emits by
+      # default on gfx9; measurably reduces launch overhead for these short,
+      # wave-dense normalization kernels.
+      -mllvm
+      -amdgpu-kernarg-preload-count=16
     >
     $<$<COMPILE_LANGUAGE:CXX>:
       -Wno-unused-result

--- a/README.md
+++ b/README.md
@@ -184,14 +184,20 @@ softmax statistics to reduce vocabulary reads and fixed launch overhead.
 ## Quick Start
 
 ### Requirements
+
+For the NVIDIA CUDA build (full operator set):
 - NVIDIA SM90 architecture GPU
 - Python 3.8 or higher
 - Compilers with C++17 support
 - CUDA Toolkit: CUDA 12.8 or higher
 
+For the AMD ROCm build (currently the normalization operators only):
+- AMD gfx950 (MI350X) GPU
+- ROCm 7.2 or higher, with a matching ROCm build of PyTorch (`torch.version.hip` must be set)
+
 *You can set up the environment by installing the modules listed in requirements-dev.txt.*
 
-### Install from Source
+### Install from Source (NVIDIA CUDA)
 
 ```bash
 git clone https://github.com/Tencent/hpc-ops.git
@@ -200,6 +206,24 @@ cd hpc-ops
 # build packages
 make wheel
 python3 -m pip install dist/*.whl
+```
+
+### Install from Source (AMD ROCm)
+
+The ROCm backend is opt-in via `USE_ROCM=1` and builds only the ported operators
+under `src/amd/`. The target architecture defaults to `gfx950` and can be
+overridden with `PYTORCH_ROCM_ARCH`.
+
+```bash
+git clone https://github.com/Tencent/hpc-ops.git
+cd hpc-ops
+
+# build packages (defaults to gfx950; set PYTORCH_ROCM_ARCH to target another arch)
+USE_ROCM=1 make wheel
+
+# install WITHOUT dependency resolution so pip does not replace your ROCm
+# PyTorch with a CUDA build from PyPI
+python3 -m pip install --no-deps dist/*.whl
 ```
 
 ### Basic Usage

--- a/hpc/__init__.py
+++ b/hpc/__init__.py
@@ -23,6 +23,16 @@ def _discover_modules() -> Dict[str, ModuleType]:
             modules[module_name] = module
         except ImportError as e:
             print(f"WARNING: Failed to import {module_name}: {str(e)}", file=sys.stderr)
+        except RuntimeError as e:
+            # A partial build (e.g. the ROCm backend only compiles the ported
+            # operators) leaves some ops unregistered, so a module's
+            # register_fake for a missing op raises RuntimeError. Skip that
+            # module instead of aborting the whole package import.
+            print(
+                f"WARNING: Skipping {module_name}: operator not available in this build "
+                f"({str(e)})",
+                file=sys.stderr,
+            )
 
     return modules
 

--- a/src/amd/C/built_json.cc
+++ b/src/amd/C/built_json.cc
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Tencent.
+// ROCm/HIP build-info reporter. Mirrors src/C/built_json.cu but reports the HIP
+// toolchain instead of nvcc/cutlass/cub (which do not exist in a ROCm build).
+
+#include <hip/hip_version.h>
+#include <torch/library.h>
+
+#include <sstream>
+#include <string>
+
+#ifndef HPC_VERSION_STR
+#define HPC_VERSION_STR "unknown"
+#endif
+
+#ifndef HPC_GIT_HASH_STR
+#define HPC_GIT_HASH_STR "unknown"
+#endif
+
+static const std::string built_json() {
+  std::ostringstream oss;
+
+  // NOLINTBEGIN clang-format off
+  oss << "{" << "\n";
+  oss << " \"version\": " << "\"" << HPC_VERSION_STR << "\",\n";
+  oss << " \"git-hash\": " << "\"" << HPC_GIT_HASH_STR << "\",\n";
+  oss << " \"g++\": " << "\"g++-" << __GNUC__ << "." << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__
+      << "\",\n";
+  oss << " \"hip\": " << "\"" << HIP_VERSION_MAJOR << "." << HIP_VERSION_MINOR << "."
+      << HIP_VERSION_PATCH << "\",\n";
+  oss << " \"stdc++\": " << "\"" << __cplusplus << "." << "\",\n";
+  oss << " \"backend\": " << "\"rocm\",\n";
+  oss << " \"built-date\": " << "\"" << __DATE__ << "\",\n";
+  oss << " \"built-time\": " << "\"" << __TIME__ << "\",\n";
+  oss << " \"_C\": " << "\"" << __FILE__ << "\"\n";
+  oss << "}\n";
+  // NOLINTEND clang-format on
+
+  return oss.str();
+}
+
+TORCH_LIBRARY_FRAGMENT(hpc, m) { m.def("built_json", &built_json); }

--- a/src/amd/normalization/entry.cc
+++ b/src/amd/normalization/entry.cc
@@ -1,0 +1,64 @@
+// Copyright 2025 hpc-ops authors
+
+// ROCm PyTorch exposes the current stream through the HIP ATen headers. The
+// "MasqueradingAsCUDA" stream is torch's official CUDA->HIP bridge (it is what
+// hipify rewrites at::cuda::getCurrentCUDAStream into on ROCm).
+#include <ATen/hip/HIPContext.h>
+#include <hip/hip_runtime_api.h>
+#include <torch/all.h>
+#include <torch/library.h>
+
+#include <limits>
+#include <tuple>
+
+#include "src/amd/normalization/fused_rmsnorm_with_scale.h"
+
+namespace hpc {
+namespace normalization {
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> fused_rmsnorm_with_scale_entry(
+    const torch::Tensor &input, const torch::Tensor &weight, const torch::Tensor &scale, double eps,
+    bool is_moe) {
+  auto stream = at::hip::getCurrentHIPStreamMasqueradingAsCUDA(input.get_device());
+
+  TORCH_CHECK(input.scalar_type() == torch::kBFloat16 && weight.scalar_type() == torch::kBFloat16,
+              "input and weight must be bfloat16.");
+
+  torch::Tensor output = torch::empty_like(input, torch::kFloat8_e4m3fn);
+  torch::Tensor output_fp32 = torch::empty_like(input, torch::kFloat32);
+  torch::Tensor output_scale2 = torch::empty_like(input, torch::kFloat8_e4m3fn);
+
+  void *output_fp32_ptr = nullptr;
+  void *output_scale2_ptr = nullptr;
+  if (is_moe) {
+    output_fp32_ptr = output_fp32.mutable_data_ptr();
+    output_scale2_ptr = output_scale2.mutable_data_ptr();
+  }
+
+  int hidden_state = input.size(input.dim() - 1);
+  int batch_size = input.numel() / hidden_state;
+
+  const auto *input_ptr = input.const_data_ptr();
+  const auto *weight_ptr = weight.const_data_ptr();
+  const auto *scale_ptr = scale.const_data_ptr();
+  auto *output_ptr = output.mutable_data_ptr();
+
+  auto running = fused_rmsnorm_with_scale_async(input_ptr, weight_ptr, output_ptr, output_fp32_ptr,
+                                                output_scale2_ptr, scale_ptr, eps, batch_size,
+                                                hidden_state, is_moe, stream);
+
+  TORCH_CHECK(running, "fused_rmsnorm_with_scale_async launch failed!");
+
+  return std::make_tuple(output, output_fp32, output_scale2);
+}
+
+}  // namespace normalization
+}  // namespace hpc
+
+TORCH_LIBRARY_FRAGMENT(hpc, m) {
+  m.def(
+      "fused_rmsnorm_with_scale(Tensor input, Tensor weight, Tensor scale, float eps, bool "
+      "is_moe) -> (Tensor, Tensor, Tensor)");
+  m.impl("fused_rmsnorm_with_scale", torch::kCUDA,
+         &hpc::normalization::fused_rmsnorm_with_scale_entry);
+}

--- a/src/amd/normalization/entry.cc
+++ b/src/amd/normalization/entry.cc
@@ -25,14 +25,24 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> fused_rmsnorm_with_scale
               "input and weight must be bfloat16.");
 
   torch::Tensor output = torch::empty_like(input, torch::kFloat8_e4m3fn);
-  torch::Tensor output_fp32 = torch::empty_like(input, torch::kFloat32);
-  torch::Tensor output_scale2 = torch::empty_like(input, torch::kFloat8_e4m3fn);
 
+  // output_fp32 / output_scale2 are only produced (and only read by the Python
+  // wrapper) on the MoE path; on the non-MoE path they are unused, so allocate
+  // zero-element placeholders instead of full input-sized buffers (the fp32 one
+  // is 4x the input bytes) to drop that per-call allocation cost.
+  torch::Tensor output_fp32;
+  torch::Tensor output_scale2;
   void *output_fp32_ptr = nullptr;
   void *output_scale2_ptr = nullptr;
   if (is_moe) {
+    output_fp32 = torch::empty_like(input, torch::kFloat32);
+    output_scale2 = torch::empty_like(input, torch::kFloat8_e4m3fn);
     output_fp32_ptr = output_fp32.mutable_data_ptr();
     output_scale2_ptr = output_scale2.mutable_data_ptr();
+  } else {
+    auto opts = input.options();
+    output_fp32 = torch::empty({0}, opts.dtype(torch::kFloat32));
+    output_scale2 = torch::empty({0}, opts.dtype(torch::kFloat8_e4m3fn));
   }
 
   int hidden_state = input.size(input.dim() - 1);

--- a/src/amd/normalization/fused_rmsnorm_with_scale.cu
+++ b/src/amd/normalization/fused_rmsnorm_with_scale.cu
@@ -4,7 +4,7 @@
 #include <iostream>
 
 #include "src/amd/normalization/fused_rmsnorm_with_scale.h"
-#include "src/amd/normalization/utils_hip.cuh"
+#include "src/amd/utils/utils_hip.cuh"
 
 namespace hpc {
 namespace normalization {
@@ -121,24 +121,25 @@ __global__ void fused_rmsnorm_with_scale(const __hip_bfloat16 *input_ptr,
 
         auto &split_input = reshape<2, kItemPer16B / 2>(reg_input[iter]);
         if constexpr (kIsMoe) {
-          store(&output_ptr_fp32[istore], split_input[0]);
-          store(&output_ptr_fp32[istore + kItemPer16B / 2], split_input[1]);
+          store_streaming(&output_ptr_fp32[istore], split_input[0]);
+          store_streaming(&output_ptr_fp32[istore + kItemPer16B / 2], split_input[1]);
 #pragma unroll
           for (int i = 0; i < kItemPer16B; i++) {
             reg_input[iter][i] *= inv_scale2;
           }
 
-          store(&output_ptr_fp8_scale2[istore], to<__hip_fp8x4_e4m3>(split_input[0]));
-          store(&output_ptr_fp8_scale2[istore + kItemPer16B / 2],
-                to<__hip_fp8x4_e4m3>(split_input[1]));
+          store_streaming(&output_ptr_fp8_scale2[istore], to<__hip_fp8x4_e4m3>(split_input[0]));
+          store_streaming(&output_ptr_fp8_scale2[istore + kItemPer16B / 2],
+                          to<__hip_fp8x4_e4m3>(split_input[1]));
 #pragma unroll
           for (int i = 0; i < kItemPer16B; i++) {
             reg_input[iter][i] *= inv_scale;
           }
         }
 
-        store(&output_ptr_fp8[istore], to<__hip_fp8x4_e4m3>(split_input[0]));
-        store(&output_ptr_fp8[istore + kItemPer16B / 2], to<__hip_fp8x4_e4m3>(split_input[1]));
+        store_streaming(&output_ptr_fp8[istore], to<__hip_fp8x4_e4m3>(split_input[0]));
+        store_streaming(&output_ptr_fp8[istore + kItemPer16B / 2],
+                        to<__hip_fp8x4_e4m3>(split_input[1]));
       }
     }
   }

--- a/src/amd/normalization/fused_rmsnorm_with_scale.cu
+++ b/src/amd/normalization/fused_rmsnorm_with_scale.cu
@@ -1,0 +1,235 @@
+// Copyright 2025 hpc-ops authors
+#include <hip/hip_runtime.h>
+
+#include <iostream>
+
+#include "src/amd/normalization/fused_rmsnorm_with_scale.h"
+#include "src/amd/normalization/utils_hip.cuh"
+
+namespace hpc {
+namespace normalization {
+
+// Warp/wavefront width: 64 lanes on AMD CDNA, 32 on NVIDIA. All the tiling math
+// (kIterPerBatch, column offsets, block dim) derives from this constant, so the
+// same source stays correct on both backends.
+#ifdef __HIP_PLATFORM_AMD__
+constexpr int kWarpSize = 64;
+#else
+constexpr int kWarpSize = 32;
+#endif
+
+namespace kernels {
+
+template <int kHiddenStates, int kWarpPerBatch, int kBatchPerBlock, bool kIsMoe>
+__global__ void fused_rmsnorm_with_scale(const __hip_bfloat16 *input_ptr,
+                                         const __hip_bfloat16 *weight_ptr, float *output_ptr_fp32,
+                                         __hip_fp8_e4m3 *output_ptr_fp8,
+                                         __hip_fp8_e4m3 *output_ptr_fp8_scale2, const float *scale,
+                                         float eps, int batch_size) {
+  constexpr int kItemPer16B = 8;
+  constexpr float kInvHiddenStates = 1.0f / kHiddenStates;
+  constexpr int kIterPerBatch = (kHiddenStates + kWarpPerBatch * kWarpSize * kItemPer16B - 1) /
+                                (kWarpPerBatch * kWarpSize * kItemPer16B);
+  float inv_scale = rcpf_ftz(scale[0]);
+  float inv_scale2 = 1;
+  if constexpr (kIsMoe) {
+    inv_scale2 = rcpf_ftz(scale[1]);
+    inv_scale *= scale[1];
+  }
+
+  const int iwarp = threadIdx.x / kWarpSize;
+  const int ilane = threadIdx.x % kWarpSize;
+
+  const uint64_t ibatch = blockIdx.x * kBatchPerBlock + iwarp / kWarpPerBatch;
+  const uint64_t icol_thr_offset = ((iwarp % kWarpPerBatch) * kWarpSize + ilane) * kItemPer16B;
+
+  __shared__ float smem_sum[kWarpPerBatch];
+
+  vec_t<float, kItemPer16B> reg_input[kIterPerBatch];
+  vec_t<float, kItemPer16B> reg_weight[kIterPerBatch];
+
+#pragma unroll
+  for (int i = 0; i < kIterPerBatch; i++) {
+#pragma unroll
+    for (int j = 0; j < kItemPer16B; j++) {
+      reg_input[i][j] = 0;
+      reg_weight[i][j] = 0;
+    }
+  }
+
+#pragma unroll
+  for (int iter = 0; iter < kIterPerBatch; iter++) {
+    uint64_t icol = icol_thr_offset + iter * kWarpPerBatch * kWarpSize * kItemPer16B;
+
+    if (icol < kHiddenStates) {
+      reg_weight[iter] = to<float>(load<__hip_bfloat162, kItemPer16B / 2>(&weight_ptr[icol]));
+    }
+  }
+
+  float local_mean = 0.0f;
+
+  if (ibatch < batch_size) {
+#pragma unroll
+    for (int iter = 0; iter < kIterPerBatch; iter++) {
+      uint64_t icol = icol_thr_offset + iter * kWarpPerBatch * kWarpSize * kItemPer16B;
+
+      if (icol < kHiddenStates) {
+        reg_input[iter] = to<float>(
+            load<__hip_bfloat162, kItemPer16B / 2>(&input_ptr[ibatch * kHiddenStates + icol]));
+#pragma unroll
+        for (int i = 0; i < kItemPer16B; i++) {
+          local_mean += reg_input[iter][i] * reg_input[iter][i];
+        }
+      }
+    }
+  }
+
+  // warp reduce
+  local_mean = warp_reduce_sum_xor(local_mean);
+
+  if (ilane == 0) {
+    smem_sum[iwarp] = local_mean;
+  }
+  __syncthreads();
+
+  int first_warp_in_batch = (iwarp / kWarpPerBatch) * kWarpPerBatch;
+#pragma unroll
+  for (int iwarp_in_batch = 0; iwarp_in_batch < kWarpPerBatch; iwarp_in_batch++) {
+    int reduce_warp = first_warp_in_batch + iwarp_in_batch;
+    if (iwarp != reduce_warp) {
+      local_mean += smem_sum[reduce_warp];
+    }
+  }
+
+  local_mean = rsqrtf_ftz(local_mean * kInvHiddenStates + eps);
+
+  if constexpr (!kIsMoe) {
+    local_mean *= inv_scale;
+  }
+
+  if (ibatch < batch_size) {
+#pragma unroll
+    for (int iter = 0; iter < kIterPerBatch; iter++) {
+      uint64_t icol = icol_thr_offset + iter * kWarpPerBatch * kWarpSize * kItemPer16B;
+      uint64_t istore = ibatch * kHiddenStates + icol;
+
+      if (icol < kHiddenStates) {
+#pragma unroll
+        for (int i = 0; i < kItemPer16B; i++) {
+          reg_input[iter][i] = reg_input[iter][i] * reg_weight[iter][i] * local_mean;
+        }
+
+        auto &split_input = reshape<2, kItemPer16B / 2>(reg_input[iter]);
+        if constexpr (kIsMoe) {
+          store(&output_ptr_fp32[istore], split_input[0]);
+          store(&output_ptr_fp32[istore + kItemPer16B / 2], split_input[1]);
+#pragma unroll
+          for (int i = 0; i < kItemPer16B; i++) {
+            reg_input[iter][i] *= inv_scale2;
+          }
+
+          store(&output_ptr_fp8_scale2[istore], to<__hip_fp8x4_e4m3>(split_input[0]));
+          store(&output_ptr_fp8_scale2[istore + kItemPer16B / 2],
+                to<__hip_fp8x4_e4m3>(split_input[1]));
+#pragma unroll
+          for (int i = 0; i < kItemPer16B; i++) {
+            reg_input[iter][i] *= inv_scale;
+          }
+        }
+
+        store(&output_ptr_fp8[istore], to<__hip_fp8x4_e4m3>(split_input[0]));
+        store(&output_ptr_fp8[istore + kItemPer16B / 2], to<__hip_fp8x4_e4m3>(split_input[1]));
+      }
+    }
+  }
+}
+
+}  // namespace kernels
+
+bool fused_rmsnorm_with_scale_async(const void *input_ptr, const void *weight_ptr, void *output_ptr,
+                                    void *output_fp32_ptr, void *output_fp8_scale2_ptr,
+                                    const void *scale, float eps, int batch_size, int hidden_states,
+                                    bool is_moe, hipStream_t stream) {
+  constexpr int kWarpCount = 4;
+
+  using Tin = const __hip_bfloat16;
+  using Tout = __hip_fp8_e4m3;
+
+  dim3 block(kWarpSize * kWarpCount);
+  if (hidden_states == 5120) {
+    constexpr int kHiddenStates = 5120;
+    constexpr int kWarpPerBatch = 4;
+    constexpr int kBatchPerBlock = kWarpCount / kWarpPerBatch;
+    dim3 grid((batch_size + kBatchPerBlock - 1) / kBatchPerBlock);
+    if (is_moe) {
+      constexpr bool kIsMoe = true;
+      kernels::fused_rmsnorm_with_scale<kHiddenStates, kWarpPerBatch, kBatchPerBlock, kIsMoe>
+          <<<grid, block, 0, stream>>>(
+              reinterpret_cast<Tin *>(input_ptr), reinterpret_cast<Tin *>(weight_ptr),
+              reinterpret_cast<float *>(output_fp32_ptr), reinterpret_cast<Tout *>(output_ptr),
+              reinterpret_cast<Tout *>(output_fp8_scale2_ptr),
+              reinterpret_cast<const float *>(scale), eps, batch_size);
+    } else {
+      constexpr bool kIsMoe = false;
+      kernels::fused_rmsnorm_with_scale<kHiddenStates, kWarpPerBatch, kBatchPerBlock, kIsMoe>
+          <<<grid, block, 0, stream>>>(
+              reinterpret_cast<Tin *>(input_ptr), reinterpret_cast<Tin *>(weight_ptr),
+              reinterpret_cast<float *>(output_fp32_ptr), reinterpret_cast<Tout *>(output_ptr),
+              reinterpret_cast<Tout *>(output_fp8_scale2_ptr),
+              reinterpret_cast<const float *>(scale), eps, batch_size);
+    }
+  } else if (hidden_states == 4096) {
+    constexpr int kHiddenStates = 4096;
+    constexpr int kWarpPerBatch = 4;
+    constexpr int kBatchPerBlock = kWarpCount / kWarpPerBatch;
+    dim3 grid((batch_size + kBatchPerBlock - 1) / kBatchPerBlock);
+    if (is_moe) {
+      constexpr bool kIsMoe = true;
+      kernels::fused_rmsnorm_with_scale<kHiddenStates, kWarpPerBatch, kBatchPerBlock, kIsMoe>
+          <<<grid, block, 0, stream>>>(
+              reinterpret_cast<Tin *>(input_ptr), reinterpret_cast<Tin *>(weight_ptr),
+              reinterpret_cast<float *>(output_fp32_ptr), reinterpret_cast<Tout *>(output_ptr),
+              reinterpret_cast<Tout *>(output_fp8_scale2_ptr),
+              reinterpret_cast<const float *>(scale), eps, batch_size);
+    } else {
+      constexpr bool kIsMoe = false;
+      kernels::fused_rmsnorm_with_scale<kHiddenStates, kWarpPerBatch, kBatchPerBlock, kIsMoe>
+          <<<grid, block, 0, stream>>>(
+              reinterpret_cast<Tin *>(input_ptr), reinterpret_cast<Tin *>(weight_ptr),
+              reinterpret_cast<float *>(output_fp32_ptr), reinterpret_cast<Tout *>(output_ptr),
+              reinterpret_cast<Tout *>(output_fp8_scale2_ptr),
+              reinterpret_cast<const float *>(scale), eps, batch_size);
+    }
+  } else if (hidden_states == 320) {
+    constexpr int kHiddenStates = 320;
+    constexpr int kWarpPerBatch = 1;
+    constexpr int kBatchPerBlock = kWarpCount / kWarpPerBatch;
+    dim3 grid((batch_size + kBatchPerBlock - 1) / kBatchPerBlock);
+    if (is_moe) {
+      constexpr bool kIsMoe = true;
+      kernels::fused_rmsnorm_with_scale<kHiddenStates, kWarpPerBatch, kBatchPerBlock, kIsMoe>
+          <<<grid, block, 0, stream>>>(
+              reinterpret_cast<Tin *>(input_ptr), reinterpret_cast<Tin *>(weight_ptr),
+              reinterpret_cast<float *>(output_fp32_ptr), reinterpret_cast<Tout *>(output_ptr),
+              reinterpret_cast<Tout *>(output_fp8_scale2_ptr),
+              reinterpret_cast<const float *>(scale), eps, batch_size);
+    } else {
+      constexpr bool kIsMoe = false;
+      kernels::fused_rmsnorm_with_scale<kHiddenStates, kWarpPerBatch, kBatchPerBlock, kIsMoe>
+          <<<grid, block, 0, stream>>>(
+              reinterpret_cast<Tin *>(input_ptr), reinterpret_cast<Tin *>(weight_ptr),
+              reinterpret_cast<float *>(output_fp32_ptr), reinterpret_cast<Tout *>(output_ptr),
+              reinterpret_cast<Tout *>(output_fp8_scale2_ptr),
+              reinterpret_cast<const float *>(scale), eps, batch_size);
+    }
+  } else {
+    std::cout << "not supported hidden_size for fused_rmsnorm_with_scale_async:" << hidden_states
+              << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace normalization
+}  // namespace hpc

--- a/src/amd/normalization/fused_rmsnorm_with_scale.h
+++ b/src/amd/normalization/fused_rmsnorm_with_scale.h
@@ -1,0 +1,23 @@
+// Copyright 2025 hpc-ops authors
+// HIP port: torch/ATen includes dropped (only entry.cc needs torch, and it
+// includes those itself). Kernel launcher declaration only needs hipStream_t.
+
+#ifndef SRC_AMD_NORMALIZATION_FUSED_RMSNORM_WITH_SCALE_H_
+#define SRC_AMD_NORMALIZATION_FUSED_RMSNORM_WITH_SCALE_H_
+
+#include <hip/hip_runtime_api.h>  // hipStream_t only; device types live in the .cu
+
+#include <tuple>
+
+namespace hpc {
+namespace normalization {
+
+bool fused_rmsnorm_with_scale_async(const void* input_ptr, const void* weight_ptr, void* output_ptr,
+                                    void* output_fp32_ptr, void* output_fp8_scale2_ptr,
+                                    const void* scale, float eps, int batch_size, int hidden_state,
+                                    bool is_moe, hipStream_t stream);
+
+}  // namespace normalization
+}  // namespace hpc
+
+#endif  // SRC_AMD_NORMALIZATION_FUSED_RMSNORM_WITH_SCALE_H_

--- a/src/amd/normalization/utils_hip.cuh
+++ b/src/amd/normalization/utils_hip.cuh
@@ -1,0 +1,260 @@
+// Copyright (C) 2026 Tencent.
+// Slimmed HIP port of utils.cuh for the norm operator on AMD gfx950 (wave64).
+// Kept verbatim from the original: vec_t / traits_vec_t / size / reshape /
+// to<> / load / store. Ported: rcpf_ftz / rsqrtf_ftz (PTX -> HIP intrinsics),
+// warp_reduce_sum_xor (wave32 -> wave64). Removed: cute/CUTLASS include and
+// attention helpers, multimem/atom/barrier PTX, unused fast-math.
+
+#ifndef SRC_AMD_NORMALIZATION_UTILS_HIP_CUH_
+#define SRC_AMD_NORMALIZATION_UTILS_HIP_CUH_
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_fp8.h>
+#include <hip/hip_runtime.h>
+
+namespace hpc {
+
+// ============================
+//    Load/Store(vectorized)
+// ============================
+template <typename T, int N>
+struct vec_t {
+  T data[N];
+
+  using type = T;
+  static constexpr int num = N;
+  static constexpr int kNum = N;
+
+  __device__ __forceinline__ constexpr T &operator[](int idx) { return data[idx]; }
+
+  __device__ __forceinline__ constexpr const T &operator[](int idx) const { return data[idx]; }
+};
+
+template <typename T, int N, int... Dims>
+struct traits_vec_t;
+
+template <typename T, int N, int Dim>
+struct traits_vec_t<T, N, Dim> {
+  static_assert(N == Dim, "dimension mismatch");
+  using type = vec_t<T, Dim>;
+};
+
+template <typename T, int N, int First, int... Rest>
+struct traits_vec_t<T, N, First, Rest...> {
+  static_assert(N % First == 0, "first dimension must divide total size");
+  using inner_type = typename traits_vec_t<T, N / First, Rest...>::type;
+  using type = vec_t<inner_type, First>;
+};
+
+template <typename T, int N>
+__device__ __forceinline__ constexpr int size(vec_t<T, N> &v) {
+  return N;
+}
+
+template <int... Dims, typename T, int N>
+__device__ __forceinline__ constexpr auto &reshape(vec_t<T, N> &v) {
+  constexpr int num_elements = (Dims * ...);
+
+  using ResultType = typename traits_vec_t<T, N, Dims...>::type;
+  return *reinterpret_cast<ResultType *>(&v);
+}
+
+template <typename U, typename T, int N>
+__device__ __forceinline__ constexpr auto to(const vec_t<T, N> &v) {
+  if constexpr (std::is_same_v<T, float> && std::is_same_v<U, __hip_bfloat16>) {
+    using V = vec_t<__hip_bfloat16, N>;
+    V o;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      o[i] = __float2bfloat16(v[i]);
+    }
+    return o;
+  } else if constexpr (std::is_same_v<T, float> && std::is_same_v<U, __half2>) {
+    using V = vec_t<U, N / 2>;
+    V o;
+#pragma unroll
+    for (int i = 0; i < N / 2; ++i) {
+      o[i] = __float22half2_rn(*reinterpret_cast<const float2 *>(&v[2 * i]));
+    }
+    return o;
+  } else if constexpr (std::is_same_v<T, __hip_bfloat16> && std::is_same_v<U, float>) {
+    using V = vec_t<float, N>;
+    V o;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      o[i] = __bfloat162float(v[i]);
+    }
+    return o;
+  } else if constexpr (std::is_same_v<T, __hip_bfloat162> && std::is_same_v<U, float>) {
+    using V = vec_t<float, N * 2>;
+    V o;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      auto y = __bfloat1622float2(v[i]);
+      o[i * 2 + 0] = y.x;
+      o[i * 2 + 1] = y.y;
+    }
+    return o;
+  } else if constexpr (std::is_same_v<T, __half2> && std::is_same_v<U, float>) {
+    using V = vec_t<float, N * 2>;
+    V o;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      auto y = __half22float2(v[i]);
+      o[i * 2 + 0] = y.x;
+      o[i * 2 + 1] = y.y;
+    }
+    return o;
+  } else if constexpr (std::is_same_v<T, float> && std::is_same_v<U, __hip_fp8x4_e4m3>) {
+    static_assert(N % 4 == 0, "N % 4 must be 0");
+    using V = vec_t<__hip_fp8x4_e4m3, N / 4>;
+    V o;
+#pragma unroll
+    for (int i = 0; i < N / 4; ++i) {
+      o[i] = __hip_fp8x4_e4m3(*reinterpret_cast<const float4 *>(&v[4 * i]));
+    }
+    return o;
+  } else if constexpr (std::is_same_v<T, __hip_fp8x4_e4m3> && std::is_same_v<U, float>) {
+    using V = vec_t<float, N * 4>;
+    V o;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      auto y = static_cast<float4>(v[i]);
+      o[i * 4 + 0] = y.x;
+      o[i * 4 + 1] = y.y;
+      o[i * 4 + 2] = y.z;
+      o[i * 4 + 3] = y.w;
+    }
+    return o;
+  } else if constexpr (std::is_same_v<T, __hip_fp8_e4m3> && std::is_same_v<U, float>) {
+    using V = vec_t<float, N>;
+    V o;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      o[i] = static_cast<float>(v[i]);
+    }
+    return o;
+  } else if constexpr (std::is_same_v<T, __hip_bfloat162> && std::is_same_v<U, __hip_fp8x4_e4m3>) {
+    static_assert(N % 2 == 0, "N % 2 must be 0");
+    using V = vec_t<__hip_fp8x4_e4m3, N / 2>;
+    V o;
+#pragma unroll
+    for (int i = 0; i < N / 2; ++i) {
+      o[i] = __hip_fp8x4_e4m3(*(reinterpret_cast<__hip_bfloat162 *>(&v[2 * i])),
+                              *(reinterpret_cast<__hip_bfloat162 *>(&v[2 * i + 1])));
+    }
+    return o;
+  } else if constexpr (std::is_same_v<T, float> && std::is_same_v<U, __hip_bfloat162>) {
+    static_assert(N % 2 == 0, "N % 2 must be 0");
+    using V = vec_t<__hip_bfloat162, N / 2>;
+    V o;
+#pragma unroll
+    for (int i = 0; i < N / 2; ++i) {
+      o[i] = __float22bfloat162_rn(*reinterpret_cast<const float2 *>(&v[2 * i]));
+    }
+    return o;
+  } else if constexpr (std::is_same_v<T, U>) {
+    return v;
+  }
+}
+
+template <typename T, int N>
+__device__ __forceinline__ constexpr auto load(const void *ptr) {
+  using V = vec_t<T, N>;
+  V v;
+
+  constexpr int kBytes = sizeof(T) * N;
+
+  static_assert(kBytes == 1 || kBytes == 2 || kBytes == 4 || kBytes == 8 || kBytes == 16,
+                "not support for T x N");
+
+  if constexpr (kBytes == 1) {
+    using L = uint8_t;
+    *reinterpret_cast<L *>(&v) = *reinterpret_cast<const L *>(ptr);
+  } else if constexpr (kBytes == 2) {
+    using L = uint16_t;
+    *reinterpret_cast<L *>(&v) = *reinterpret_cast<const L *>(ptr);
+  } else if constexpr (kBytes == 4) {
+    using L = uint32_t;
+    *reinterpret_cast<L *>(&v) = *reinterpret_cast<const L *>(ptr);
+  } else if constexpr (kBytes == 8) {
+    using L = uint64_t;
+    *reinterpret_cast<L *>(&v) = *reinterpret_cast<const L *>(ptr);
+  } else if constexpr (kBytes == 16) {
+    using L = uint4;
+    *reinterpret_cast<L *>(&v) = *reinterpret_cast<const L *>(ptr);
+  }
+
+  return v;
+}
+
+template <typename T, int N>
+__device__ __forceinline__ constexpr void store(void *ptr, const vec_t<T, N> &v) {
+  using V = vec_t<T, N>;
+
+  constexpr int kBytes = sizeof(T) * N;
+
+  static_assert(kBytes == 1 || kBytes == 2 || kBytes == 4 || kBytes == 8 || kBytes == 16,
+                "not support for T x N");
+
+  if constexpr (kBytes == 1) {
+    using S = uint8_t;
+    *reinterpret_cast<S *>(ptr) = *reinterpret_cast<const S *>(&v);
+  } else if constexpr (kBytes == 2) {
+    using S = uint16_t;
+    *reinterpret_cast<S *>(ptr) = *reinterpret_cast<const S *>(&v);
+  } else if constexpr (kBytes == 4) {
+    using S = uint32_t;
+    *reinterpret_cast<S *>(ptr) = *reinterpret_cast<const S *>(&v);
+  } else if constexpr (kBytes == 8) {
+    using S = uint64_t;
+    *reinterpret_cast<S *>(ptr) = *reinterpret_cast<const S *>(&v);
+  } else if constexpr (kBytes == 16) {
+    using S = uint4;
+    *reinterpret_cast<S *>(ptr) = *reinterpret_cast<const S *>(&v);
+  }
+
+  return;
+}
+
+template <typename T, typename... Args>
+__device__ __forceinline__ constexpr void store(void *ptr, T val, Args... vals) {
+  constexpr int N = sizeof...(Args);
+  using V = vec_t<T, 1 + N>;
+
+  static_assert((std::is_same_v<Args, T> && ...), "all vals must be type of T");
+
+  V v;
+  int idx = 0;
+  (reinterpret_cast<T *>(&v))[idx++] = val;
+  (((reinterpret_cast<T *>(&v))[idx++] = vals), ...);
+
+  store(ptr, v);
+}
+
+// ============================
+//       Fast Math API
+// ============================
+
+// PTX rcp.approx.ftz.f32 -> HIP round-to-nearest reciprocal intrinsic.
+__device__ __forceinline__ float rcpf_ftz(float x) { return __frcp_rn(x); }
+
+// PTX rsqrt.approx.ftz.f32 -> HIP fast inverse square root.
+__device__ __forceinline__ float rsqrtf_ftz(float in) { return rsqrtf(in); }
+
+// Butterfly all-reduce across the wavefront. Offset starts at warpSize/2 so it
+// covers the full wave (32 lanes on NVIDIA, 64 on AMD CDNA). HIP __shfl_xor
+// defaults to width == warpSize.
+__device__ __forceinline__ float warp_reduce_sum_xor(float x) {
+#pragma unroll
+  for (int ioffset = warpSize / 2; ioffset >= 1; ioffset /= 2) {
+    x += __shfl_xor(x, ioffset);
+  }
+
+  return x;
+}
+
+}  // namespace hpc
+
+#endif  // SRC_AMD_NORMALIZATION_UTILS_HIP_CUH_

--- a/src/amd/utils/utils_hip.cuh
+++ b/src/amd/utils/utils_hip.cuh
@@ -1,12 +1,12 @@
 // Copyright (C) 2026 Tencent.
-// Slimmed HIP port of utils.cuh for the norm operator on AMD gfx950 (wave64).
+// Slimmed HIP port of utils.cuh — shared device helpers for AMD gfx950 (wave64).
 // Kept verbatim from the original: vec_t / traits_vec_t / size / reshape /
 // to<> / load / store. Ported: rcpf_ftz / rsqrtf_ftz (PTX -> HIP intrinsics),
 // warp_reduce_sum_xor (wave32 -> wave64). Removed: cute/CUTLASS include and
 // attention helpers, multimem/atom/barrier PTX, unused fast-math.
 
-#ifndef SRC_AMD_NORMALIZATION_UTILS_HIP_CUH_
-#define SRC_AMD_NORMALIZATION_UTILS_HIP_CUH_
+#ifndef SRC_AMD_UTILS_UTILS_HIP_CUH_
+#define SRC_AMD_UTILS_UTILS_HIP_CUH_
 
 #include <hip/hip_bf16.h>
 #include <hip/hip_fp16.h>
@@ -218,6 +218,47 @@ __device__ __forceinline__ constexpr void store(void *ptr, const vec_t<T, N> &v)
   return;
 }
 
+// Streaming (non-temporal) store — an OPT-IN variant of store() for outputs that
+// are written once and never read back within the kernel. The nt/slc hint tells
+// the hardware to bypass the L2 write-allocate so a pure output stream does not
+// evict live inputs from L2; on bandwidth-bound streaming-write kernels this is
+// a net win. It is NOT safe for buffers that are read back in-kernel (in-place
+// accumulation, L2-reused scratch), which is why plain store() above keeps the
+// default temporal path — callers must request streaming explicitly.
+//
+// The 16-byte path stays a regular temporal dwordx4 store on purpose: measured
+// on the fp32 fused-RMSNorm MoE output (the dominant MoE traffic term) a nt hint
+// there REGRESSES because write-allocate helps that wide, fully-coalesced stream.
+template <typename T, int N>
+__device__ __forceinline__ constexpr void store_streaming(void *__restrict__ ptr,
+                                                          const vec_t<T, N> &v) {
+  using V = vec_t<T, N>;
+
+  constexpr int kBytes = sizeof(T) * N;
+
+  static_assert(kBytes == 1 || kBytes == 2 || kBytes == 4 || kBytes == 8 || kBytes == 16,
+                "not support for T x N");
+
+  if constexpr (kBytes == 1) {
+    using S = uint8_t;
+    __builtin_nontemporal_store(*reinterpret_cast<const S *>(&v), reinterpret_cast<S *>(ptr));
+  } else if constexpr (kBytes == 2) {
+    using S = uint16_t;
+    __builtin_nontemporal_store(*reinterpret_cast<const S *>(&v), reinterpret_cast<S *>(ptr));
+  } else if constexpr (kBytes == 4) {
+    using S = uint32_t;
+    __builtin_nontemporal_store(*reinterpret_cast<const S *>(&v), reinterpret_cast<S *>(ptr));
+  } else if constexpr (kBytes == 8) {
+    using S = uint64_t;
+    __builtin_nontemporal_store(*reinterpret_cast<const S *>(&v), reinterpret_cast<S *>(ptr));
+  } else if constexpr (kBytes == 16) {
+    using S = uint4;
+    *reinterpret_cast<S *>(ptr) = *reinterpret_cast<const S *>(&v);
+  }
+
+  return;
+}
+
 template <typename T, typename... Args>
 __device__ __forceinline__ constexpr void store(void *ptr, T val, Args... vals) {
   constexpr int N = sizeof...(Args);
@@ -257,4 +298,4 @@ __device__ __forceinline__ float warp_reduce_sum_xor(float x) {
 
 }  // namespace hpc
 
-#endif  // SRC_AMD_NORMALIZATION_UTILS_HIP_CUH_
+#endif  // SRC_AMD_UTILS_UTILS_HIP_CUH_


### PR DESCRIPTION
# Add AMD GPU (ROCm) support: build path + first norm operator

## Background

HPC-Ops is currently a CUDA-only operator library targeting NVIDIA SM90. This PR starts bringing it to **AMD GPUs (ROCm)**.

The goal is incremental: this first PR lands the **compilation path** for the ROCm backend plus **one operator** (`fused_rmsnorm_with_scale`) as a working end-to-end example. More operators will be ported in follow-up PRs, and the performance of the ported operators will continue to be optimized over time.

Target hardware for this PR: AMD MI350X (gfx950 / CDNA4).

**1. HIP kernel with simple adaptation and optimization.**
The original CUDA norm operator was converted to HIP and placed under a new `src/amd/` tree. Made some changes to adapt it to HIP。It also includes a simple optimization

**2. ROCm build path for AMD GPUs.**
`CMakeLists.txt` gains an opt-in `USE_ROCM` branch that compiles only the ported `src/amd/**` sources with `hipcc`, leaving the CUDA path byte-for-byte unchanged when `USE_ROCM` is off，and `hpc/__init__.py` tolerates operators not yet built on ROCm (only the norm op is compiled for now) so importing `hpc` works.

## Testing

The norm operator was validated for correctness (60/60 parametrized pytest cases pass on gfx950) and benchmarked against **four** references:

- **HPC** — this operator (fused RMSNorm + scale + fp8 quant)
- **Triton** — a Triton RMSNorm + scale + fp8 quant kernel
- **aiter** — AMD's `aiter` `rms_norm` (plain RMSNorm, bf16)
- **torch** — a native PyTorch RMSNorm (bf16)

### Results (gfx950 / MI350X, latency μs, lower is better)

Measured with CUDA events, median-of-100 × 3 rounds (min), warmup 20, pinned to an idle GPU.

> Columns marked **`+fp8`** (HPC and Triton) perform RMSNorm **+ scale + fp8 quantization** — i.e. they emit an fp8 output and therefore do strictly *more* work. The `aiter` and `torch` columns do a plain RMSNorm with bf16 output. The two groups are not the same workload; the `+fp8` group is doing extra quantization on top of the normalization.

**hidden = 5120**

| batch | HPC (+fp8) | Triton (+fp8) | aiter | torch |
|---:|---:|---:|---:|---:|
| 16 | **6.54** | 13.62 | 10.64 | 39.42 |
| 256 | **7.80** | 14.92 | 13.10 | 42.52 |
| 1024 | **8.14** | 13.84 | 12.14 | 56.74 |
| 4096 | 14.40 | **13.52** | 17.12 | 129.46 |
| 8192 | 23.56 | **21.22** | 28.90 | 280.82 |

**hidden = 4096**

| batch | HPC (+fp8) | Triton (+fp8) | aiter | torch |
|---:|---:|---:|---:|---:|
| 16 | **7.00** | 13.46 | 12.04 | 41.44 |
| 256 | **7.16** | 13.64 | 12.08 | 41.08 |
| 1024 | **7.72** | 13.14 | 11.48 | 50.84 |
| 4096 | **11.60** | 13.92 | 14.44 | 109.02 |
| 8192 | 19.04 | **16.84** | 23.56 | 211.56 |

**hidden = 320**

| batch | HPC (+fp8) | Triton (+fp8) | aiter | torch |
|---:|---:|---:|---:|---:|
| 16 | **7.28** | 13.48 | 11.84 | 40.72 |
| 256 | **7.16** | 13.52 | 11.88 | 41.42 |
| 1024 | **7.20** | 13.44 | 12.08 | 41.62 |
| 4096 | **7.44** | 12.92 | 12.18 | 41.12 |
| 8192 | **7.76** | 13.60 | 11.44 | 47.68 |

Summary: HPC is fastest across small/medium batches and all `hidden=320` sizes (while also doing the extra fp8 quant), and beats aiter/torch everywhere. On large batches with large hidden the picture is mixed: at batch 4096 it is competitive (faster than Triton at hidden=4096, within ~7% at hidden=5120), while at batch 8192 it trails Triton by ~11-13%; closing that batch-8192 gap is future optimization work.

<details>
<summary>Benchmark script</summary>

```python
"""hpc vs triton / aiter / torch。"""
import sys
from statistics import median

import torch
import triton
import triton.language as tl
import hpc  


@triton.jit
def _rmsnorm_fp8(x_ptr, w_ptr, o_ptr, inv_scale, eps, H: tl.constexpr, BLK: tl.constexpr):
    row = tl.program_id(0)
    off = tl.arange(0, BLK)
    mask = off < H
    x = tl.load(x_ptr + row * H + off, mask=mask, other=0.0).to(tl.float32)
    w = tl.load(w_ptr + off, mask=mask, other=0.0).to(tl.float32)
    rms = tl.rsqrt(tl.sum(x * x) / H + eps)
    y = x * rms * w * inv_scale
    tl.store(o_ptr + row * H + off, y.to(tl.float8e4nv), mask=mask)


def triton_fp8(x, w, inv_scale, eps, H, BLK):
    o = torch.empty_like(x, dtype=torch.float8_e4m3fn)
    _rmsnorm_fp8[(x.shape[0],)](x, w, o, inv_scale, eps, H, BLK)
    return o


def torch_bf16(x, w, eps):
    rms = torch.rsqrt(torch.mean(x.float() ** 2, -1, keepdim=True) + eps)
    return (x * rms * w.float()).to(torch.bfloat16)


def bench_us(fn, warmup=20, iters=100, rounds=3):
    for _ in range(warmup):
        fn()
    torch.cuda.synchronize()
    meds = []
    for _ in range(rounds):
        evs = [(torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True))
               for _ in range(iters)]
        for s, e in evs:
            s.record(); fn(); e.record()
        torch.cuda.synchronize()
        meds.append(median([s.elapsed_time(e) * 1000.0 for s, e in evs]))
    return min(meds)


def main():
    from aiter.ops.rmsnorm import rms_norm as aiter_rms  # noqa
    dev = "cuda"
    eps = 1e-6
    scale = 2.5
    st = torch.tensor([scale], dtype=torch.float32, device=dev)
    inv = 1.0 / scale
    print(f"GPU {torch.cuda.get_device_name(0)}  |  hpc from {hpc.__file__}")
    print(f"{'hidden':>6} {'batch':>6} | {'HPC(+fp8)':>10} {'Tri(+fp8)':>10} | "
          f"{'aiter':>8} {'torch':>8}")
    print("-" * 62)
    for hidden in [5120, 4096, 320]:
        BLK = triton.next_power_of_2(hidden)
        w2 = torch.rand((1, hidden), dtype=torch.bfloat16, device=dev).contiguous()
        w1 = w2.reshape(-1).contiguous()
        for bs in [16, 256, 1024, 4096, 8192, 16384]:
            x = torch.randn(bs, hidden, dtype=torch.bfloat16, device=dev)
            t_hpc = bench_us(lambda: torch.ops.hpc.fused_rmsnorm_with_scale(x, w2, st, eps, False))
            t_tri = bench_us(lambda: triton_fp8(x, w1, inv, eps, hidden, BLK))
            t_ai = bench_us(lambda: aiter_rms(x, w1, eps))
            t_to = bench_us(lambda: torch_bf16(x, w2, eps))
            print(f"{hidden:>6} {bs:>6} | {t_hpc:>10.2f} {t_tri:>10.2f} | {t_ai:>8.2f} {t_to:>8.2f}")


if __name__ == "__main__":
    main()
```

</details>
