### PR TITLE
build: require cmake 3.26 and pin Python3_EXECUTABLE from setup.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.26)
 project(hpc_ops LANGUAGES CXX CUDA)
 
 enable_language(CUDA)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,11 @@ class CMakeBuild(build_ext):
         os.makedirs(build_lib_dir, exist_ok=True)
         os.makedirs(build_temp_dir, exist_ok=True)
 
-        cmake_args = [f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={build_lib_dir}", *ext.version_macros]
+        cmake_args = [
+            f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={build_lib_dir}",
+            f"-DPython3_EXECUTABLE={sys.executable}",
+            *ext.version_macros,
+        ]
 
         subprocess.check_call(["cmake", ext.sourcedir] + cmake_args, cwd=build_temp_dir)
         subprocess.check_call(


### PR DESCRIPTION
1. CUDA C++20（`CUDA_STANDARD 20`）需要 CMake >= 3.25 —— 更早版本未定义
  `CMAKE_CUDA20_STANDARD_COMPILE_OPTION`，会在 generate 阶段报 `requires the
  language dialect "CUDA20"`；此处取 3.26 留一档余量并与 vLLM 对齐。

  2. 从 setup.py 传入 `-DPython3_EXECUTABLE=sys.executable`，避免 CMake
  自行搜索时选到发起构建之外的解释器，导致取不到其配套头文件而报 `Could NOT find
  Python3 (missing: Python3_INCLUDE_DIRS Development.Module)`。