### PR TITLE
Improve source build robustness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ set(CMAKE_BUILD_TYPE "Release")
 find_package(CUDAToolkit REQUIRED)
 find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
 
+set(HPC_OPS_CUDA_ARCHITECTURES
+    "90a"
+    CACHE STRING "CUDA architectures used to build hpc-ops kernels")
+
 file(GLOB_RECURSE SOURCES "src/*/*.cu" "src/*/*.cc")
 file(GLOB CP_ASYNC_SOURCES "src/fuse_moe/cp_async/*.cu" "src/group_gemm/cp_async/*.cu"
                            "src/group_gemm/cp_async/*.cc")
@@ -42,33 +46,96 @@ set_target_properties(
   CUDA_STANDARD_REQUIRED ON
   CUDA_EXTENSIONS OFF
 
-  CUDA_ARCHITECTURES "90a"
+  CUDA_ARCHITECTURES "${HPC_OPS_CUDA_ARCHITECTURES}"
 )
+
+function(query_python output_variable description script)
+  execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -c "${script}"
+    RESULT_VARIABLE PYTHON_QUERY_RESULT
+    OUTPUT_VARIABLE PYTHON_QUERY_OUTPUT
+    ERROR_VARIABLE PYTHON_QUERY_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT PYTHON_QUERY_RESULT EQUAL 0)
+    message(FATAL_ERROR
+            "Failed to query ${description} with ${Python3_EXECUTABLE}.\n${PYTHON_QUERY_ERROR}")
+  endif()
+  if("${PYTHON_QUERY_OUTPUT}" STREQUAL "")
+    message(FATAL_ERROR "Python query for ${description} returned an empty result.")
+  endif()
+  set(${output_variable}
+      "${PYTHON_QUERY_OUTPUT}"
+      PARENT_SCOPE)
+endfunction()
+
+query_python(
+  TORCH_VERSION
+  "PyTorch version"
+  "
+import torch
+print(torch.__version__, end='')
+")
+
+query_python(
+  TORCH_CUDA_VERSION
+  "PyTorch CUDA version"
+  "
+import torch
+print(torch.version.cuda or 'none', end='')
+")
+
+query_python(
+  TORCH_CXX11_ABI
+  "PyTorch CXX11 ABI"
+  "
+import torch
+print(int(getattr(torch._C, '_GLIBCXX_USE_CXX11_ABI', True)), end='')
+")
+
+set(HPC_OPS_USE_CXX11_ABI
+    "${TORCH_CXX11_ABI}"
+    CACHE STRING "Value for _GLIBCXX_USE_CXX11_ABI; defaults to the active PyTorch ABI")
+
+query_python(
+  TORCH_INCLUDE_PATHS
+  "PyTorch include paths"
+  "
+from torch.utils.cpp_extension import include_paths
+print(chr(59).join(include_paths()), end='')
+")
+
+query_python(
+  TORCH_LIBRARY_PATHS
+  "PyTorch library paths"
+  "
+from torch.utils.cpp_extension import library_paths
+print(chr(59).join(library_paths()), end='')
+")
+
+message(STATUS "HPC-Ops build Python: ${Python3_EXECUTABLE}")
+message(STATUS "HPC-Ops build PyTorch: ${TORCH_VERSION} (CUDA ${TORCH_CUDA_VERSION})")
+message(STATUS "HPC-Ops PyTorch CXX11 ABI: ${HPC_OPS_USE_CXX11_ABI}")
+message(STATUS "HPC-Ops CUDA architectures: ${HPC_OPS_CUDA_ARCHITECTURES}")
+message(STATUS "HPC-Ops C++ compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+message(STATUS "HPC-Ops CUDA compiler: ${CMAKE_CUDA_COMPILER_VERSION}")
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+   AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13)
+  message(
+    STATUS
+      "GCC 13+ detected. If compilation fails inside PyTorch headers, verify that the PyTorch, CUDA, and host compiler versions are supported together."
+  )
+endif()
 
 target_compile_definitions(
   _C PRIVATE
   Py_LIMITED_API=0x03090000
-  _GLIBCXX_USE_CXX11_ABI=1
+  _GLIBCXX_USE_CXX11_ABI=${HPC_OPS_USE_CXX11_ABI}
   HPC_GIT_HASH_STR=${HPC_GIT_HASH_STR}
   HPC_VERSION_STR=${HPC_VERSION_STR}
 )
-
-execute_process(
-  COMMAND python3 -c "
-from torch.utils.cpp_extension import include_paths
-print(';'.join(include_paths()), end='')
-"
-  OUTPUT_VARIABLE TORCH_INCLUDE_PATHS
-)
-
-execute_process(
-  COMMAND python3 -c "
-from torch.utils.cpp_extension import library_paths
-print(';'.join(library_paths()), end='')
-"
-  OUTPUT_VARIABLE TORCH_LIBRARY_PATHS
-)
-
 
 target_include_directories(
   _C PRIVATE

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PYTHON ?= python3
+
 PY_FILES=$(shell find hpc -name "*.py") $(shell find tests -name "*.py") $(shell find ./ -maxdepth 1 -name "*.py")
 PY_TEST=$(shell find tests -name "test_*.py")
 CC_FILES=$(shell find src -name "*.cc")
@@ -9,31 +11,31 @@ CSRC_FILES=$(CC_FILES) $(CU_FILES) $(CUH_FILES) $(H_FILES)
 
 
 all:
-	python3 setup.py build
+	$(PYTHON) setup.py build
 
 wheel:
 	find . -type d -name "__pycache__" -exec rm -rf {} +
-	python3 -m build --wheel --no-isolation
+	$(PYTHON) -m build --wheel --no-isolation
 
 format:
-	python3 -m black --line-length 100 $(PY_FILES)
+	$(PYTHON) -m black --line-length 100 $(PY_FILES)
 	clang-format --style=file -i $(CSRC_FILES)
-	python3 -m cpplint --quiet $(CSRC_FILES)
+	$(PYTHON) -m cpplint --quiet $(CSRC_FILES)
 
 format-check:
-	python3 -m black --check --line-length 100 $(PY_FILES)
+	$(PYTHON) -m black --check --line-length 100 $(PY_FILES)
 	clang-format --style=file --dry-run -Werror $(CSRC_FILES)
-	python3 -m cpplint $(CSRC_FILES)
+	$(PYTHON) -m cpplint $(CSRC_FILES)
 
 test:$(PY_TEST)
 	@for test in $^; do \
-	  python3 -m pytest -v --no-header --disable-warnings $$test || exit 1; \
+	  $(PYTHON) -m pytest -v --no-header --disable-warnings $$test || exit 1; \
 	done
 
 sanitizer:$(PY_TEST)
 	@rm -rf /dev/shm/tmp_hpc_*
 	@for test in $^; do \
-	  PYTORCH_NO_CUDA_MEMORY_CACHING=1 SANITIZER_CHECK=synccheck,memcheck,racecheck NV_SANITIZER_INJECTION_PORT_BASE=1111 python3 -m pytest -v --no-header --disable-warnings $$test || exit 1; \
+	  PYTORCH_NO_CUDA_MEMORY_CACHING=1 SANITIZER_CHECK=synccheck,memcheck,racecheck NV_SANITIZER_INJECTION_PORT_BASE=1111 $(PYTHON) -m pytest -v --no-header --disable-warnings $$test || exit 1; \
 	done
 
 clean:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <p>
     <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.8%2B-76B900">
     <img alt="GPU" src="https://img.shields.io/badge/GPU-H20%20%7C%20SM90-76B900">
-    <img alt="Python" src="https://img.shields.io/badge/Python-3.8%2B-3776AB">
+    <img alt="Python" src="https://img.shields.io/badge/Python-3.9%2B-3776AB">
     <img alt="License" src="https://img.shields.io/badge/License-MIT-blue">
   </p>
 </div>
@@ -185,7 +185,8 @@ softmax statistics to reduce vocabulary reads and fixed launch overhead.
 
 ### Requirements
 - NVIDIA SM90 architecture GPU
-- Python 3.8 or higher
+- Python 3.9 or higher
+- PyTorch installed in the build environment
 - Compilers with C++17 support
 - CUDA Toolkit: CUDA 12.8 or higher
 
@@ -201,6 +202,21 @@ cd hpc-ops
 make wheel
 python3 -m pip install dist/*.whl
 ```
+
+The source build uses the Python executable that runs `setup.py`, queries
+PyTorch include/library paths from that same environment, and matches PyTorch's
+`_GLIBCXX_USE_CXX11_ABI` setting by default. Set `CMAKE_BUILD_PARALLEL_LEVEL`,
+`MAX_JOBS`, or `SLURM_CPUS_PER_TASK` to control parallel compilation. Extra
+CMake options can be passed with `HPC_OPS_CMAKE_ARGS`, for example:
+
+```bash
+MAX_JOBS=8 HPC_OPS_CMAKE_ARGS="-DHPC_OPS_CUDA_ARCHITECTURES=90a" make wheel
+```
+
+If compilation fails inside files under `torch/include`, first verify that the
+active PyTorch wheel, CUDA toolkit, and host compiler are supported together.
+For example, failures in `ATen/core/List_inl.h` usually indicate a PyTorch
+header/toolchain compatibility issue rather than an hpc-ops kernel error.
 
 ### Basic Usage
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2026 Tencent.
 
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -10,14 +11,15 @@ from setuptools.command.build_ext import build_ext
 
 
 class CMakeExtension(Extension):
-    def __init__(self, name, version_macros=[], sourcedir=""):
-        Extension.__init__(self, name, sources=[])
-        self.version_macros = version_macros
+    def __init__(self, name, version_macros=None, sourcedir=""):
+        super().__init__(name, sources=[])
+        self.version_macros = version_macros or []
         self.sourcedir = os.path.abspath(sourcedir)
 
 
 class CMakeBuild(build_ext):
     def run(self):
+        check_build_environment()
         for ext in self.extensions:
             self.build_extension(ext)
 
@@ -28,11 +30,17 @@ class CMakeBuild(build_ext):
         os.makedirs(build_lib_dir, exist_ok=True)
         os.makedirs(build_temp_dir, exist_ok=True)
 
-        cmake_args = [f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={build_lib_dir}", *ext.version_macros]
+        cmake_args = [
+            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={build_lib_dir}",
+            f"-DPython3_EXECUTABLE={sys.executable}",
+            *ext.version_macros,
+            *get_extra_cmake_args(),
+        ]
 
         subprocess.check_call(["cmake", ext.sourcedir] + cmake_args, cwd=build_temp_dir)
         subprocess.check_call(
-            ["cmake", "--build", ".", "--config", "Release", "-j16"], cwd=build_temp_dir
+            ["cmake", "--build", ".", "--config", "Release", *get_cmake_parallel_args()],
+            cwd=build_temp_dir,
         )
 
         so_src_path = os.path.join(build_temp_dir, "_C.abi3.so")
@@ -41,10 +49,69 @@ class CMakeBuild(build_ext):
         shutil.copy(so_src_path, so_dst_path)
 
 
+def check_build_environment():
+    if sys.version_info < (3, 9):
+        raise RuntimeError("hpc-ops builds cp39 abi3 wheels and requires Python 3.9 or newer.")
+
+    if shutil.which("cmake") is None:
+        raise RuntimeError("cmake is required to build hpc-ops.")
+
+    try:
+        import torch
+    except Exception as exc:
+        raise RuntimeError(
+            "PyTorch is required in the active Python environment before building hpc-ops. "
+            "Install the build requirements or run the wheel build with --no-isolation."
+        ) from exc
+
+    print(f"-- hpc-ops build Python: {sys.version.split()[0]} ({sys.executable})")
+    print(f"-- hpc-ops build PyTorch: {torch.__version__} (CUDA {torch.version.cuda})")
+    print(
+        "-- hpc-ops build PyTorch CXX11 ABI: "
+        f"{int(getattr(torch._C, '_GLIBCXX_USE_CXX11_ABI', True))}"
+    )
+
+
+def get_extra_cmake_args():
+    return shlex.split(os.environ.get("HPC_OPS_CMAKE_ARGS", ""))
+
+
+def get_build_parallelism():
+    for env_name in ("CMAKE_BUILD_PARALLEL_LEVEL", "MAX_JOBS", "SLURM_CPUS_PER_TASK"):
+        env_value = os.environ.get(env_name)
+        if not env_value:
+            continue
+
+        try:
+            jobs = int(env_value)
+        except ValueError as exc:
+            raise RuntimeError(f"{env_name} must be a positive integer, got {env_value!r}.") from exc
+
+        if jobs < 1:
+            raise RuntimeError(f"{env_name} must be a positive integer, got {env_value!r}.")
+
+        return jobs
+
+    return min(os.cpu_count() or 1, 16)
+
+
+def get_cmake_parallel_args():
+    return ["--parallel", str(get_build_parallelism())]
+
+
 def get_version():
-    git_hash = subprocess.check_output(
-        ["git", "rev-parse", "--short=7", "HEAD"], stderr=subprocess.DEVNULL, text=True
-    ).strip()
+    git_hash = os.environ.get("HPC_GIT_HASH", "").strip()
+
+    if not git_hash:
+        try:
+            git_hash = subprocess.check_output(
+                ["git", "rev-parse", "--short=7", "HEAD"], stderr=subprocess.DEVNULL, text=True
+            ).strip()
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            git_hash = "unknown"
+
+    if git_hash == "unknown":
+        return "0.0.1.dev0", git_hash
 
     return f"0.0.1.dev0+g{git_hash}", git_hash
 
@@ -68,9 +135,10 @@ setup(
     url="https://github.com/Tencent/hpc-ops",
     license="Copyright (C) 2026 Tencent.",
     packages=["hpc"],
+    python_requires=">=3.9",
     ext_modules=[CMakeExtension("hpc", version_macros)],
     cmdclass={"build_ext": CMakeBuild},
-    package_data={"_C": ["*.so"]},
+    package_data={"hpc": ["*.so"]},
     options={"bdist_wheel": {"py_limited_api": "cp39"}},
     install_requires=["torch"],
 )


### PR DESCRIPTION
## Summary
  - Use the invoking Python interpreter for CMake/PyTorch discovery.
  - Match PyTorch's CXX11 ABI and add clearer build diagnostics.
  - Make CUDA architectures and build parallelism configurable.
  - Document toolchain troubleshooting for PyTorch header failures.

  ## Validation
  - Passed `python3 -m py_compile setup.py`
  - Passed `git diff --check`
  - Passed source extension build with CUDA 12.8 and PyTorch 2.10.0+cu128:
    `python setup.py build_ext --inplace`
  - Passed wheel build with CUDA 12.8 and PyTorch 2.10.0+cu128:
    `MAX_JOBS=8 python setup.py bdist_wheel`