### PR TITLE
style: apply make format with pinned toolchain

### DIFF
--- a/hpc/act.py
+++ b/hpc/act.py
@@ -148,8 +148,6 @@ def scaled_fp8_quant_fake(input, scale=None, output=None):
         else torch.empty_like(input, dtype=torch.float8_e4m3fn, device=input.device)
     )
     scale_tensor = (
-        scale
-        if scale is not None
-        else torch.empty((1,), dtype=torch.float32, device=input.device)
+        scale if scale is not None else torch.empty((1,), dtype=torch.float32, device=input.device)
     )
     return output_tensor, scale_tensor

--- a/hpc/allreduce.py
+++ b/hpc/allreduce.py
@@ -112,9 +112,9 @@ def fuse_allreduce_rmsnorm_low_latency(
         buffer_flags,
         world_size,
         rank,
-        True, # RMSNorm Fusion
+        True,  # RMSNorm Fusion
         launch_with_pdl,
-        True, # use two-Shot AllReduce
+        True,  # use two-Shot AllReduce
         output_x,
         residual_out,
         residual_in,
@@ -198,4 +198,3 @@ def empty_multimem(
     hdl = MulticastHandle(multicomm, size, dtype)
 
     return hdl.get_buffer(hdl.rank, size, dtype=dtype), hdl
-

--- a/src/activation/activation.cu
+++ b/src/activation/activation.cu
@@ -4,12 +4,12 @@
 #include <cuda_fp16.h>
 #include <stdio.h>
 
+#include <type_traits>
+
 #include "cutlass/fast_math.h"
 #include "src/activation/activation.h"
 #include "src/utils/utils.cuh"
 #include "src/utils/utils.h"
-
-#include <type_traits>
 
 namespace hpc {
 namespace activation {
@@ -459,8 +459,7 @@ __device__ __forceinline__ float load_quant_value<float>(const float *ptr) {
 template <typename scalar_t>
 __global__ void scaled_fp8_quant_kernel(__nv_fp8_e4m3 *__restrict__ output,
                                         const scalar_t *__restrict__ input,
-                                        const float *__restrict__ scale,
-                                        int64_t numel) {
+                                        const float *__restrict__ scale, int64_t numel) {
   const float inv_scale = 1.0f / scale[0];
   int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
 
@@ -781,8 +780,7 @@ void masked_act_mul_and_blockwise_quant_async(__nv_fp8_e4m3 *output_ptr, float *
 
 template <typename scalar_t>
 void scaled_fp8_quant_async_impl(__nv_fp8_e4m3 *output_ptr, const scalar_t *input_ptr,
-                                 const float *scale_ptr, int64_t numel,
-                                 cudaStream_t stream) {
+                                 const float *scale_ptr, int64_t numel, cudaStream_t stream) {
   dim3 block(256);
   dim3 grid(std::min<int64_t>((numel + block.x - 1) / block.x, get_sm_count() * 8));
   kernels::scaled_fp8_quant_kernel<<<grid, block, 0, stream>>>(output_ptr, input_ptr, scale_ptr,

--- a/src/activation/entry.cc
+++ b/src/activation/entry.cc
@@ -167,8 +167,9 @@ std::tuple<torch::Tensor, torch::Tensor> scaled_fp8_quant_entry(
                   input.scalar_type() == torch::kBFloat16,
               "input dtype must be float32, float16, or bfloat16");
 
-  auto output_tensor =
-      output.has_value() ? output.value() : torch::empty_like(input, input.options().dtype(torch::kFloat8_e4m3fn));
+  auto output_tensor = output.has_value()
+                           ? output.value()
+                           : torch::empty_like(input, input.options().dtype(torch::kFloat8_e4m3fn));
   TORCH_CHECK(output_tensor.device().is_cuda(), "output must be a CUDA tensor");
   TORCH_CHECK(output_tensor.is_contiguous(), "output must be contiguous");
   TORCH_CHECK(output_tensor.sizes() == input.sizes(), "output shape must match input shape");

--- a/src/allreduce/entry.cc
+++ b/src/allreduce/entry.cc
@@ -76,17 +76,16 @@ void fuse_allreduce_rmsnorm_high_throughput_entry(
 }
 
 void fuse_allreduce_rmsnorm_low_latency_entry(
-    const torch::Tensor &input_x,            // [num_tokens, token_dim]
-    const torch::Tensor &multicast_x,        // [num_tokens, token_dim] multimem_ptr tensor
-    const torch::Tensor &data_buffer_ptrs,   // [world_size] int64 pointers to remote buffers
-    torch::Tensor &multinode_x,              // local lamport buffer tensor
-    const torch::Tensor &buffer_flags,       // lamport flag buffer
-    int64_t world_size, int64_t rank, bool rmsnorm_fusion, bool launch_with_pdl,
-    bool use_two_shot,
-    torch::Tensor &output_x,                 // [num_tokens, token_dim]
-    torch::Tensor &residual_out,             // [num_tokens, token_dim]
-    const torch::Tensor &residual_in,        // [num_tokens, token_dim]
-    const torch::Tensor &weight_gamma,       // [token_dim]
+    const torch::Tensor &input_x,           // [num_tokens, token_dim]
+    const torch::Tensor &multicast_x,       // [num_tokens, token_dim] multimem_ptr tensor
+    const torch::Tensor &data_buffer_ptrs,  // [world_size] int64 pointers to remote buffers
+    torch::Tensor &multinode_x,             // local lamport buffer tensor
+    const torch::Tensor &buffer_flags,      // lamport flag buffer
+    int64_t world_size, int64_t rank, bool rmsnorm_fusion, bool launch_with_pdl, bool use_two_shot,
+    torch::Tensor &output_x,            // [num_tokens, token_dim]
+    torch::Tensor &residual_out,        // [num_tokens, token_dim]
+    const torch::Tensor &residual_in,   // [num_tokens, token_dim]
+    const torch::Tensor &weight_gamma,  // [token_dim]
     double rms_norm_eps) {
   auto stream = at::cuda::getCurrentCUDAStream(input_x.get_device());
 
@@ -116,17 +115,17 @@ void fuse_allreduce_rmsnorm_low_latency_entry(
               "weight_gamma tensor data type must be bfloat16");
   TORCH_CHECK(data_buffer_ptrs.scalar_type() == torch::kInt64,
               "data_buffer_ptrs tensor data type must be int64");
-  TORCH_CHECK(buffer_flags.scalar_type() == torch::kUInt32 ||
-                  buffer_flags.scalar_type() == torch::kInt32,
-              "buffer_flags tensor data type must be uint32/int32");
+  TORCH_CHECK(
+      buffer_flags.scalar_type() == torch::kUInt32 || buffer_flags.scalar_type() == torch::kInt32,
+      "buffer_flags tensor data type must be uint32/int32");
 
   // Shape & value checks
   TORCH_CHECK(input_x.dim() == 2, "input_x must be 2D [num_tokens, token_dim]");
   int64_t num_tokens = input_x.size(0);
   int64_t token_dim = input_x.size(1);
   using c_type = __nv_bfloat16;
-  TORCH_CHECK(token_dim % (sizeof(float4) / sizeof(c_type)) == 0,
-              "token_dim must be divisible by ", sizeof(float4) / sizeof(c_type));
+  TORCH_CHECK(token_dim % (sizeof(float4) / sizeof(c_type)) == 0, "token_dim must be divisible by ",
+              sizeof(float4) / sizeof(c_type));
   TORCH_CHECK(output_x.size(0) == num_tokens && output_x.size(1) == token_dim,
               "output_x shape mismatch: expected (", num_tokens, ", ", token_dim, ") but got (",
               output_x.size(0), ", ", output_x.size(1), ")");
@@ -167,10 +166,10 @@ void fuse_allreduce_rmsnorm_low_latency_entry(
   params.rank = static_cast<int>(rank);
   params.numTokens = static_cast<int>(num_tokens);
   params.tokenDim = static_cast<int>(token_dim);
-  params.bufferPtrsDev = reinterpret_cast<void**>(const_cast<void*>(data_buffer_ptrs_ptr));
+  params.bufferPtrsDev = reinterpret_cast<void **>(const_cast<void *>(data_buffer_ptrs_ptr));
   params.bufferPtrLocal = multinode_ptr;
-  params.multicastPtr = const_cast<void*>(multicast_ptr);
-  params.bufferFlags = reinterpret_cast<uint32_t*>(buffer_flags_ptr);
+  params.multicastPtr = const_cast<void *>(multicast_ptr);
+  params.bufferFlags = reinterpret_cast<uint32_t *>(buffer_flags_ptr);
   params.rmsNormFusion = rmsnorm_fusion;
   params.launchWithPdl = launch_with_pdl;
 
@@ -187,8 +186,7 @@ void fuse_allreduce_rmsnorm_low_latency_entry(
 
   cudaError_t status = fuse_allreduce_rmsnorm_low_latency_async<c_type>(params);
   TORCH_CHECK(status == cudaSuccess,
-              "fuse_allreduce_rmsnorm_low_latency failed with error: ",
-              cudaGetErrorString(status));
+              "fuse_allreduce_rmsnorm_low_latency failed with error: ", cudaGetErrorString(status));
 }
 
 }  // namespace allreduce

--- a/src/allreduce/fuse_allreduce_rmsnorm_high_throughput.cu
+++ b/src/allreduce/fuse_allreduce_rmsnorm_high_throughput.cu
@@ -100,11 +100,13 @@ __global__ void fused_allreduce_rmsnorm_kernel(
 
 }  // namespace kernels
 
-void fuse_allreduce_rmsnorm_high_throughput_async(
-    const void *input_ptr, const void *mc_input_ptr, const void *in_res_ptr,
-    const void *weight_ptr, void *output_ptr, void *mc_output_ptr, void *out_res_ptr,
-    void *signal_ptr, int64_t rank, int64_t world_size, int64_t num_max_blocks,
-    double rms_norm_eps, int num_tokens, int hidden_size, cudaStream_t stream) {
+void fuse_allreduce_rmsnorm_high_throughput_async(const void *input_ptr, const void *mc_input_ptr,
+                                                  const void *in_res_ptr, const void *weight_ptr,
+                                                  void *output_ptr, void *mc_output_ptr,
+                                                  void *out_res_ptr, void *signal_ptr, int64_t rank,
+                                                  int64_t world_size, int64_t num_max_blocks,
+                                                  double rms_norm_eps, int num_tokens,
+                                                  int hidden_size, cudaStream_t stream) {
   constexpr int kVecSize = 8;
   if (hidden_size == 4096) {
     constexpr int kNumThreadPerBlcok = 512;

--- a/src/allreduce/fuse_allreduce_rmsnorm_high_throughput.h
+++ b/src/allreduce/fuse_allreduce_rmsnorm_high_throughput.h
@@ -8,11 +8,13 @@
 namespace hpc {
 namespace allreduce {
 
-void fuse_allreduce_rmsnorm_high_throughput_async(
-    const void *input_ptr, const void *mc_input_ptr, const void *in_res_ptr,
-    const void *weight_ptr, void *output_ptr, void *mc_output_ptr, void *out_res_ptr,
-    void *signal_ptr, int64_t rank, int64_t world_size, int64_t num_max_blocks,
-    double rms_norm_eps, int num_tokens, int hidden_size, cudaStream_t stream);
+void fuse_allreduce_rmsnorm_high_throughput_async(const void *input_ptr, const void *mc_input_ptr,
+                                                  const void *in_res_ptr, const void *weight_ptr,
+                                                  void *output_ptr, void *mc_output_ptr,
+                                                  void *out_res_ptr, void *signal_ptr, int64_t rank,
+                                                  int64_t world_size, int64_t num_max_blocks,
+                                                  double rms_norm_eps, int num_tokens,
+                                                  int hidden_size, cudaStream_t stream);
 
 }  // namespace allreduce
 }  // namespace hpc

--- a/src/allreduce/fuse_allreduce_rmsnorm_low_latency.cu
+++ b/src/allreduce/fuse_allreduce_rmsnorm_low_latency.cu
@@ -3,6 +3,7 @@
 #include <cuda.h>
 #include <cuda_bf16.h>
 #include <cuda_pipeline.h>
+
 #include <algorithm>
 
 #include "src/allreduce/fuse_allreduce_rmsnorm_low_latency.h"
@@ -324,14 +325,14 @@ cudaError_t fuse_allreduce_rmsnorm_low_latency_async(AllReduceFusionParams const
       .numAttrs = 1,
   };
 
-#define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE)                                                      \
-  do {                                                                                           \
-    cudaError_t _err = cudaLaunchKernelEx(                                                       \
+#define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE)                                                       \
+  do {                                                                                            \
+    cudaError_t _err = cudaLaunchKernelEx(                                                        \
         &arConfig, &kernels::twoshotAllreduceKernel<WORLD_SIZE, T>, output, input, ucPtrs,        \
-        mcastPtr, numTokens, tokenDim, params.rank, params.bufferFlags, (!params.rmsNormFusion));\
-    if (_err != cudaSuccess) {                                                                   \
-      return _err;                                                                               \
-    }                                                                                            \
+        mcastPtr, numTokens, tokenDim, params.rank, params.bufferFlags, (!params.rmsNormFusion)); \
+    if (_err != cudaSuccess) {                                                                    \
+      return _err;                                                                                \
+    }                                                                                             \
   } while (0)
   T** ucPtrs = reinterpret_cast<T**>(params.bufferPtrsDev);
   T* mcastPtr = reinterpret_cast<T*>(params.multicastPtr);
@@ -391,22 +392,22 @@ cudaError_t fuse_allreduce_rmsnorm_low_latency_async(AllReduceFusionParams const
 
     size_t const smemSize = 3 * rnBlockSize * iters * sizeof(T);
 
-#define RUN_RMSNORM_KERNEL(LOADS_PER_THREAD)                                                      \
-  do {                                                                                            \
-    cudaError_t _err = cudaFuncSetAttribute(&kernels::rmsNormLamport<T, T, LOADS_PER_THREAD>,     \
-                                            cudaFuncAttributeMaxDynamicSharedMemorySize,          \
-                                            smemSize);                                            \
-    if (_err != cudaSuccess) {                                                                    \
-      return _err;                                                                                \
-    }                                                                                             \
-    rnConfig.dynamicSmemBytes = smemSize;                                                         \
-    _err = cudaLaunchKernelEx(&rnConfig, &kernels::rmsNormLamport<T, T, LOADS_PER_THREAD>,        \
-                              residualOut, output, bufferInput, gamma,                            \
-                              static_cast<float>(params.epsilon), residualIn, numTokens,          \
-                              tokenDim, params.nRanks, params.bufferFlags);                       \
-    if (_err != cudaSuccess) {                                                                    \
-      return _err;                                                                                \
-    }                                                                                             \
+#define RUN_RMSNORM_KERNEL(LOADS_PER_THREAD)                                                       \
+  do {                                                                                             \
+    cudaError_t _err =                                                                             \
+        cudaFuncSetAttribute(&kernels::rmsNormLamport<T, T, LOADS_PER_THREAD>,                     \
+                             cudaFuncAttributeMaxDynamicSharedMemorySize, smemSize);               \
+    if (_err != cudaSuccess) {                                                                     \
+      return _err;                                                                                 \
+    }                                                                                              \
+    rnConfig.dynamicSmemBytes = smemSize;                                                          \
+    _err = cudaLaunchKernelEx(&rnConfig, &kernels::rmsNormLamport<T, T, LOADS_PER_THREAD>,         \
+                              residualOut, output, bufferInput, gamma,                             \
+                              static_cast<float>(params.epsilon), residualIn, numTokens, tokenDim, \
+                              params.nRanks, params.bufferFlags);                                  \
+    if (_err != cudaSuccess) {                                                                     \
+      return _err;                                                                                 \
+    }                                                                                              \
   } while (0)
 
     T* residualOut = reinterpret_cast<T*>(params.residualOut);

--- a/src/allreduce/fuse_allreduce_rmsnorm_low_latency.h
+++ b/src/allreduce/fuse_allreduce_rmsnorm_low_latency.h
@@ -3,18 +3,18 @@
 #ifndef SRC_ALLREDUCE_FUSE_ALLREDUCE_RMSNORM_LOW_LATENCY_H_
 #define SRC_ALLREDUCE_FUSE_ALLREDUCE_RMSNORM_LOW_LATENCY_H_
 
-#include <cuda_runtime_api.h>
 #include <cooperative_groups.h>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#include <cuda_runtime_api.h>
 
 #include <array>
-#include <iostream>
-#include <type_traits>
 #include <atomic>
 #include <cstdint>
+#include <iostream>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 
 namespace hpc {
@@ -254,9 +254,9 @@ struct __attribute__((aligned(32))) LamportFlags {
     int tid = cluster.thread_rank();
     cluster.sync();
     if (tid == 0) {
-    // red.async does not accept the .release qualifier (rejected by ptxas on
-    // sm_90a / CUDA 13). Use the plain release reduction instead, which is the
-    // intended global atomic-add-with-release semantics for the flag counter.
+      // red.async does not accept the .release qualifier (rejected by ptxas on
+      // sm_90a / CUDA 13). Use the plain release reduction instead, which is the
+      // intended global atomic-add-with-release semantics for the flag counter.
       asm volatile("red.release.global.gpu.add.u32 [%0], %1;" ::"l"(mFlagAccessPtr), "r"(1)
                    : "memory");
     }
@@ -465,7 +465,8 @@ inline __device__ T blockReduceSum(T val) {
 
 // A helper function to tune the grid configuration for fused oneshot and rmsnorm kernels
 // Return (block_size, cluster_size, loads_per_thread)
-// TODO(draken): I have modified this function. This function assumes the target is B200 (sm_100), which always supports CGA.
+// TODO(draken): I have modified this function. This function assumes the target is B200 (sm_100),
+// which always supports CGA.
 inline std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerThread) {
   // B200 always supports CGA, start with the preferred cluster size
   int clusterSize = 8;

--- a/src/attention/decode/assign_task.cu
+++ b/src/attention/decode/assign_task.cu
@@ -310,7 +310,7 @@ bool assign_attention_decode_task_async(int* task_map_ptr, const int* num_seq_kv
   auto launch = [&](auto tilen_tag) {
     constexpr int kTileN = decltype(tilen_tag)::value;
     int max_splitk = num_total_ctas;
-  
+
     kernels::assign_attention_decode_task_kernel<kMaxNumBatch, kTileN><<<grid, block, 0, stream>>>(
         task_map_ptr, num_seq_kvcache, num_batch, num_head_kv, num_seq_q, new_kv_included,
         min_process_len, num_total_ctas, max_splitk);


### PR DESCRIPTION
Normalize formatting across the tree by running `make format` with the pinned formatter versions:

- black 25.9.0
- cpplint 2.0.2
- clang-format 21.1.2

Pure formatting changes only (line reflows, include ordering, pointer `*` spacing, trailing blank lines); no logic changes. This keeps the tree consistent with the exact tool versions used for `format-check` in CI.