### PR TITLE
Fix AllReduce benchmark README script name

### DIFF
--- a/benchmark/fuse_allreduce_rmsorm/README.md
+++ b/benchmark/fuse_allreduce_rmsorm/README.md
@@ -29,7 +29,7 @@ Run from the repository root:
 
 ```bash
 cd benchmark/fuse_allreduce_rmsorm/
-python3 bench_allreduce_rmsnorm.py \
+python3 benchmark_fuse_allreduce_rmsnorm.py \
   --hidden 7168 \
   --tokens 8 32 128 512 4096 8192 16384 32768 \
   --fi-backend mnnvl \


### PR DESCRIPTION
## Summary
  - Update the AllReduce benchmark README to use the actual script name: `benchmark_fuse_allreduce_rmsnorm.py`.

  ## Why
  The documented command referenced `bench_allreduce_rmsnorm.py`, which does not exist in the benchmark directory.

  ## Validation
  - Verified the referenced script exists in `benchmark/fuse_allreduce_rmsorm/`.